### PR TITLE
add LTE-only option

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -1204,16 +1204,19 @@
     </string-array>
 
     <string-array name="enabled_networks_choices" translatable="false">
+        <item>@string/network_lte_only</item>
         <item>@string/network_lte</item>
         <item>@string/network_3G</item>
         <item>@string/network_2G</item>
     </string-array>
     <string-array name="enabled_networks_4g_choices" translatable="false">
+        <item>@string/network_4G_only</item>
         <item>@string/network_4G</item>
         <item>@string/network_3G</item>
         <item>@string/network_2G</item>
     </string-array>
     <string-array name="enabled_networks_values" translatable="false">
+        <item>"11"</item>
         <item>"9"</item>
         <item>"0"</item>
         <item>"1"</item>
@@ -1249,7 +1252,7 @@
         <item>CDMA + LTE/EvDo</item>
         <item>GSM/WCDMA/LTE</item>
         <item>Global</item>
-        <item>LTE</item>
+        <item>LTE only</item>
         <item>LTE / WCDMA</item>
         <item>TDSCDMA only</item>
         <item>TDSCDMA/WCDMA</item>
@@ -1302,14 +1305,17 @@
     </string-array>
 
     <string-array name="enabled_networks_except_gsm_choices" translatable="false">
+        <item>@string/network_lte_only</item>
         <item>@string/network_lte</item>
         <item>@string/network_3G</item>
     </string-array>
     <string-array name="enabled_networks_except_gsm_4g_choices" translatable="false">
+        <item>@string/network_4G_only</item>
         <item>@string/network_4G</item>
         <item>@string/network_3G</item>
     </string-array>
     <string-array name="enabled_networks_except_gsm_values" translatable="false">
+        <item>"11"</item>
         <item>"9"</item>
         <item>"0"</item>
     </string-array>
@@ -1331,12 +1337,14 @@
     </string-array>
 
     <string-array name="enabled_networks_cdma_choices" translatable="false">
+        <item>@string/network_lte_only</item>
         <item>@string/network_lte</item>
         <item>@string/network_3G</item>
         <item>@string/network_1x</item>
         <item>@string/network_global</item>
     </string-array>
     <string-array name="enabled_networks_cdma_values" translatable="false">
+        <item>"11"</item>
         <item>"8"</item>
         <item>"4"</item>
         <item>"5"</item>
@@ -1353,20 +1361,24 @@
     </string-array>
 
     <string-array name="enabled_networks_cdma_only_lte_choices" translatable="false">
+        <item>@string/network_lte_only</item>
         <item>@string/network_lte</item>
         <item>@string/network_global</item>
     </string-array>
     <string-array name="enabled_networks_cdma_only_lte_values" translatable="false">
+        <item>"11"</item>
         <item>"8"</item>
         <item>"10"</item>
     </string-array>
 
     <string-array name="enabled_networks_tdscdma_choices" translatable="false">
+        <item>@string/network_lte_only</item>
         <item>@string/network_lte</item>
         <item>@string/network_3G</item>
         <item>@string/network_2G</item>
     </string-array>
     <string-array name="enabled_networks_tdscdma_values" translatable="false">
+        <item>"11"</item>
         <item>"22"</item>
         <item>"18"</item>
         <item>"1"</item>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -10867,6 +10867,8 @@
     <string name="preferred_network_mode_cdma_evdo_gsm_wcdma_summary">Preferred network mode: CDMA/EvDo/GSM/WCDMA</string>
     <!-- LTE [CHAR LIMIT=NONE] -->
     <string name="preferred_network_mode_lte_summary">Preferred network mode: LTE </string>
+    <!-- LTE only [CHAR LIMIT=100] -->
+    <string name="preferred_network_mode_lte_only_summary">Preferred network mode: LTE only</string>
     <!-- GSM/WCDMA/LTE [CHAR LIMIT=NONE] -->
     <string name="preferred_network_mode_lte_gsm_wcdma_summary">Preferred network mode: GSM/WCDMA/LTE</string>
     <!-- CDMA+LTE/EVDO [CHAR LIMIT=NONE] -->
@@ -10902,8 +10904,12 @@
 
     <!-- Text for Network lte [CHAR LIMIT=NONE] -->
     <string name="network_lte">LTE (recommended)</string>
+    <!-- Text for Network lte only [CHAR LIMIT=NONE] -->
+    <string name="network_lte_only">LTE only</string>
     <!-- Text for Network 4g [CHAR LIMIT=NONE] -->
     <string name="network_4G">4G (recommended)</string>
+    <!-- Text for Network 4g [CHAR LIMIT=NONE] -->
+    <string name="network_4G_only">4G only</string>
     <!-- Text for Network 3g [CHAR LIMIT=NONE] -->
     <string name="network_3G" translatable="false">3G</string>
     <!-- Text for Network 2g [CHAR LIMIT=NONE] -->

--- a/src/com/android/settings/network/telephony/EnabledNetworkModePreferenceController.java
+++ b/src/com/android/settings/network/telephony/EnabledNetworkModePreferenceController.java
@@ -291,7 +291,6 @@ public class EnabledNetworkModePreferenceController extends
                             R.string.preferred_network_mode_lte_gsm_umts_summary);
                     break;
                 }
-            case TelephonyManager.NETWORK_MODE_LTE_ONLY:
             case TelephonyManager.NETWORK_MODE_LTE_WCDMA:
                 if (!mIsGlobalCdma) {
                     preference.setValue(
@@ -304,6 +303,12 @@ public class EnabledNetworkModePreferenceController extends
                                     .NETWORK_MODE_LTE_CDMA_EVDO_GSM_WCDMA));
                     preference.setSummary(R.string.network_global);
                 }
+                break;
+            case TelephonyManager.NETWORK_MODE_LTE_ONLY:
+                preference.setValue(
+                        Integer.toString(TelephonyManager.NETWORK_MODE_LTE_ONLY));
+                preference.setSummary(
+                        mShow4GForLTE ? R.string.network_4G_only : R.string.network_lte_only);
                 break;
             case TelephonyManager.NETWORK_MODE_LTE_CDMA_EVDO:
                 if (MobileNetworkUtils.isWorldMode(mContext, mSubId)) {

--- a/src/com/android/settings/network/telephony/PreferredNetworkModePreferenceController.java
+++ b/src/com/android/settings/network/telephony/PreferredNetworkModePreferenceController.java
@@ -141,7 +141,7 @@ public class PreferredNetworkModePreferenceController extends TelephonyBasePrefe
             case TelephonyManager.NETWORK_MODE_LTE_TDSCDMA:
                 return R.string.preferred_network_mode_lte_tdscdma_summary;
             case TelephonyManager.NETWORK_MODE_LTE_ONLY:
-                return R.string.preferred_network_mode_lte_summary;
+                return R.string.preferred_network_mode_lte_only_summary;
             case TelephonyManager.NETWORK_MODE_LTE_TDSCDMA_GSM:
                 return R.string.preferred_network_mode_lte_tdscdma_gsm_summary;
             case TelephonyManager.NETWORK_MODE_LTE_TDSCDMA_GSM_WCDMA:


### PR DESCRIPTION
This mostly follows the work done in https://github.com/AndroidHardeningArchive/platform_packages_services_Telephony/commit/7f1b1088ade90096d874e8e554f0d47b9040ed14.

Changes are based on QQ1A.200205.002.2020.02.07.19

Tested on Pixel 3a
- The system seems to recognize the setting according to what is displayed in the `*#*#4636#*#*` menu from the Phone dialer. 

  That is, when the LTE-only option is on, the "Set Preferred Network Type" in `*#*#4636#*#*` is shown as "LTE only"; when LTE-only is not used, the Preferred Network Type shown is a different option ("LTE/UMTS auto (PRL)" in my case when I choose LTE preferred).
- I found some spots where my phone would once switch from LTE to 3G, and with the setting on, it no longer switches over to 3G.
- I spent a day with the option on and didn't have any issues with the data connection.
- My carrier doesn't seem to have VoLTE provisioned on GrapheneOS (but the settings are there on stock), so I can't test the calling with LTE-only on (just hangs up immediately if I try to call). 

  SMS and MMS work fine with LTE-only on.

Closes https://github.com/GrapheneOS/os_issue_tracker/issues/107