### PR TITLE
Ignore carrier restrictions on editing network settings.

### DIFF
--- a/src/com/android/settings/network/telephony/EnabledNetworkModePreferenceController.java
+++ b/src/com/android/settings/network/telephony/EnabledNetworkModePreferenceController.java
@@ -76,7 +76,7 @@ public class EnabledNetworkModePreferenceController extends
                 CarrierConfigManager.KEY_HIDE_CARRIER_NETWORK_SETTINGS_BOOL)
                 || carrierConfig.getBoolean(
                 CarrierConfigManager.KEY_HIDE_PREFERRED_NETWORK_TYPE_BOOL)) {
-            visible = false;
+            visible = true;
         } else if (carrierConfig.getBoolean(CarrierConfigManager.KEY_WORLD_PHONE_BOOL)) {
             visible = false;
         } else {


### PR DESCRIPTION
This ignores:
https://developer.android.com/reference/android/telephony/CarrierConfigManager#KEY_HIDE_CARRIER_NETWORK_SETTINGS_BOOL
https://developer.android.com/reference/android/telephony/CarrierConfigManager#KEY_HIDE_PREFERRED_NETWORK_TYPE_BOOL