### PR TITLE
add missing android title for top_level_settings

### DIFF
--- a/res/xml/top_level_settings.xml
+++ b/res/xml/top_level_settings.xml
@@ -18,7 +18,8 @@
 <PreferenceScreen
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:settings="http://schemas.android.com/apk/res-auto"
-    android:key="top_level_settings">
+    android:key="top_level_settings"
+    android:title="Settings">
 
     <Preference
         android:key="top_level_network"


### PR DESCRIPTION
closes https://github.com/GrapheneOS/os_issue_tracker/issues/148

remember to delete `/data` to test. Otherwise, risk losing half a day like me.