### PR TITLE
don't change network value arrays for LTE only

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -1293,28 +1293,27 @@
         <item>4</item> <!-- AutofillManager.FLAG_ADD_CLIENT_VERBOSE -->
     </string-array>
 
+    <!-- Note: The LTE only option is added in code, not here. Also, these enabled_networks_choices
+         and enabled_networks_4g_choices string arrays are just placeholders for
+         mobile_network_settings.xml -->
     <string-array name="enabled_networks_choices" translatable="false">
         <item>@string/network_lte</item>
-        <item>@string/network_lte_only</item>
         <item>@string/network_3G</item>
         <item>@string/network_2G</item>
     </string-array>
     <string-array name="enabled_networks_4g_choices" translatable="false">
         <item>@string/network_4G</item>
-        <item>@string/network_4G_only</item>
         <item>@string/network_3G</item>
         <item>@string/network_2G</item>
     </string-array>
     <string-array name="enabled_networks_values" translatable="false">
         <item>"9"</item>
-        <item>"11"</item>
         <item>"0"</item>
         <item>"1"</item>
     </string-array>
 
     <string-array name="enabled_networks_except_gsm_values" translatable="false">
         <item>"9"</item>
-        <item>"11"</item>
         <item>"0"</item>
     </string-array>
 
@@ -1329,7 +1328,6 @@
 
     <string-array name="enabled_networks_cdma_values" translatable="false">
         <item>"8"</item>
-        <item>"11"</item>
         <item>"4"</item>
         <item>"5"</item>
         <item>"10"</item>
@@ -1342,13 +1340,11 @@
 
     <string-array name="enabled_networks_cdma_only_lte_values" translatable="false">
         <item>"8"</item>
-        <item>"11"</item>
         <item>"10"</item>
     </string-array>
 
     <string-array name="enabled_networks_tdscdma_values" translatable="false">
         <item>"22"</item>
-        <item>"11"</item>
         <item>"18"</item>
         <item>"1"</item>
     </string-array>

--- a/src/com/android/settings/network/telephony/EnabledNetworkModePreferenceController.java
+++ b/src/com/android/settings/network/telephony/EnabledNetworkModePreferenceController.java
@@ -229,16 +229,16 @@ public class EnabledNetworkModePreferenceController extends
                     entryValues = mContext.getResources().getStringArray(
                             R.array.enabled_networks_cdma_values);
                     entryValuesInt = Stream.of(entryValues).mapToInt(Integer::parseInt).toArray();
-                    if (entryValuesInt.length < 5) {
+                    if (entryValuesInt.length < 4) {
                         throw new IllegalArgumentException(
                                 "ENABLED_NETWORKS_CDMA_CHOICES index error.");
                     }
                     add5gEntry(addNrToLteNetworkType(entryValuesInt[0]));
                     addLteEntry(entryValuesInt[0]);
-                    addLteOnlyEntry(entryValuesInt[1]);
-                    add3gEntry(entryValuesInt[2]);
-                    add1xEntry(entryValuesInt[3]);
-                    addGlobalEntry(entryValuesInt[4]);
+                    addLteOnlyEntry();
+                    add3gEntry(entryValuesInt[1]);
+                    add1xEntry(entryValuesInt[2]);
+                    addGlobalEntry(entryValuesInt[3]);
                     break;
                 case ENABLED_NETWORKS_CDMA_NO_LTE_CHOICES:
                     entryValues = mContext.getResources().getStringArray(
@@ -255,27 +255,27 @@ public class EnabledNetworkModePreferenceController extends
                     entryValues = mContext.getResources().getStringArray(
                             R.array.enabled_networks_cdma_only_lte_values);
                     entryValuesInt = Stream.of(entryValues).mapToInt(Integer::parseInt).toArray();
-                    if (entryValuesInt.length < 3) {
+                    if (entryValuesInt.length < 2) {
                         throw new IllegalArgumentException(
                                 "ENABLED_NETWORKS_CDMA_ONLY_LTE_CHOICES index error.");
                     }
                     addLteEntry(entryValuesInt[0]);
-                    addLteOnlyEntry(entryValuesInt[1]);
-                    addGlobalEntry(entryValuesInt[2]);
+                    addLteOnlyEntry();
+                    addGlobalEntry(entryValuesInt[1]);
                     break;
                 case ENABLED_NETWORKS_TDSCDMA_CHOICES:
                     entryValues = mContext.getResources().getStringArray(
                             R.array.enabled_networks_tdscdma_values);
                     entryValuesInt = Stream.of(entryValues).mapToInt(Integer::parseInt).toArray();
-                    if (entryValuesInt.length < 4) {
+                    if (entryValuesInt.length < 3) {
                         throw new IllegalArgumentException(
                                 "ENABLED_NETWORKS_TDSCDMA_CHOICES index error.");
                     }
                     add5gEntry(addNrToLteNetworkType(entryValuesInt[0]));
                     addLteEntry(entryValuesInt[0]);
-                    addLteOnlyEntry(entryValuesInt[1]);
-                    add3gEntry(entryValuesInt[2]);
-                    add2gEntry(entryValuesInt[3]);
+                    addLteOnlyEntry();
+                    add3gEntry(entryValuesInt[1]);
+                    add2gEntry(entryValuesInt[2]);
                     break;
                 case ENABLED_NETWORKS_EXCEPT_GSM_LTE_CHOICES:
                     entryValues = mContext.getResources().getStringArray(
@@ -291,27 +291,27 @@ public class EnabledNetworkModePreferenceController extends
                     entryValues = mContext.getResources().getStringArray(
                             R.array.enabled_networks_except_gsm_values);
                     entryValuesInt = Stream.of(entryValues).mapToInt(Integer::parseInt).toArray();
-                    if (entryValuesInt.length < 3) {
+                    if (entryValuesInt.length < 2) {
                         throw new IllegalArgumentException(
                                 "ENABLED_NETWORKS_EXCEPT_GSM_4G_CHOICES index error.");
                     }
                     add5gEntry(addNrToLteNetworkType(entryValuesInt[0]));
                     add4gEntry(entryValuesInt[0]);
-                    add4gOnlyEntry(entryValuesInt[1]);
-                    add3gEntry(entryValuesInt[2]);
+                    add4gOnlyEntry();
+                    add3gEntry(entryValuesInt[1]);
                     break;
                 case ENABLED_NETWORKS_EXCEPT_GSM_CHOICES:
                     entryValues = mContext.getResources().getStringArray(
                             R.array.enabled_networks_except_gsm_values);
                     entryValuesInt = Stream.of(entryValues).mapToInt(Integer::parseInt).toArray();
-                    if (entryValuesInt.length < 3) {
+                    if (entryValuesInt.length < 2) {
                         throw new IllegalArgumentException(
                                 "ENABLED_NETWORKS_EXCEPT_GSM_CHOICES index error.");
                     }
                     add5gEntry(addNrToLteNetworkType(entryValuesInt[0]));
                     addLteEntry(entryValuesInt[0]);
-                    addLteOnlyEntry(entryValuesInt[1]);
-                    add3gEntry(entryValuesInt[2]);
+                    addLteOnlyEntry();
+                    add3gEntry(entryValuesInt[1]);
                     break;
                 case ENABLED_NETWORKS_EXCEPT_LTE_CHOICES:
                     entryValues = mContext.getResources().getStringArray(
@@ -328,29 +328,29 @@ public class EnabledNetworkModePreferenceController extends
                     entryValues = mContext.getResources().getStringArray(
                             R.array.enabled_networks_values);
                     entryValuesInt = Stream.of(entryValues).mapToInt(Integer::parseInt).toArray();
-                    if (entryValuesInt.length < 4) {
+                    if (entryValuesInt.length < 3) {
                         throw new IllegalArgumentException(
                                 "ENABLED_NETWORKS_4G_CHOICES index error.");
                     }
                     add5gEntry(addNrToLteNetworkType(
                             entryValuesInt[0]));
                     add4gEntry(entryValuesInt[0]);
-                    add4gOnlyEntry(entryValuesInt[1]);
-                    add3gEntry(entryValuesInt[2]);
-                    add2gEntry(entryValuesInt[3]);
+                    add4gOnlyEntry();
+                    add3gEntry(entryValuesInt[1]);
+                    add2gEntry(entryValuesInt[2]);
                     break;
                 case ENABLED_NETWORKS_CHOICES:
                     entryValues = mContext.getResources().getStringArray(
                             R.array.enabled_networks_values);
                     entryValuesInt = Stream.of(entryValues).mapToInt(Integer::parseInt).toArray();
-                    if (entryValuesInt.length < 4) {
+                    if (entryValuesInt.length < 3) {
                         throw new IllegalArgumentException("ENABLED_NETWORKS_CHOICES index error.");
                     }
                     add5gEntry(addNrToLteNetworkType(entryValuesInt[0]));
                     addLteEntry(entryValuesInt[0]);
-                    addLteOnlyEntry(entryValuesInt[1]);
-                    add3gEntry(entryValuesInt[2]);
-                    add2gEntry(entryValuesInt[3]);
+                    addLteOnlyEntry();
+                    add3gEntry(entryValuesInt[1]);
+                    add2gEntry(entryValuesInt[2]);
                     break;
                 case PREFERRED_NETWORK_MODE_CHOICES_WORLD_MODE:
                     entryValues = mContext.getResources().getStringArray(
@@ -691,17 +691,17 @@ public class EnabledNetworkModePreferenceController extends
         /**
          * Add LTE only entry.
          */
-        private void addLteOnlyEntry(int value) {
+        private void addLteOnlyEntry() {
             mEntries.add(mContext.getString(R.string.network_lte_only));
-            mEntriesValue.add(value);
+            mEntriesValue.add(TelephonyManagerConstants.NETWORK_MODE_LTE_ONLY);
         }
 
         /**
          * Add 4G only entry
          */
-        private void add4gOnlyEntry(int value) {
+        private void add4gOnlyEntry() {
             mEntries.add(mContext.getString(R.string.network_4G_only));
-            mEntriesValue.add(value);
+            mEntriesValue.add(TelephonyManagerConstants.NETWORK_MODE_LTE_ONLY);
         }
 
         /**


### PR DESCRIPTION
If we add in any overlays that affect these network mode value arrays, then their dimensions may revert back to how they were before. In that case, EnabledNetworkModePreferenceController can throw an IllegalArgumentException, since there are assertions on the lengths of these arrays. Thus, we move out the LTE only value out of these arrays and just use the constant value directly in the code.