### PR TITLE
add active users limit toggle and show active users

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -11451,4 +11451,5 @@
     <string name="user_settings_limit_number_active_users_summary">Limits the number of active users to <xliff:g id="count">%1$d</xliff:g> by stopping the least recently switched-to users when over the limit. Turning this off may degrade performance. The admin user is never stopped.</string>
     <!-- User settings toast that appears when enabling the setting [CHAR LIMIT=50] -->
     <string name="user_settings_limit_number_active_users_toast">The limit will be enforced when switching users.</string>
+    <string name="user_summary_active">Active</string>
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -6843,6 +6843,7 @@
     <string name="user_lockscreen_settings">Lock screen settings</string>
     <!-- User settings item to allow creating new users from locks screen [CHAR LIMIT=50] -->
     <string name="user_add_on_lockscreen_menu">Add users from lock screen</string>
+
     <!-- User details new user name [CHAR LIMIT=30] -->
     <string name="user_new_user_name">New user</string>
     <!-- User details new restricted profile name [CHAR LIMIT=30] -->
@@ -11444,4 +11445,10 @@
     <string name="scramble_pin_summary">Controls PIN scrambling option when inputting PIN on screen lock.</string>
     <string name="keyguard_camera_title">Screenlock camera access toggle</string>
     <string name="keyguard_camera_summary">When checked, camera access is available while the device is locked.</string>
+    <!-- User settings item to enable a limit on active users [CHAR LIMIT=50] -->
+    <string name="user_settings_limit_number_active_users">Limit active users</string>
+    <!-- User settings item to enable a limit on active users summary for setting on  -->
+    <string name="user_settings_limit_number_active_users_summary">Limits the number of active users to <xliff:g id="count">%1$d</xliff:g> by stopping the least recently switched-to users when over the limit. Turning this off may degrade performance. The admin user is never stopped.</string>
+    <!-- User settings toast that appears when enabling the setting [CHAR LIMIT=50] -->
+    <string name="user_settings_limit_number_active_users_toast">The limit will be enforced when switching users.</string>
 </resources>

--- a/res/xml/user_settings.xml
+++ b/res/xml/user_settings.xml
@@ -33,11 +33,23 @@
         android:icon="@drawable/ic_add_24dp"
         android:order="20"/>
 
-    <com.android.settingslib.RestrictedSwitchPreference
-        android:key="user_settings_add_users_when_locked"
-        android:title="@string/user_add_on_lockscreen_menu"
-        android:singleLineTitle="false"
+    <PreferenceCategory
         android:order="105"
-        settings:allowDividerAbove="true"/>
+        android:key="user_settings_option_for_users"
+        android:layout="@layout/preference_category_no_label">
+
+        <com.android.settingslib.RestrictedSwitchPreference
+            android:key="user_settings_add_users_when_locked"
+            android:title="@string/user_add_on_lockscreen_menu"
+            android:singleLineTitle="false"
+            android:order="105"/>
+
+        <SwitchPreference
+            android:key="user_settings_limit_number_active_users"
+            android:title="@string/user_settings_limit_number_active_users"
+            android:summary="@string/user_settings_limit_number_active_users_summary"
+            android:order="106"/>
+
+    </PreferenceCategory>
 
 </PreferenceScreen>

--- a/src/com/android/settings/users/LimitNumberOfRunningUsersPreferenceController.java
+++ b/src/com/android/settings/users/LimitNumberOfRunningUsersPreferenceController.java
@@ -1,0 +1,68 @@
+package com.android.settings.users;
+
+import android.content.Context;
+import android.provider.Settings;
+import android.widget.Toast;
+
+import androidx.preference.Preference;
+
+import com.android.settings.R;
+import com.android.settings.core.TogglePreferenceController;
+
+public class LimitNumberOfRunningUsersPreferenceController extends TogglePreferenceController {
+    private final UserCapabilities mUserCaps;
+
+    public LimitNumberOfRunningUsersPreferenceController(Context context, String key) {
+        super(context, key);
+        mUserCaps = UserCapabilities.create(context);
+    }
+
+    @Override
+    public void updateState(Preference preference) {
+        super.updateState(preference);
+        mUserCaps.updateAddUserCapabilities(mContext);
+
+        preference.setSummary(getSummary());
+        if (!isAvailable()) {
+            preference.setVisible(false);
+        } else {
+            preference.setVisible(mUserCaps.mUserSwitcherEnabled);
+        }
+    }
+
+    @Override
+    public int getAvailabilityStatus() {
+        if (!mUserCaps.isAdmin()) {
+            return DISABLED_FOR_USER;
+        } else {
+            return mUserCaps.mUserSwitcherEnabled ? AVAILABLE : CONDITIONALLY_UNAVAILABLE;
+        }
+    }
+
+    @Override
+    public boolean isChecked() {
+        return Settings.Global.getInt(mContext.getContentResolver(),
+                Settings.Global.RUNNING_USERS_LIMIT_ENABLED, 1) != 0;
+    }
+
+    @Override
+    public boolean setChecked(boolean isChecked) {
+        if (isChecked) {
+            // Tell the user that enabling the setting won't enforce the limit right away.
+            Toast.makeText(mContext, R.string.user_settings_limit_number_active_users_toast,
+                    Toast.LENGTH_SHORT).show();
+        }
+
+        return Settings.Global.putInt(mContext.getContentResolver(),
+                Settings.Global.RUNNING_USERS_LIMIT_ENABLED, isChecked ? 1 : 0);
+    }
+
+    @Override
+    public CharSequence getSummary() {
+        final int maxRunningUsers = mContext.getResources().getInteger(
+                com.android.internal.R.integer.config_multiuserMaxRunningUsers);
+        return mContext.getString(R.string.user_settings_limit_number_active_users_summary,
+                maxRunningUsers);
+    }
+}
+

--- a/src/com/android/settings/users/UserSettings.java
+++ b/src/com/android/settings/users/UserSettings.java
@@ -111,6 +111,8 @@ public class UserSettings extends SettingsPreferenceFragment
     private static final String KEY_USER_GUEST = "user_guest";
     private static final String KEY_ADD_USER = "user_add";
     private static final String KEY_ADD_USER_WHEN_LOCKED = "user_settings_add_users_when_locked";
+    private static final String KEY_LIMIT_NUMBER_RUNNING_USERS =
+            "user_settings_limit_number_active_users";
 
     private static final int MENU_REMOVE_USER = Menu.FIRST;
 
@@ -166,6 +168,7 @@ public class UserSettings extends SettingsPreferenceFragment
     private MultiUserSwitchBarController mSwitchBarController;
     private EditUserInfoController mEditUserInfoController = new EditUserInfoController();
     private AddUserWhenLockedPreferenceController mAddUserWhenLockedPreferenceController;
+    private LimitNumberOfRunningUsersPreferenceController mLimitNumberOfRunningUsersPreferenceController;
     private MultiUserFooterPreferenceController mMultiUserFooterPreferenceController;
 
     // A place to cache the generated default avatar
@@ -233,15 +236,21 @@ public class UserSettings extends SettingsPreferenceFragment
 
         mAddUserWhenLockedPreferenceController = new AddUserWhenLockedPreferenceController(
                 activity, KEY_ADD_USER_WHEN_LOCKED);
+        mLimitNumberOfRunningUsersPreferenceController =
+                new LimitNumberOfRunningUsersPreferenceController(
+                        activity, KEY_LIMIT_NUMBER_RUNNING_USERS);
         mMultiUserFooterPreferenceController = new MultiUserFooterPreferenceController(activity)
                 .setFooterMixin(mFooterPreferenceMixin);
 
         final PreferenceScreen screen = getPreferenceScreen();
         mAddUserWhenLockedPreferenceController.displayPreference(screen);
+        mLimitNumberOfRunningUsersPreferenceController.displayPreference(screen);
         mMultiUserFooterPreferenceController.displayPreference(screen);
 
         screen.findPreference(mAddUserWhenLockedPreferenceController.getPreferenceKey())
                 .setOnPreferenceChangeListener(mAddUserWhenLockedPreferenceController);
+        screen.findPreference(mLimitNumberOfRunningUsersPreferenceController.getPreferenceKey())
+                .setOnPreferenceChangeListener(mLimitNumberOfRunningUsersPreferenceController);
 
         if (icicle != null) {
             if (icicle.containsKey(SAVE_ADDING_USER)) {
@@ -295,6 +304,8 @@ public class UserSettings extends SettingsPreferenceFragment
 
         mAddUserWhenLockedPreferenceController.updateState(screen.findPreference(
                 mAddUserWhenLockedPreferenceController.getPreferenceKey()));
+        mLimitNumberOfRunningUsersPreferenceController.updateState(screen.findPreference(
+                mLimitNumberOfRunningUsersPreferenceController.getPreferenceKey()));
 
         if (mShouldUpdateUserList) {
             updateUI();
@@ -957,7 +968,11 @@ public class UserSettings extends SettingsPreferenceFragment
         // If multi-user is disabled, just show footer and return.
         final Preference addUserOnLockScreen = getPreferenceScreen().findPreference(
                 mAddUserWhenLockedPreferenceController.getPreferenceKey());
+        final Preference limitBackgroundUsers = getPreferenceScreen().findPreference(
+                mLimitNumberOfRunningUsersPreferenceController.getPreferenceKey());
+
         mAddUserWhenLockedPreferenceController.updateState(addUserOnLockScreen);
+        mLimitNumberOfRunningUsersPreferenceController.updateState(limitBackgroundUsers);
         mMultiUserFooterPreferenceController.updateState(null /* preference */);
         mUserListCategory.setVisible(mUserCaps.mUserSwitcherEnabled);
 
@@ -1247,6 +1262,8 @@ public class UserSettings extends SettingsPreferenceFragment
                             suppressAllPage);
                     new AddUserWhenLockedPreferenceController(context, KEY_ADD_USER_WHEN_LOCKED)
                             .updateNonIndexableKeys(niks);
+                    new LimitNumberOfRunningUsersPreferenceController(context,
+                            KEY_LIMIT_NUMBER_RUNNING_USERS).updateNonIndexableKeys(niks);
                     new AutoSyncDataPreferenceController(context, null /* parent */)
                             .updateNonIndexableKeys(niks);
                     new AutoSyncPersonalDataPreferenceController(context, null /* parent */)


### PR DESCRIPTION
Closes GrapheneOS/os_issue_tracker#87
Review with: https://github.com/GrapheneOS/platform_frameworks_base/pull/32

Adds a toggle in Settings to control whether the number of active users is limited to 3. Also lets the admin user see the state of all the users. Switching to a user makes the user considered active, regardless of whether the user signs in

| ![limit2](https://user-images.githubusercontent.com/26474149/91926866-14b26180-ec8d-11ea-9bfb-18ee5e12bb99.png)  | ![limit1](https://user-images.githubusercontent.com/26474149/91926861-12e89e00-ec8d-11ea-8d69-83d77cd4ed6e.png) |
| --- | --- |

There's currently no option to adjust the limit; it's just an on or off toggle. The toggle is on by default, as that's the default Android behavior.

Tested on a Pixel 3a. Performance of the phone is heavily degraded if keeping all 17 (16 + guest) users active. It's somewhat acceptable if keeping 8 users active all with something like Vanadium open