### PR TITLE
add a toggle for disabling fingerprint unlock

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -13621,4 +13621,7 @@
     <string name="keyguard_camera_summary">Allow camera access when the device is locked</string>
     <string name="native_debug_title">Enable native code debugging</string>
     <string name="native_debug_summary">Generate useful logs / bug reports from crashes and permit debugging native code.</string>
+    <string name="security_settings_fingerprint_settings_screen_lock_category">Screen lock</string>
+    <string name="security_settings_fingerprint_settings_use_fingerprint_unlock_phone_title">Allow fingerprint unlocking</string>
+    <string name="security_settings_fingerprint_settings_use_fingerprint_unlock_phone_summary">Allow fingerprints to unlock the screen lock. If this is disabled, fingerprints can still be used in apps.</string>
 </resources>

--- a/res/xml/security_settings_fingerprint.xml
+++ b/res/xml/security_settings_fingerprint.xml
@@ -16,5 +16,18 @@
 
 <PreferenceScreen
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:title="@string/security_settings_fingerprint_preference_title"/>
+    android:title="@string/security_settings_fingerprint_preference_title">
+
+    <PreferenceCategory
+        android:title="@string/security_settings_fingerprint_settings_screen_lock_category"
+        android:order="10"
+        android:key="security_settings_fingerprint_unlock_category">
+
+        <SwitchPreference
+            android:key="security_settings_fingerprint_keyguard"
+            android:title="@string/security_settings_fingerprint_settings_use_fingerprint_unlock_phone_title"
+            android:summary="@string/security_settings_fingerprint_settings_use_fingerprint_unlock_phone_summary" />
+    </PreferenceCategory>
+
+</PreferenceScreen>
 

--- a/src/com/android/settings/biometrics/fingerprint/FingerprintSettings.java
+++ b/src/com/android/settings/biometrics/fingerprint/FingerprintSettings.java
@@ -36,6 +36,7 @@ import android.os.UserHandle;
 import android.os.UserManager;
 import android.text.InputFilter;
 import android.text.Spanned;
+import android.provider.Settings;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.View;
@@ -51,6 +52,7 @@ import androidx.preference.Preference.OnPreferenceChangeListener;
 import androidx.preference.PreferenceGroup;
 import androidx.preference.PreferenceScreen;
 import androidx.preference.PreferenceViewHolder;
+import androidx.preference.SwitchPreference;
 
 import com.android.settings.R;
 import com.android.settings.SettingsPreferenceFragment;
@@ -115,8 +117,10 @@ public class FingerprintSettings extends SubSettings {
         private static final String TAG = "FingerprintSettings";
         private static final String KEY_FINGERPRINT_ITEM_PREFIX = "key_fingerprint_item";
         private static final String KEY_FINGERPRINT_ADD = "key_fingerprint_add";
+        private static final String KEY_FINGERPRINT_SCREEN_LOCK_OPTIONS_CATEGORY =
+                "security_settings_fingerprint_unlock_category";
         private static final String KEY_FINGERPRINT_ENABLE_KEYGUARD_TOGGLE =
-                "fingerprint_enable_keyguard_toggle";
+                "security_settings_fingerprint_keyguard";
         private static final String KEY_LAUNCHED_CONFIRM = "launched_confirm";
 
         private static final int MSG_REFRESH_FINGERPRINT_TEMPLATES = 1000;
@@ -399,6 +403,24 @@ public class FingerprintSettings extends SubSettings {
             root = getPreferenceScreen();
             addFingerprintItemPreferences(root);
             setPreferenceScreen(root);
+
+            // Need to add back the keyguard preferences, since addFingerprintItemPreferences
+            // calls root.removeAll() again.
+            addPreferencesFromResource(R.xml.security_settings_fingerprint);
+
+            // Don't show keyguard preferences for work profile settings.
+            if (UserManager.get(getContext()).isManagedProfile(mUserId)) {
+                removePreference(KEY_FINGERPRINT_SCREEN_LOCK_OPTIONS_CATEGORY);
+            } else {
+                SwitchPreference lockScreenFingerprintPreference =
+                        (SwitchPreference) findPreference(KEY_FINGERPRINT_ENABLE_KEYGUARD_TOGGLE);
+
+                lockScreenFingerprintPreference.setChecked(Settings.Secure.getInt(
+                        getContext().getContentResolver(),
+                        Settings.Secure.BIOMETRIC_KEYGUARD_ENABLED, 1) == 1);
+                lockScreenFingerprintPreference.setOnPreferenceChangeListener(this);
+            }
+
             return root;
         }
 
@@ -413,6 +435,7 @@ public class FingerprintSettings extends SubSettings {
                 pref.setKey(genKey(item.getBiometricId()));
                 pref.setTitle(item.getName());
                 pref.setFingerprint(item);
+                pref.setOrder(1);
                 pref.setPersistent(false);
                 pref.setIcon(R.drawable.ic_fingerprint_24dp);
                 if (mRemovalSidecar.isRemovingFingerprint(item.getBiometricId())) {
@@ -428,6 +451,7 @@ public class FingerprintSettings extends SubSettings {
             addPreference.setKey(KEY_FINGERPRINT_ADD);
             addPreference.setTitle(R.string.fingerprint_add_title);
             addPreference.setIcon(R.drawable.ic_add_24dp);
+            addPreference.setOrder(2);
             root.addPreference(addPreference);
             addPreference.setOnPreferenceChangeListener(this);
             updateAddPreference();
@@ -582,7 +606,10 @@ public class FingerprintSettings extends SubSettings {
             boolean result = true;
             final String key = preference.getKey();
             if (KEY_FINGERPRINT_ENABLE_KEYGUARD_TOGGLE.equals(key)) {
-                // TODO
+                boolean enableFingerprintUnlock = (boolean) value;
+                Settings.Secure.putInt(getContext().getContentResolver(),
+                        Settings.Secure.BIOMETRIC_KEYGUARD_ENABLED,
+                        (enableFingerprintUnlock) ? 1 : 0);
             } else {
                 Log.v(TAG, "Unknown key:" + key);
             }


### PR DESCRIPTION
Ported from 11. In 12 fingerprint is handled by the new biometric API and so technically in 12 this is not just disabling fingerprint unlock but all biometrics. This does not affect the Pixel 4 generation of devices with face scanning however as they were released on Q and so use the legacy face API. No frameworks/base changes are needed for 12 in this case other than migration which can be done in another commit.