### PR TITLE
3rd mode for disabling connectivity checks

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -273,11 +273,13 @@
     <string-array name="connectivity_check_entries">
         <item>GrapheneOS</item>
         <item>Standard (Google)</item>
+        <item>Disabled</item>
     </string-array>
 
     <string-array name="connectivity_check_values" translatable="false">
         <item>0</item>
         <item>1</item>
+        <item>2</item>
     </string-array>
 
     <!-- Do not translate. -->


### PR DESCRIPTION
This disables captive portal checks,
[see for more.](https://github.com/GrapheneOS/platform_packages_modules_NetworkStack/blob/11/src/com/android/server/connectivity/NetworkMonitor.java#L2264-L2269 ) 

can be closed [#500](https://github.com/GrapheneOS/os-issue-tracker/issues/500)