### PR TITLE
add a toggle for fingerprint unlock

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -12251,4 +12251,7 @@
     <string name="keyguard_camera_summary">Allow camera access when the device is locked</string>
     <string name="native_debug_title">Enable native code debugging</string>
     <string name="native_debug_summary">Generate useful logs / bug reports from crashes and permit debugging native code.</string>
+    <string name="security_settings_fingerprint_settings_screen_lock_category">Screen lock</string>
+    <string name="security_settings_fingerprint_settings_use_fingerprint_unlock_phone_title">Allow fingerprint unlocking</string>
+    <string name="security_settings_fingerprint_settings_use_fingerprint_unlock_phone_summary">Allow fingerprints to unlock the screen lock. If this is disabled, fingerprints can still be used in apps.</string>
 </resources>

--- a/res/xml/security_settings_fingerprint.xml
+++ b/res/xml/security_settings_fingerprint.xml
@@ -16,5 +16,18 @@
 
 <PreferenceScreen
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:title="@string/security_settings_fingerprint_preference_title"/>
+    android:title="@string/security_settings_fingerprint_preference_title">
+
+    <PreferenceCategory
+        android:title="@string/security_settings_fingerprint_settings_screen_lock_category"
+        android:order="10"
+        android:key="security_settings_fingerprint_unlock_category">
+
+        <SwitchPreference
+            android:key="security_settings_fingerprint_keyguard"
+            android:title="@string/security_settings_fingerprint_settings_use_fingerprint_unlock_phone_title"
+            android:summary="@string/security_settings_fingerprint_settings_use_fingerprint_unlock_phone_summary" />
+    </PreferenceCategory>
+
+</PreferenceScreen>
 

--- a/src/com/android/settings/biometrics/fingerprint/FingerprintSettings.java
+++ b/src/com/android/settings/biometrics/fingerprint/FingerprintSettings.java
@@ -33,6 +33,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.UserHandle;
 import android.os.UserManager;
+import android.provider.Settings;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.View;
@@ -46,6 +47,7 @@ import androidx.preference.Preference.OnPreferenceChangeListener;
 import androidx.preference.PreferenceGroup;
 import androidx.preference.PreferenceScreen;
 import androidx.preference.PreferenceViewHolder;
+import androidx.preference.SwitchPreference;
 
 import com.android.settings.R;
 import com.android.settings.SettingsPreferenceFragment;
@@ -109,8 +111,10 @@ public class FingerprintSettings extends SubSettings {
         private static final String TAG = "FingerprintSettings";
         private static final String KEY_FINGERPRINT_ITEM_PREFIX = "key_fingerprint_item";
         private static final String KEY_FINGERPRINT_ADD = "key_fingerprint_add";
+        private static final String KEY_FINGERPRINT_SCREEN_LOCK_OPTIONS_CATEGORY =
+                "security_settings_fingerprint_unlock_category";
         private static final String KEY_FINGERPRINT_ENABLE_KEYGUARD_TOGGLE =
-                "fingerprint_enable_keyguard_toggle";
+                "security_settings_fingerprint_keyguard";
         private static final String KEY_LAUNCHED_CONFIRM = "launched_confirm";
 
         private static final int MSG_REFRESH_FINGERPRINT_TEMPLATES = 1000;
@@ -370,6 +374,24 @@ public class FingerprintSettings extends SubSettings {
             root = getPreferenceScreen();
             addFingerprintItemPreferences(root);
             setPreferenceScreen(root);
+
+            // Need to add back the keyguard preferences, since addFingerprintItemPreferences
+            // calls root.removeAll() again.
+            addPreferencesFromResource(R.xml.security_settings_fingerprint);
+
+            // Don't show keyguard preferences for work profile settings.
+            if (UserManager.get(getContext()).isManagedProfile(mUserId)) {
+                removePreference(KEY_FINGERPRINT_SCREEN_LOCK_OPTIONS_CATEGORY);
+            } else {
+                SwitchPreference lockScreenFingerprintPreference =
+                        (SwitchPreference) findPreference(KEY_FINGERPRINT_ENABLE_KEYGUARD_TOGGLE);
+
+                lockScreenFingerprintPreference.setChecked(Settings.Secure.getInt(
+                        getContext().getContentResolver(),
+                        Settings.Secure.FINGERPRINT_UNLOCK_KEYGUARD_ENABLED, 1) == 1);
+                lockScreenFingerprintPreference.setOnPreferenceChangeListener(this);
+            }
+
             return root;
         }
 
@@ -384,6 +406,7 @@ public class FingerprintSettings extends SubSettings {
                 pref.setKey(genKey(item.getBiometricId()));
                 pref.setTitle(item.getName());
                 pref.setFingerprint(item);
+                pref.setOrder(1);
                 pref.setPersistent(false);
                 pref.setIcon(R.drawable.ic_fingerprint_24dp);
                 if (mRemovalSidecar.isRemovingFingerprint(item.getBiometricId())) {
@@ -399,6 +422,7 @@ public class FingerprintSettings extends SubSettings {
             addPreference.setKey(KEY_FINGERPRINT_ADD);
             addPreference.setTitle(R.string.fingerprint_add_title);
             addPreference.setIcon(R.drawable.ic_add_24dp);
+            addPreference.setOrder(2);
             root.addPreference(addPreference);
             addPreference.setOnPreferenceChangeListener(this);
             updateAddPreference();
@@ -548,7 +572,10 @@ public class FingerprintSettings extends SubSettings {
             boolean result = true;
             final String key = preference.getKey();
             if (KEY_FINGERPRINT_ENABLE_KEYGUARD_TOGGLE.equals(key)) {
-                // TODO
+                boolean enableFingerprintUnlock = (boolean) value;
+                Settings.Secure.putInt(getContext().getContentResolver(),
+                        Settings.Secure.FINGERPRINT_UNLOCK_KEYGUARD_ENABLED,
+                        (enableFingerprintUnlock) ? 1 : 0);
             } else {
                 Log.v(TAG, "Unknown key:" + key);
             }


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/os_issue_tracker/issues/202
Review this PR with: https://github.com/GrapheneOS/platform_frameworks_base/pull/28

Add a preference in FingerprintSettings to allow toggling fingerprint unlock. This is enabled by default.

Currently, searching inside of settings will not pick up on the new preference (though the preference is behind the fingerprint options, which requires authentication to get in). 

This implementation doesn't use a controller class to handle the new preference; it instead follows the TODO left in the code, using the the fact that the Fragment implements OnPreferenceChangeListener.

<img src="https://user-images.githubusercontent.com/26474149/80438391-ea086480-88b8-11ea-9b88-d42836c28362.png" width="35%" />

Tested on Pixel 3a, based on QQ3A.200805.001.2020.08.03.22.
- Tested that each profile gets their own setting
- Tested with PIN, pattern, and password options
- Tested that another app, Aegis Authenticator, can still use fingerprints with the preference off
- Tested that the 72-hour fallback to primary authentication still works
- Did not test for compatibility (more for the commits in frameworks/base) with face unlock features of Pixel 4 and 4 XL

This preference could be refined in the future to work with https://github.com/GrapheneOS/os_issue_tracker/issues/28 (e.g. grey out or hide the 2FA setting if fingerprint unlock is disabled)