### PR TITLE
hide pattern screenlock option

### DIFF
--- a/res/values/config.xml
+++ b/res/values/config.xml
@@ -282,6 +282,9 @@
     <!-- Whether swipe security option is hidden or not -->
     <bool name="config_hide_swipe_security_option">false</bool>
 
+    <!-- Whether pattern security option is hidden or not -->
+    <bool name="config_hide_pattern_security_option">true</bool>
+
     <!--Whether help links are defined. -->
     <bool name="config_has_help">false</bool>
 

--- a/src/com/android/settings/password/ChooseLockGenericController.java
+++ b/src/com/android/settings/password/ChooseLockGenericController.java
@@ -114,6 +114,7 @@ public class ChooseLockGenericController {
                 return mManagedPasswordProvider.isManagedPasswordChoosable();
             case PIN:
             case PATTERN:
+                return !mContext.getResources().getBoolean(R.bool.config_hide_pattern_security_option);
             case PASSWORD:
                 // Hide the secure lock screen options if the device doesn't support the secure lock
                 // screen feature.

--- a/tests/robotests/src/com/android/settings/password/ChooseLockGenericControllerTest.java
+++ b/tests/robotests/src/com/android/settings/password/ChooseLockGenericControllerTest.java
@@ -73,6 +73,7 @@ public class ChooseLockGenericControllerTest {
         mController = createController(PASSWORD_COMPLEXITY_NONE);
         SettingsShadowResources.overrideResource(R.bool.config_hide_none_security_option, false);
         SettingsShadowResources.overrideResource(R.bool.config_hide_swipe_security_option, false);
+        SettingsShadowResources.overrideResource(R.bool.config_hide_pattern_security_option, false);
     }
 
     @After
@@ -90,9 +91,12 @@ public class ChooseLockGenericControllerTest {
 
         SettingsShadowResources.overrideResource(R.bool.config_hide_none_security_option, true);
         SettingsShadowResources.overrideResource(R.bool.config_hide_swipe_security_option, true);
+        SettingsShadowResources.overrideResource(R.bool.config_hide_pattern_security_option, true);
         assertThat(mController.isScreenLockVisible(ScreenLockType.NONE)).named("NONE visible")
                 .isFalse();
         assertThat(mController.isScreenLockVisible(ScreenLockType.SWIPE)).named("SWIPE visible")
+                .isFalse();
+        assertThat(mController.isScreenLockVisible(ScreenLockType.PATTERN)).named("PATTERN visible")
                 .isFalse();
     }
 


### PR DESCRIPTION
fix https://github.com/GrapheneOS/os-issue-tracker/issues/570

Tested on emulator. Successfully hides the option from both Settings and SetupWizard.