### PR TITLE
Expose deny_new_usb settings

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -114,6 +114,23 @@
         <item>30 minutes</item>
     </string-array>
 
+    <!-- Security Settings -->
+    <string-array name="deny_new_usb_entries">
+        <item>Deny new USB peripherals</item>
+        <item>Allow new USB peripherals when unlocked</item>
+        <item>Allow new USB peripherals</item>
+    </string-array>
+
+    <!-- Do not translate. -->
+    <string-array name="deny_new_usb_values" translatable="false">
+        <!-- Do not translate. -->
+        <item>enabled</item>
+        <!-- Do not translate. -->
+        <item>dynamic</item>
+        <!-- Do not translate. -->
+        <item>disabled</item>
+    </string-array>
+
     <!-- Do not translate. -->
     <string-array name="lock_after_timeout_values" translatable="false">
         <!-- Do not translate. -->

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -11352,4 +11352,6 @@
     <!-- Summary for Enterprise Privacy settings, explaining what the user can expect to find under it [CHAR LIMIT=NONE]-->
     <string name="work_policy_privacy_settings_summary">Settings managed by your IT admin</string>
 
+    <string name="deny_new_usb_title">USB accessories</string>
+    <string name="deny_new_usb_summary">Control support for USB peripherals such as input (mice, keyboards, joysticks) and storage devices.</string>
 </resources>

--- a/res/xml/security_dashboard_settings.xml
+++ b/res/xml/security_dashboard_settings.xml
@@ -20,7 +20,7 @@
     xmlns:settings="http://schemas.android.com/apk/res-auto"
     android:key="security_dashboard_page"
     android:title="@string/security_settings_title"
-    settings:initialExpandedChildrenCount="9">
+    settings:initialExpandedChildrenCount="10">
 
     <!-- security_settings_status.xml -->
     <PreferenceCategory
@@ -55,6 +55,15 @@
             android:title="@string/security_settings_face_preference_title"
             android:summary="@string/summary_placeholder"
             settings:keywords="@string/keywords_face_settings" />
+
+        <ListPreference
+            android:key="deny_new_usb"
+            android:title="@string/deny_new_usb_title"
+            android:summary="@string/deny_new_usb_summary"
+            android:persistent="false"
+            android:entries="@array/deny_new_usb_entries"
+            android:entryValues="@array/deny_new_usb_values" />
+
     </PreferenceCategory>
 
     <!-- work profile security section -->

--- a/src/com/android/settings/security/DenyNewUsbPreferenceController.java
+++ b/src/com/android/settings/security/DenyNewUsbPreferenceController.java
@@ -45,7 +45,7 @@ public class DenyNewUsbPreferenceController extends AbstractPreferenceController
     public void displayPreference(PreferenceScreen screen) {
         super.displayPreference(screen);
         mSecurityCategory = screen.findPreference(PREF_KEY_SECURITY_CATEGORY);
-        updateAvailability();
+        updatePreferenceState();
     }
 
     @Override
@@ -60,13 +60,14 @@ public class DenyNewUsbPreferenceController extends AbstractPreferenceController
     }
 
     // TODO: should we use onCreatePreferences() instead?
-    private void updateAvailability() {
+    private void updatePreferenceState() {
         if (mSecurityCategory == null) {
             return;
         }
 
         if (mIsAdmin) {
             mDenyNewUsb = (ListPreference) mSecurityCategory.findPreference(KEY_DENY_NEW_USB);
+            mDenyNewUsb.setValue(SystemProperties.get(DENY_NEW_USB_PERSIST_PROP, "disabled"));
         } else {
                 mSecurityCategory.removePreference(mSecurityCategory.findPreference(KEY_DENY_NEW_USB));
         }
@@ -74,9 +75,10 @@ public class DenyNewUsbPreferenceController extends AbstractPreferenceController
 
     @Override
     public void onResume() {
-        updateAvailability();
+        updatePreferenceState();
 
         if (mDenyNewUsb != null) {
+
             String mode = mDenyNewUsb.getValue();
             if (mode.equals("dynamic") || mode.equals("disabled")) {
                 SystemProperties.set(DENY_NEW_USB_PROP, "0");

--- a/src/com/android/settings/security/DenyNewUsbPreferenceController.java
+++ b/src/com/android/settings/security/DenyNewUsbPreferenceController.java
@@ -77,8 +77,6 @@ public class DenyNewUsbPreferenceController extends AbstractPreferenceController
         updateAvailability();
 
         if (mDenyNewUsb != null) {
-            mDenyNewUsb.setValue(SystemProperties.get(DENY_NEW_USB_PERSIST_PROP, "disabled"));
-
             String mode = mDenyNewUsb.getValue();
             if (mode.equals("dynamic") || mode.equals("disabled")) {
                 SystemProperties.set(DENY_NEW_USB_PROP, "0");

--- a/src/com/android/settings/security/DenyNewUsbPreferenceController.java
+++ b/src/com/android/settings/security/DenyNewUsbPreferenceController.java
@@ -1,0 +1,106 @@
+package com.android.settings.security;
+
+import android.content.Context;
+
+import android.os.UserHandle;
+import android.os.UserManager;
+import android.os.SystemProperties;
+
+import android.provider.Settings;
+
+
+import androidx.preference.ListPreference;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceCategory;
+import androidx.preference.PreferenceGroup;
+import androidx.preference.PreferenceScreen;
+
+
+import com.android.internal.widget.LockPatternUtils;
+import com.android.settings.core.PreferenceControllerMixin;
+import com.android.settingslib.core.AbstractPreferenceController;
+import com.android.settingslib.core.lifecycle.events.OnResume;
+
+public class DenyNewUsbPreferenceController extends AbstractPreferenceController
+        implements PreferenceControllerMixin, OnResume, Preference.OnPreferenceChangeListener {
+
+    private static final String KEY_DENY_NEW_USB = "deny_new_usb";
+    private static final String DENY_NEW_USB_PROP = "security.deny_new_usb";
+    private static final String DENY_NEW_USB_PERSIST_PROP = "persist.security.deny_new_usb";
+    private static final String PREF_KEY_SECURITY_CATEGORY = "security_category";
+
+
+    private PreferenceCategory mSecurityCategory;
+    private ListPreference mDenyNewUsb;
+    private boolean mIsAdmin;
+    private UserManager mUm;
+
+
+    public DenyNewUsbPreferenceController(Context context) {
+        super(context);
+        mUm = UserManager.get(context);
+    }
+
+    @Override
+    public void displayPreference(PreferenceScreen screen) {
+        super.displayPreference(screen);
+        mSecurityCategory = screen.findPreference(PREF_KEY_SECURITY_CATEGORY);
+        updateAvailability();
+    }
+
+    @Override
+    public boolean isAvailable() {
+        mIsAdmin = mUm.isAdminUser();
+        return mIsAdmin;
+    }
+
+    @Override
+    public String getPreferenceKey() {
+        return KEY_DENY_NEW_USB;
+    }
+
+    // TODO: should we use onCreatePreferences() instead?
+    private void updateAvailability() {
+        if (mSecurityCategory == null) {
+            return;
+        }
+
+        if (mIsAdmin) {
+            mDenyNewUsb = (ListPreference) mSecurityCategory.findPreference(KEY_DENY_NEW_USB);
+        } else {
+                mSecurityCategory.removePreference(mSecurityCategory.findPreference(KEY_DENY_NEW_USB));
+        }
+    }
+
+    @Override
+    public void onResume() {
+        updateAvailability();
+
+        if (mDenyNewUsb != null) {
+            mDenyNewUsb.setValue(SystemProperties.get(DENY_NEW_USB_PERSIST_PROP, "disabled"));
+
+            String mode = mDenyNewUsb.getValue();
+            if (mode.equals("dynamic") || mode.equals("disabled")) {
+                SystemProperties.set(DENY_NEW_USB_PROP, "0");
+            } else {
+                SystemProperties.set(DENY_NEW_USB_PROP, "1");
+            }
+        }
+    }
+
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object value) {
+        final String key = preference.getKey();
+        if (KEY_DENY_NEW_USB.equals(key)) {
+            String mode = (String) value;
+            SystemProperties.set(DENY_NEW_USB_PERSIST_PROP, mode);
+            // The dynamic mode defaults to the disabled state
+            if (mode.equals("dynamic") || mode.equals("disabled")) {
+                SystemProperties.set(DENY_NEW_USB_PROP, "0");
+            } else {
+                SystemProperties.set(DENY_NEW_USB_PROP, "1");
+            }
+        }
+        return true;
+    }
+}

--- a/src/com/android/settings/security/SecuritySettings.java
+++ b/src/com/android/settings/security/SecuritySettings.java
@@ -116,6 +116,7 @@ public class SecuritySettings extends DashboardFragment {
         securityPreferenceControllers.add(new FaceStatusPreferenceController(context));
         securityPreferenceControllers.add(new FingerprintStatusPreferenceController(context));
         securityPreferenceControllers.add(new ChangeScreenLockPreferenceController(context, host));
+        securityPreferenceControllers.add(new DenyNewUsbPreferenceController(context));
         controllers.add(new PreferenceCategoryController(context, SECURITY_CATEGORY)
                 .setChildren(securityPreferenceControllers));
         controllers.addAll(securityPreferenceControllers);


### PR DESCRIPTION
(Re-)Implement #71

Seems to work; behaviour verified via getprop.
Dynamic mode sets / unsets `security.deny_new_usb` on lock/unlock as
intended, in other modes it remains enabled/disabled.

Current setting is not pre-selected when opening Settings; I currently
lack the knowledge to quickly fix that aspect.