### PR TITLE
add LTE only option

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -1266,22 +1266,26 @@
 
     <string-array name="enabled_networks_choices" translatable="false">
         <item>@string/network_lte</item>
+        <item>@string/network_lte_only</item>
         <item>@string/network_3G</item>
         <item>@string/network_2G</item>
     </string-array>
     <string-array name="enabled_networks_4g_choices" translatable="false">
         <item>@string/network_4G</item>
+        <item>@string/network_4G_only</item>
         <item>@string/network_3G</item>
         <item>@string/network_2G</item>
     </string-array>
     <string-array name="enabled_networks_values" translatable="false">
         <item>"9"</item>
+        <item>"11"</item>
         <item>"0"</item>
         <item>"1"</item>
     </string-array>
 
     <string-array name="enabled_networks_except_gsm_values" translatable="false">
         <item>"9"</item>
+        <item>"11"</item>
         <item>"0"</item>
     </string-array>
 
@@ -1296,6 +1300,7 @@
 
     <string-array name="enabled_networks_cdma_values" translatable="false">
         <item>"8"</item>
+        <item>"11"</item>
         <item>"4"</item>
         <item>"5"</item>
         <item>"10"</item>
@@ -1308,11 +1313,13 @@
 
     <string-array name="enabled_networks_cdma_only_lte_values" translatable="false">
         <item>"8"</item>
+        <item>"11"</item>
         <item>"10"</item>
     </string-array>
 
     <string-array name="enabled_networks_tdscdma_values" translatable="false">
         <item>"22"</item>
+        <item>"11"</item>
         <item>"18"</item>
         <item>"1"</item>
     </string-array>
@@ -1353,7 +1360,7 @@
         <item>CDMA + LTE/EvDo</item>
         <item>GSM/WCDMA/LTE</item>
         <item>Global</item>
-        <item>LTE</item>
+        <item>LTE only</item>
         <item>LTE / WCDMA</item>
         <item>TDSCDMA only</item>
         <item>TDSCDMA/WCDMA</item>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -11503,6 +11503,8 @@
     <string name="preferred_network_mode_cdma_evdo_gsm_wcdma_summary">Preferred network mode: CDMA/EvDo/GSM/WCDMA</string>
     <!-- LTE [CHAR LIMIT=NONE] -->
     <string name="preferred_network_mode_lte_summary">Preferred network mode: LTE </string>
+    <!-- LTE only [CHAR LIMIT=100] -->
+    <string name="preferred_network_mode_lte_only_summary">Preferred network mode: LTE only</string>
     <!-- GSM/WCDMA/LTE [CHAR LIMIT=NONE] -->
     <string name="preferred_network_mode_lte_gsm_wcdma_summary">Preferred network mode: GSM/WCDMA/LTE</string>
     <!-- CDMA+LTE/EVDO [CHAR LIMIT=NONE] -->
@@ -11570,8 +11572,12 @@
     <string name="network_4G_pure" translatable="false">4G</string>
     <!-- Text for Network lte [CHAR LIMIT=NONE] -->
     <string name="network_lte">LTE (recommended)</string>
+    <!-- Text for Network lte only [CHAR LIMIT=NONE] -->
+    <string name="network_lte_only">LTE only</string>
     <!-- Text for Network 4g [CHAR LIMIT=NONE] -->
     <string name="network_4G">4G (recommended)</string>
+    <!-- Text for Network 4g only [CHAR LIMIT=NONE] -->
+    <string name="network_4G_only">4G only</string>
     <!-- Text for Network 3g [CHAR LIMIT=NONE] -->
     <string name="network_3G" translatable="false">3G</string>
     <!-- Text for Network 2g [CHAR LIMIT=NONE] -->

--- a/src/com/android/settings/network/telephony/EnabledNetworkModePreferenceController.java
+++ b/src/com/android/settings/network/telephony/EnabledNetworkModePreferenceController.java
@@ -229,15 +229,16 @@ public class EnabledNetworkModePreferenceController extends
                     entryValues = mContext.getResources().getStringArray(
                             R.array.enabled_networks_cdma_values);
                     entryValuesInt = Stream.of(entryValues).mapToInt(Integer::parseInt).toArray();
-                    if (entryValuesInt.length < 4) {
+                    if (entryValuesInt.length < 5) {
                         throw new IllegalArgumentException(
                                 "ENABLED_NETWORKS_CDMA_CHOICES index error.");
                     }
                     add5gEntry(addNrToLteNetworkType(entryValuesInt[0]));
                     addLteEntry(entryValuesInt[0]);
-                    add3gEntry(entryValuesInt[1]);
-                    add1xEntry(entryValuesInt[2]);
-                    addGlobalEntry(entryValuesInt[3]);
+                    addLteOnlyEntry(entryValuesInt[1]);
+                    add3gEntry(entryValuesInt[2]);
+                    add1xEntry(entryValuesInt[3]);
+                    addGlobalEntry(entryValuesInt[4]);
                     break;
                 case ENABLED_NETWORKS_CDMA_NO_LTE_CHOICES:
                     entryValues = mContext.getResources().getStringArray(
@@ -254,25 +255,27 @@ public class EnabledNetworkModePreferenceController extends
                     entryValues = mContext.getResources().getStringArray(
                             R.array.enabled_networks_cdma_only_lte_values);
                     entryValuesInt = Stream.of(entryValues).mapToInt(Integer::parseInt).toArray();
-                    if (entryValuesInt.length < 2) {
+                    if (entryValuesInt.length < 3) {
                         throw new IllegalArgumentException(
                                 "ENABLED_NETWORKS_CDMA_ONLY_LTE_CHOICES index error.");
                     }
                     addLteEntry(entryValuesInt[0]);
-                    addGlobalEntry(entryValuesInt[1]);
+                    addLteOnlyEntry(entryValuesInt[1]);
+                    addGlobalEntry(entryValuesInt[2]);
                     break;
                 case ENABLED_NETWORKS_TDSCDMA_CHOICES:
                     entryValues = mContext.getResources().getStringArray(
                             R.array.enabled_networks_tdscdma_values);
                     entryValuesInt = Stream.of(entryValues).mapToInt(Integer::parseInt).toArray();
-                    if (entryValuesInt.length < 3) {
+                    if (entryValuesInt.length < 4) {
                         throw new IllegalArgumentException(
                                 "ENABLED_NETWORKS_TDSCDMA_CHOICES index error.");
                     }
                     add5gEntry(addNrToLteNetworkType(entryValuesInt[0]));
                     addLteEntry(entryValuesInt[0]);
-                    add3gEntry(entryValuesInt[1]);
-                    add2gEntry(entryValuesInt[2]);
+                    addLteOnlyEntry(entryValuesInt[1]);
+                    add3gEntry(entryValuesInt[2]);
+                    add2gEntry(entryValuesInt[3]);
                     break;
                 case ENABLED_NETWORKS_EXCEPT_GSM_LTE_CHOICES:
                     entryValues = mContext.getResources().getStringArray(
@@ -288,25 +291,27 @@ public class EnabledNetworkModePreferenceController extends
                     entryValues = mContext.getResources().getStringArray(
                             R.array.enabled_networks_except_gsm_values);
                     entryValuesInt = Stream.of(entryValues).mapToInt(Integer::parseInt).toArray();
-                    if (entryValuesInt.length < 2) {
+                    if (entryValuesInt.length < 3) {
                         throw new IllegalArgumentException(
                                 "ENABLED_NETWORKS_EXCEPT_GSM_4G_CHOICES index error.");
                     }
                     add5gEntry(addNrToLteNetworkType(entryValuesInt[0]));
                     add4gEntry(entryValuesInt[0]);
-                    add3gEntry(entryValuesInt[1]);
+                    add4gOnlyEntry(entryValuesInt[1]);
+                    add3gEntry(entryValuesInt[2]);
                     break;
                 case ENABLED_NETWORKS_EXCEPT_GSM_CHOICES:
                     entryValues = mContext.getResources().getStringArray(
                             R.array.enabled_networks_except_gsm_values);
                     entryValuesInt = Stream.of(entryValues).mapToInt(Integer::parseInt).toArray();
-                    if (entryValuesInt.length < 2) {
+                    if (entryValuesInt.length < 3) {
                         throw new IllegalArgumentException(
                                 "ENABLED_NETWORKS_EXCEPT_GSM_CHOICES index error.");
                     }
                     add5gEntry(addNrToLteNetworkType(entryValuesInt[0]));
                     addLteEntry(entryValuesInt[0]);
-                    add3gEntry(entryValuesInt[1]);
+                    addLteOnlyEntry(entryValuesInt[1]);
+                    add3gEntry(entryValuesInt[2]);
                     break;
                 case ENABLED_NETWORKS_EXCEPT_LTE_CHOICES:
                     entryValues = mContext.getResources().getStringArray(
@@ -323,27 +328,29 @@ public class EnabledNetworkModePreferenceController extends
                     entryValues = mContext.getResources().getStringArray(
                             R.array.enabled_networks_values);
                     entryValuesInt = Stream.of(entryValues).mapToInt(Integer::parseInt).toArray();
-                    if (entryValuesInt.length < 3) {
+                    if (entryValuesInt.length < 4) {
                         throw new IllegalArgumentException(
                                 "ENABLED_NETWORKS_4G_CHOICES index error.");
                     }
                     add5gEntry(addNrToLteNetworkType(
                             entryValuesInt[0]));
                     add4gEntry(entryValuesInt[0]);
-                    add3gEntry(entryValuesInt[1]);
-                    add2gEntry(entryValuesInt[2]);
+                    add4gOnlyEntry(entryValuesInt[1]);
+                    add3gEntry(entryValuesInt[2]);
+                    add2gEntry(entryValuesInt[3]);
                     break;
                 case ENABLED_NETWORKS_CHOICES:
                     entryValues = mContext.getResources().getStringArray(
                             R.array.enabled_networks_values);
                     entryValuesInt = Stream.of(entryValues).mapToInt(Integer::parseInt).toArray();
-                    if (entryValuesInt.length < 3) {
+                    if (entryValuesInt.length < 4) {
                         throw new IllegalArgumentException("ENABLED_NETWORKS_CHOICES index error.");
                     }
                     add5gEntry(addNrToLteNetworkType(entryValuesInt[0]));
                     addLteEntry(entryValuesInt[0]);
-                    add3gEntry(entryValuesInt[1]);
-                    add2gEntry(entryValuesInt[2]);
+                    addLteOnlyEntry(entryValuesInt[1]);
+                    add3gEntry(entryValuesInt[2]);
+                    add2gEntry(entryValuesInt[3]);
                     break;
                 case PREFERRED_NETWORK_MODE_CHOICES_WORLD_MODE:
                     entryValues = mContext.getResources().getStringArray(
@@ -481,7 +488,6 @@ public class EnabledNetworkModePreferenceController extends
                                 R.string.preferred_network_mode_lte_gsm_umts_summary);
                         break;
                     }
-                case TelephonyManagerConstants.NETWORK_MODE_LTE_ONLY:
                 case TelephonyManagerConstants.NETWORK_MODE_LTE_WCDMA:
                     if (!mIsGlobalCdma) {
                         setSelectedEntry(
@@ -498,6 +504,11 @@ public class EnabledNetworkModePreferenceController extends
                                 TelephonyManagerConstants.NETWORK_MODE_LTE_CDMA_EVDO_GSM_WCDMA);
                         setSummary(R.string.network_global);
                     }
+                    break;
+                case TelephonyManagerConstants.NETWORK_MODE_LTE_ONLY:
+                    setSelectedEntry(TelephonyManagerConstants.NETWORK_MODE_LTE_ONLY);
+                    setSummary(mShow4gForLTE
+                            ? R.string.network_4G_only : R.string.network_lte_only);
                     break;
                 case TelephonyManagerConstants.NETWORK_MODE_LTE_CDMA_EVDO:
                     if (MobileNetworkUtils.isWorldMode(mContext, mSubId)) {
@@ -675,6 +686,22 @@ public class EnabledNetworkModePreferenceController extends
 
         private boolean showNrList() {
             return mSupported5gRadioAccessFamily && mAllowed5gNetworkType;
+        }
+
+        /**
+         * Add LTE only entry.
+         */
+        private void addLteOnlyEntry(int value) {
+            mEntries.add(mContext.getString(R.string.network_lte_only));
+            mEntriesValue.add(value);
+        }
+
+        /**
+         * Add 4G only entry
+         */
+        private void add4gOnlyEntry(int value) {
+            mEntries.add(mContext.getString(R.string.network_4G_only));
+            mEntriesValue.add(value);
         }
 
         /**

--- a/src/com/android/settings/network/telephony/PreferredNetworkModePreferenceController.java
+++ b/src/com/android/settings/network/telephony/PreferredNetworkModePreferenceController.java
@@ -136,7 +136,7 @@ public class PreferredNetworkModePreferenceController extends TelephonyBasePrefe
             case TelephonyManagerConstants.NETWORK_MODE_LTE_TDSCDMA:
                 return R.string.preferred_network_mode_lte_tdscdma_summary;
             case TelephonyManagerConstants.NETWORK_MODE_LTE_ONLY:
-                return R.string.preferred_network_mode_lte_summary;
+                return R.string.preferred_network_mode_lte_only_summary;
             case TelephonyManagerConstants.NETWORK_MODE_LTE_TDSCDMA_GSM:
                 return R.string.preferred_network_mode_lte_tdscdma_gsm_summary;
             case TelephonyManagerConstants.NETWORK_MODE_LTE_TDSCDMA_GSM_WCDMA:


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/os_issue_tracker/issues/276

Ported from 10:
https://github.com/GrapheneOS/platform_packages_apps_Settings/commit/e977bf319cf4b3af311499003d206c6527df45ab

Changes since 10:
- We need to account for the new way the PreferenceEntries are
  constructed.

  The choice string arrays for each enabled_network case (like
  `enabled_networks_except_gsm_4g_choices`) are no longer being used. The
  summaries and their values are now programmatically created in the
  EnabledNetworkModePreferenceController PreferenceEntriesBuilder.

- Caveat: If the user hasn't set any preferred network type beforehand,
  then, when they view the dialog, the very first list item is selected
  by default. This is an issue with the original placement of the LTE
  only mode being the first option, e.g. tapping the ListPreference,
  they will see that the "LTE only" mode radio button is selected
  despite the ListPreference summary being "LTE (Recommended)".
  This is caused by `setSelectedEntry`  in the EnabledNetworkModePreferenceController 
  defaulting to the first entry value if it can't find it, and the first entry
  value is LTE only mode.

  The fix: move LTE only option to being the second option.
  This should fix default-to-first-entry caveat, as it now aligns to the
  original expected default values.

Original commit message:

This mostly follows the work done in
https://github.com/GrapheneOS/platform_packages_services_Telephony/commit/7f1b1088ade90096d874e8e554f0d47b9040ed14