### PR TITLE
fix resultCodes from WifiPickerActivity

### DIFF
--- a/src/com/android/settings/wifi/WifiPickerActivity.java
+++ b/src/com/android/settings/wifi/WifiPickerActivity.java
@@ -55,10 +55,17 @@ public class WifiPickerActivity extends SettingsActivity implements ButtonBarHan
                 || isSavedAccessPointsWifiSettings) {
             return true;
         }
+
+        if (FeatureFlagUtils.isEnabled(this, FeatureFlagUtils.SETTINGS_WIFITRACKER2)
+                && WifiSettings2.class.getName().equals(fragmentName)) {
+            return true;
+        }
+
         return false;
     }
 
     /* package */ Class<? extends PreferenceFragmentCompat> getWifiSettingsClass() {
-        return WifiSettings.class;
+        return FeatureFlagUtils.isEnabled(this, FeatureFlagUtils.SETTINGS_WIFITRACKER2)
+                ? WifiSettings2.class : WifiSettings.class;
     }
 }


### PR DESCRIPTION
Related to https://github.com/GrapheneOS/os_issue_tracker/issues/265

This fixes the Wifi Activity inside SetupWizard (the commit in SetupWizard to remove it should be reverted).

The [android.net.wifi.PICK_WIFI_NETWORK intent is received by WifiPickerActivity](https://github.com/GrapheneOS/platform_packages_apps_Settings/blob/11/AndroidManifest.xml#L292-L300), and then [WifiPickerActivity launches the WifiSettings Fragment](https://github.com/GrapheneOS/platform_packages_apps_Settings/blob/11/src/com/android/settings/wifi/WifiPickerActivity.java#L62), and then [WifiSettings launches WifiSettings2, and then WifiSettings finishes itself](https://github.com/GrapheneOS/platform_packages_apps_Settings/blob/11/src/com/android/settings/wifi/WifiSettings.java#L241-L250). (This is assuming that the SETTINGS_WIFITRACKER2 feature flag is enabled.)

EDIT: "WifiSettings finishing itself" means that it calls `finish()`, which finishes the Activity that launched it: https://github.com/GrapheneOS/platform_packages_apps_Settings/blob/11/src/com/android/settings/SettingsPreferenceFragment.java#L672-L680. The WifiSettings2 Fragment is launched from WifiSettings2Activity, which extends SettingsActivity, so it has its own Next button.

Instead of relying on WifiSettings to launch WifiSettings2, we should just launch WifiSettings2 directly. If we don't do this, WifiSettings finishing itself will send a resultCode of RESULT_CANCELLED to the app that launched an Intent with action android.net.wifi.PICK_WIFI_NETWORK.  This means that the resultCode from WifiSettings2Activity will never get propagated.