### PR TITLE
Remove misleading "Google Play system update" info field

### DIFF
--- a/res/xml/firmware_version.xml
+++ b/res/xml/firmware_version.xml
@@ -37,14 +37,6 @@
         settings:enableCopying="true"
         settings:controller="com.android.settings.deviceinfo.firmwareversion.SecurityPatchLevelPreferenceController"/>
 
-    <!-- Mainline module version -->
-    <Preference
-        android:key="module_version"
-        android:title="@string/module_version"
-        android:summary="@string/summary_placeholder"
-        settings:enableCopying="true"
-        settings:controller="com.android.settings.deviceinfo.firmwareversion.MainlineModuleVersionPreferenceController"/>
-
     <!-- Baseband -->
     <Preference
         android:key="base_band"


### PR DESCRIPTION
User's have come into the Matrix channel being misled. GrapheneOS does not use APEX and does not bundle Google Play so this does not make sense to have.