### PR TITLE
Toggle VPN lockdown to on when Always-On is toggled to on

### DIFF
--- a/res/drawable/ic_settings_install.xml
+++ b/res/drawable/ic_settings_install.xml
@@ -18,7 +18,8 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24">
+    android:viewportHeight="24"
+    android:tint="?android:attr/colorControlNormal">
   <path
       android:fillColor="#FF000000"
       android:pathData="M18,15v3H6v-3H4v3c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2v-3H18z"/>

--- a/res/layout/wifi_dialog.xml
+++ b/res/layout/wifi_dialog.xml
@@ -682,7 +682,7 @@
                          android:layout_height="wrap_content"
                          style="@style/wifi_item_spinner"
                          android:prompt="@string/wifi_privacy_settings"
-                         android:entries="@array/wifi_privacy_entries"/>
+                         android:entries="@array/wifi_privacy_entries_extended"/>
             </LinearLayout>
 
             <LinearLayout

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -124,6 +124,16 @@
         <item>30 minutes</item>
     </string-array>
 
+    <string-array name="scramble_pin_entries">
+        <item>Scramble PIN</item>
+        <item>No PIN scrambling</item>
+    </string-array>
+
+    <string-array name="scramble_pin_values" translatable="false">
+        <item>true</item>
+        <item>false</item>
+    </string-array>
+
     <!-- Do not translate. -->
     <string-array name="lock_after_timeout_values" translatable="false">
         <!-- Do not translate. -->

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -39,6 +39,50 @@
         <item>All</item>
     </string-array>
 
+    <!-- Bluetooth settings.  The delay in inactivity before bluetooth is turned off. These are shown in a list dialog. -->
+    <string-array name="bluetooth_timeout_entries">
+        <item>@string/bluetooth_timeout_summary_never</item>
+        <item>@string/bluetooth_timeout_summary_15secs</item>
+        <item>@string/bluetooth_timeout_summary_30secs</item>
+        <item>@string/bluetooth_timeout_summary_1min</item>
+        <item>@string/bluetooth_timeout_summary_2mins</item>
+        <item>@string/bluetooth_timeout_summary_5mins</item>
+        <item>@string/bluetooth_timeout_summary_10mins</item>
+        <item>@string/bluetooth_timeout_summary_30mins</item>
+        <item>@string/bluetooth_timeout_summary_1hour</item>
+        <item>@string/bluetooth_timeout_summary_2hours</item>
+        <item>@string/bluetooth_timeout_summary_4hours</item>
+        <item>@string/bluetooth_timeout_summary_8hours</item>
+    </string-array>
+
+    <!-- Do not translate. -->
+    <string-array name="bluetooth_timeout_values" translatable="false">
+        <!-- Do not translate. -->
+        <item>0</item>
+        <!-- Do not translate. -->
+        <item>15000</item>
+        <!-- Do not translate. -->
+        <item>30000</item>
+        <!-- Do not translate. -->
+        <item>60000</item>
+        <!-- Do not translate. -->
+        <item>120000</item>
+        <!-- Do not translate. -->
+        <item>300000</item>
+        <!-- Do not translate. -->
+        <item>600000</item>
+        <!-- Do not translate. -->
+        <item>1800000</item>
+        <!-- Do not translate. -->
+        <item>3600000</item>
+        <!-- Do not translate. -->
+        <item>7200000</item>
+        <!-- Do not translate. -->
+        <item>14400000</item>
+        <!-- Do not translate. -->
+        <item>28800000</item>
+    </string-array>
+
     <!-- Display settings.  The delay in inactivity before the screen is turned off. These are shown in a list dialog. -->
     <string-array name="screen_timeout_entries">
         <item>15 seconds</item>

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -83,6 +83,50 @@
         <item>28800000</item>
     </string-array>
 
+    <!-- Wifi settings.  The delay in inactivity before wifi is turned off. These are shown in a list dialog. -->
+    <string-array name="wifi_timeout_entries">
+        <item>@string/wifi_timeout_summary_never</item>
+        <item>@string/wifi_timeout_summary_15secs</item>
+        <item>@string/wifi_timeout_summary_30secs</item>
+        <item>@string/wifi_timeout_summary_1min</item>
+        <item>@string/wifi_timeout_summary_2mins</item>
+        <item>@string/wifi_timeout_summary_5mins</item>
+        <item>@string/wifi_timeout_summary_10mins</item>
+        <item>@string/wifi_timeout_summary_30mins</item>
+        <item>@string/wifi_timeout_summary_1hour</item>
+        <item>@string/wifi_timeout_summary_2hours</item>
+        <item>@string/wifi_timeout_summary_4hours</item>
+        <item>@string/wifi_timeout_summary_8hours</item>
+    </string-array>
+
+    <!-- Do not translate. -->
+    <string-array name="wifi_timeout_values" translatable="false">
+        <!-- Do not translate. -->
+        <item>0</item>
+        <!-- Do not translate. -->
+        <item>15000</item>
+        <!-- Do not translate. -->
+        <item>30000</item>
+        <!-- Do not translate. -->
+        <item>60000</item>
+        <!-- Do not translate. -->
+        <item>120000</item>
+        <!-- Do not translate. -->
+        <item>300000</item>
+        <!-- Do not translate. -->
+        <item>600000</item>
+        <!-- Do not translate. -->
+        <item>1800000</item>
+        <!-- Do not translate. -->
+        <item>3600000</item>
+        <!-- Do not translate. -->
+        <item>7200000</item>
+        <!-- Do not translate. -->
+        <item>14400000</item>
+        <!-- Do not translate. -->
+        <item>28800000</item>
+    </string-array>
+
     <!-- Display settings.  The delay in inactivity before the screen is turned off. These are shown in a list dialog. -->
     <string-array name="screen_timeout_entries">
         <item>15 seconds</item>

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -134,6 +134,37 @@
         <item>false</item>
     </string-array>
 
+    <!-- Auto reboot settings -->
+    <string-array name="auto_reboot_entries">
+        <item>Off</item>
+        <item>10 minutes</item>
+        <item>30 minutes</item>
+        <item>1 hour</item>
+        <item>2 hours</item>
+        <item>4 hours</item>
+        <item>8 hours</item>
+        <item>12 hours</item>
+        <item>24 hours</item>
+        <item>36 hours</item>
+        <item>48 hours</item>
+        <item>72 hours</item>
+    </string-array>
+
+    <string-array name="auto_reboot_values" translatable="false">
+        <item>0</item>  <!-- Disabled -->
+        <item>600000</item>
+        <item>1800000</item>
+        <item>3600000</item>
+        <item>7200000</item>
+        <item>14400000</item>
+        <item>28800000</item>
+        <item>43200000</item>
+        <item>86400000</item>
+        <item>129600000</item>
+        <item>172800000</item>
+        <item>259200000</item>
+    </string-array>
+
     <string-array name="deny_new_usb_entries">
         <item>Deny new USB peripherals</item>
         <item>Allow new USB peripherals when unlocked</item>

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -269,6 +269,18 @@
         <item>disabled</item>
     </string-array>
 
+    <string-array name="connectivity_check_entries">
+        <item>GrapheneOS</item>
+        <item>Standard (Google)</item>
+        <item>Disabled</item>
+    </string-array>
+
+    <string-array name="connectivity_check_values" translatable="false">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+    </string-array>
+
     <!-- Do not translate. -->
     <string-array name="lock_after_timeout_values" translatable="false">
         <!-- Do not translate. -->

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -134,6 +134,22 @@
         <item>false</item>
     </string-array>
 
+    <string-array name="deny_new_usb_entries">
+        <item>Deny new USB peripherals</item>
+        <item>Allow new USB peripherals when unlocked</item>
+        <item>Allow new USB peripherals</item>
+    </string-array>
+
+    <!-- Do not translate. -->
+    <string-array name="deny_new_usb_values" translatable="false">
+        <!-- Do not translate. -->
+        <item>enabled</item>
+        <!-- Do not translate. -->
+        <item>dynamic</item>
+        <!-- Do not translate. -->
+        <item>disabled</item>
+    </string-array>
+
     <!-- Do not translate. -->
     <string-array name="lock_after_timeout_values" translatable="false">
         <!-- Do not translate. -->

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -1288,6 +1288,12 @@
         <item>Treat as unmetered</item>
     </string-array>
 
+    <string-array name="wifi_privacy_entries_extended">
+        <item>Use per-connection randomized MAC (default)</item>
+        <item>Use per-network randomized MAC</item>
+        <item>Use device MAC</item>
+    </string-array>
+
     <string-array name="wifi_privacy_entries">
         <item>Use randomized MAC (default)</item>
         <item>Use device MAC</item>
@@ -1305,6 +1311,7 @@
     </string-array>
 
     <string-array name="wifi_privacy_values" translatable="false">
+        <item>100</item>
         <item>1</item>
         <item>0</item>
     </string-array>

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -1355,6 +1355,9 @@
         <item>4</item> <!-- AutofillManager.FLAG_ADD_CLIENT_VERBOSE -->
     </string-array>
 
+    <!-- Note: The LTE only option is added in code, not here. Also, these enabled_networks_choices
+         and enabled_networks_4g_choices string arrays are just placeholders for
+         mobile_network_settings.xml -->
     <string-array name="enabled_networks_choices" translatable="false">
         <item>@string/network_lte</item>
         <item>@string/network_3G</item>
@@ -1444,7 +1447,7 @@
         <item>CDMA + LTE/EvDo</item>
         <item>GSM/WCDMA/LTE</item>
         <item>LTE/CDMA/EvDo/GSM/WCDMA</item>
-        <item>LTE</item>
+        <item>LTE Only</item>
         <item>LTE / WCDMA</item>
         <item>TDSCDMA only</item>
         <item>TDSCDMA/WCDMA</item>

--- a/res/values/config.xml
+++ b/res/values/config.xml
@@ -63,7 +63,7 @@
     <string name="gesture_double_twist_sensor_vendor" translatable="false"></string>
 
     <!-- When true enable gesture setting. -->
-    <bool name="config_gesture_settings_enabled">false</bool>
+    <bool name="config_gesture_settings_enabled">true</bool>
 
     <!-- If the Storage Manager settings are enabled. -->
     <bool name="config_storage_manager_settings_enabled">false</bool>

--- a/res/values/config.xml
+++ b/res/values/config.xml
@@ -455,7 +455,7 @@
     <bool name="config_enable_extra_screen_zoom_preview">true</bool>
 
     <!-- Slice Uri to query nearby devices. -->
-    <string name="config_nearby_devices_slice_uri" translatable="false">content://com.google.android.gms.nearby.fastpair/device_status_list_item</string>
+    <string name="config_nearby_devices_slice_uri" translatable="false"></string>
 
     <!-- Grayscale settings intent -->
     <string name="config_grayscale_settings_intent" translatable="false"></string>

--- a/res/values/config.xml
+++ b/res/values/config.xml
@@ -208,7 +208,7 @@
         Whether or not the homepage should be powered by legacy suggestion (versus contextual cards)
         Default to true as not all devices support contextual cards.
     -->
-    <bool name="config_use_legacy_suggestion">true</bool>
+    <bool name="config_use_legacy_suggestion">false</bool>
 
     <!-- Whether or not homepage should display user's account avatar -->
     <bool name="config_show_avatar_in_homepage">false</bool>

--- a/res/values/config.xml
+++ b/res/values/config.xml
@@ -415,7 +415,7 @@
     <bool name="config_show_trust_agent_click_intent">true</bool>
 
     <!-- Whether wallpaper attribution should be shown or not. -->
-    <bool name="config_show_wallpaper_attribution">true</bool>
+    <bool name="config_show_wallpaper_attribution">false</bool>
 
     <!-- Whether assist_and_voice_input should be shown or not. -->
     <bool name="config_show_assist_and_voice_input">true</bool>

--- a/res/values/config.xml
+++ b/res/values/config.xml
@@ -80,6 +80,7 @@
         <item>com.example.package.first/com.example.class.FirstService</item>
         <item>com.example.package.second/com.example.class.SecondService</item>
         -->
+        <item>com.google.android.accessibility.talkback/com.google.android.marvin.talkback.TalkBackService</item>
     </string-array>
 
     <!-- List containing the component names of pre-installed captioning services. -->

--- a/res/values/config.xml
+++ b/res/values/config.xml
@@ -45,10 +45,11 @@
     <string name="config_featureFactory" translatable="false">com.android.settings.overlay.FeatureFactoryImpl</string>
 
     <!-- Package name and fully-qualified class name for the wallpaper picker activity. -->
-    <string name="config_wallpaper_picker_package" translatable="false">com.android.settings</string>
-    <string name="config_wallpaper_picker_class" translatable="false">com.android.settings.Settings$WallpaperSettingsActivity</string>
+    <string name="config_wallpaper_picker_package" translatable="false">com.android.wallpaper</string>
+    <string name="config_wallpaper_picker_class" translatable="false">com.android.wallpaper.picker.CategoryPickerActivity</string>
+    
     <!-- Fully-qualified class name for the styles & wallpaper picker activity. -->
-    <string name="config_styles_and_wallpaper_picker_class" translatable="false"></string>
+    <string name="config_styles_and_wallpaper_picker_class" translatable="false">com.android.customization.picker.CustomizationPickerActivity</string>
     <!-- Intent extra for wallpaper picker activity. -->
     <string name="config_wallpaper_picker_launch_extra" translatable="false">com.android.wallpaper.LAUNCH_SOURCE</string>
 

--- a/res/values/config.xml
+++ b/res/values/config.xml
@@ -80,7 +80,7 @@
         <item>com.example.package.first/com.example.class.FirstService</item>
         <item>com.example.package.second/com.example.class.SecondService</item>
         -->
-        <item>com.google.android.accessibility.talkback/com.google.android.marvin.talkback.TalkBackService</item>
+        <item>com.android.talkback/com.google.android.marvin.talkback.TalkBackService</item>
     </string-array>
 
     <!-- List containing the component names of pre-installed captioning services. -->

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -46,6 +46,25 @@
     <string name="bluetooth_timeout_summary_4hours">4 hours</string>
     <string name="bluetooth_timeout_summary_8hours">8 hours</string>
 
+    <!--  screen, setting option name to change wifi timeout -->
+    <string name="wifi_timeout">Turn off Wi-Fi automatically</string>
+
+    <!--  screen, setting option summary to change wifi timeout -->
+    <string name="wifi_timeout_summary">Wi-Fi will turn off after <xliff:g id="timeout_description">%1$s</xliff:g> if no network connected</string>
+    <string name="wifi_timeout_summary2">Disabled</string>
+    <string name="wifi_timeout_summary_never">Never</string>
+    <string name="wifi_timeout_summary_15secs">15 seconds</string>
+    <string name="wifi_timeout_summary_30secs">30 seconds</string>
+    <string name="wifi_timeout_summary_1min">1 minute</string>
+    <string name="wifi_timeout_summary_2mins">2 minutes</string>
+    <string name="wifi_timeout_summary_5mins">5 minutes</string>
+    <string name="wifi_timeout_summary_10mins">10 minutes</string>
+    <string name="wifi_timeout_summary_30mins">30 minutes</string>
+    <string name="wifi_timeout_summary_1hour">1 hour</string>
+    <string name="wifi_timeout_summary_2hours">2 hours</string>
+    <string name="wifi_timeout_summary_4hours">4 hours</string>
+    <string name="wifi_timeout_summary_8hours">8 hours</string>
+
     <!-- Device Info screen. Used for a status item's value when the proper value is not known -->
     <string name="device_info_default">Unknown</string>
     <!-- [CHAR LIMIT=NONE] Device Info screen. Countdown for user taps to enable development settings -->

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -27,6 +27,25 @@
     <!-- Used in confirmation dialogs as the action that the user will tap to turn on the feature. [CHAR LIMIT=40]-->
     <string name="confirmation_turn_on">Turn on</string>
 
+    <!-- Connected devices screen, setting option name to change bluetooth timeout -->
+    <string name="bluetooth_timeout">Bluetooth timeout</string>
+
+    <!-- Connected devices screen, setting option summary to change bluetooth timeout -->
+    <string name="bluetooth_timeout_summary">Bluetooth will turn off after <xliff:g id="timeout_description">%1$s</xliff:g> if no devices connected</string>
+    <string name="bluetooth_timeout_summary2">Do not automatically turn off Bluetooth</string>
+    <string name="bluetooth_timeout_summary_never">Never</string>
+    <string name="bluetooth_timeout_summary_15secs">15 seconds</string>
+    <string name="bluetooth_timeout_summary_30secs">30 seconds</string>
+    <string name="bluetooth_timeout_summary_1min">1 minute</string>
+    <string name="bluetooth_timeout_summary_2mins">2 minutes</string>
+    <string name="bluetooth_timeout_summary_5mins">5 minutes</string>
+    <string name="bluetooth_timeout_summary_10mins">10 minutes</string>
+    <string name="bluetooth_timeout_summary_30mins">30 minutes</string>
+    <string name="bluetooth_timeout_summary_1hour">1 hour</string>
+    <string name="bluetooth_timeout_summary_2hours">2 hours</string>
+    <string name="bluetooth_timeout_summary_4hours">4 hours</string>
+    <string name="bluetooth_timeout_summary_8hours">8 hours</string>
+
     <!-- Device Info screen. Used for a status item's value when the proper value is not known -->
     <string name="device_info_default">Unknown</string>
     <!-- [CHAR LIMIT=NONE] Device Info screen. Countdown for user taps to enable development settings -->

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -3373,6 +3373,8 @@
     <!-- About phone screen,  setting option name  [CHAR LIMIT=40] -->
     <string name="baseband_version">Baseband version</string>
     <!-- About phone screen,  setting option name  [CHAR LIMIT=40] -->
+    <string name="bootloader_version">Bootloader version</string>
+    <!-- About phone screen,  setting option name  [CHAR LIMIT=40] -->
     <string name="kernel_version">Kernel version</string>
     <!-- About phone screen,  setting option name  [CHAR LIMIT=40] -->
     <string name="build_number">Build number</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -13665,4 +13665,6 @@
     <string name="security_settings_fingerprint_settings_screen_lock_category">Screen lock</string>
     <string name="security_settings_fingerprint_settings_use_fingerprint_unlock_phone_title">Allow fingerprint unlocking</string>
     <string name="security_settings_fingerprint_settings_use_fingerprint_unlock_phone_summary">Allow fingerprints to unlock the screen lock. If this is disabled, fingerprints can still be used in apps.</string>
+    <string name="connectivity_check_title">Internet connectivity check</string>
+    <string name="connectivity_check_summary">HTTP endpoints to use for performing internet connectivity checks.</string>
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -13603,4 +13603,7 @@
     <string name="bluetooth_connect_access_dialog_negative">Don\u2019t connect</string>
     <!-- Strings for Dialog connect button -->
     <string name="bluetooth_connect_access_dialog_positive">Connect</string>
+
+    <string name="scramble_pin_title">PIN scrambling</string>
+    <string name="scramble_pin_summary">Controls PIN scrambling option when inputting PIN on screen lock.</string>
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -3128,6 +3128,10 @@
     <string name="auto_rotate_summary_no_permission">Camera access is required for Face Detection. Tap to manage permissions for Device Personalization Services</string>
     <!-- auto_rotate settings screen, text for the camera permission button [CHAR LIMIT=NONE]-->
     <string name="auto_rotate_manage_permission_button">Manage permissions</string>
+    <!-- Display settings screen, increased touch sensitivity settings title [CHAR LIMIT=30] -->
+    <string name="touch_sensitivity_title">Increase touch sensitivity</string>
+    <!-- Display settings screen, increased touch sensitivity settings summary [CHAR LIMIT=NONE] -->
+    <string name="touch_sensitivity_summary">Improves touch when using screen protectors</string>
 
     <!-- Night display screen, setting option name to enable night display (renamed "Night Light" with title caps). [CHAR LIMIT=30] -->
     <string name="night_display_title">Night Light</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -13616,4 +13616,6 @@
     <string name="deny_new_usb_summary">Control support for USB peripherals such as input (mice, keyboards, joysticks) and storage devices.</string>
     <string name="keyguard_camera_title">Screen lock camera access</string>
     <string name="keyguard_camera_summary">Allow camera access when the device is locked</string>
+    <string name="native_debug_title">Enable native code debugging</string>
+    <string name="native_debug_summary">Generate useful logs / bug reports from crashes and permit debugging native code.</string>
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -13615,6 +13615,8 @@
     <string name="scramble_pin_title">PIN scrambling</string>
     <string name="scramble_pin_summary">Controls PIN scrambling option when inputting PIN on screen lock.</string>
     <string name="deny_new_usb_title">USB accessories</string>
+    <string name="auto_reboot_title">Auto reboot</string>
+    <string name="auto_reboot_summary">Automatically reboot the device, if the phone hasn\'t been unlocked within the selected number of hours.</string>
     <string name="deny_new_usb_summary">Control support for USB peripherals such as input (mice, keyboards, joysticks) and storage devices.</string>
     <string name="keyguard_camera_title">Screen lock camera access</string>
     <string name="keyguard_camera_summary">Allow camera access when the device is locked</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -4040,9 +4040,9 @@
     <!-- Button title to factory data reset the entire device. The "(factory reset)" part is optional for translation. [CHAR LIMIT=30 BACKUP_MESSAGE_ID=3531267871084279512]-->
     <string name="main_clear_short_title">Erase all data (factory reset)</string>
     <!-- SD card & phone storage settings screen, message on screen after user selects Factory data reset [CHAR LIMIT=NONE] -->
-    <string name="main_clear_desc" product="tablet">"This will erase all data from your tablet\u2019s <b>internal storage</b>, including:\n\n<li>Your Google Account</li>\n<li>System and app data and settings</li>\n<li>Downloaded apps</li>"</string>
+    <string name="main_clear_desc" product="tablet">"This will erase all data from your tablet\u2019s <b>internal storage</b>, including:\n\n<li>System and app data and settings</li>\n<li>Downloaded apps</li>"</string>
     <!-- SD card & phone storage settings screen, message on screen after user selects Factory data reset [CHAR LIMIT=NONE] -->
-    <string name="main_clear_desc" product="default">"This will erase all data from your phone\u2019s <b>internal storage</b>, including:\n\n<li>Your Google Account</li>\n<li>System and app data and settings</li>\n<li>Downloaded apps</li>"</string>
+    <string name="main_clear_desc" product="default">"This will erase all data from your phone\u2019s <b>internal storage</b>, including:\n\n<li>System and app data and settings</li>\n<li>Downloaded apps</li>"</string>
     <!-- SD card & phone storage settings screen, instructions and list of current accounts.  The list of accounts follows this text[CHAR LIMIT=NONE] -->
     <string name="main_clear_accounts" product="default">"\n\nYou are currently signed into the following accounts:\n"</string>
     <!-- SD card & phone storage settings screen, notification if other users are present on the device [CHAR LIMIT=NONE] -->

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -13612,4 +13612,6 @@
 
     <string name="scramble_pin_title">PIN scrambling</string>
     <string name="scramble_pin_summary">Controls PIN scrambling option when inputting PIN on screen lock.</string>
+    <string name="deny_new_usb_title">USB accessories</string>
+    <string name="deny_new_usb_summary">Control support for USB peripherals such as input (mice, keyboards, joysticks) and storage devices.</string>
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -12545,6 +12545,8 @@
     <string name="preferred_network_mode_cdma_evdo_gsm_wcdma_summary">Preferred network mode: CDMA/EvDo/GSM/WCDMA</string>
     <!-- LTE [CHAR LIMIT=NONE] -->
     <string name="preferred_network_mode_lte_summary">Preferred network mode: LTE </string>
+    <!-- LTE only [CHAR LIMIT=100] -->
+    <string name="preferred_network_mode_lte_only_summary">Preferred network mode: LTE only</string>
     <!-- GSM/WCDMA/LTE [CHAR LIMIT=NONE] -->
     <string name="preferred_network_mode_lte_gsm_wcdma_summary">Preferred network mode: GSM/WCDMA/LTE</string>
     <!-- CDMA+LTE/EVDO [CHAR LIMIT=NONE] -->
@@ -12610,8 +12612,12 @@
     <string name="network_4G_pure" translatable="false">4G</string>
     <!-- Text for Network lte [CHAR LIMIT=NONE] -->
     <string name="network_lte">LTE (recommended)</string>
+    <!-- Text for Network lte only [CHAR LIMIT=NONE] -->
+    <string name="network_lte_only">LTE only</string>
     <!-- Text for Network 4g [CHAR LIMIT=NONE] -->
     <string name="network_4G">4G (recommended)</string>
+    <!-- Text for Network 4g only [CHAR LIMIT=NONE] -->
+    <string name="network_4G_only">4G only</string>
     <!-- Text for Network 3g [CHAR LIMIT=NONE] -->
     <string name="network_3G" translatable="false">3G</string>
     <!-- Text for Network 2g [CHAR LIMIT=NONE] -->

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -13662,4 +13662,7 @@
     <string name="keyguard_camera_summary">Allow camera access when the device is locked</string>
     <string name="native_debug_title">Enable native code debugging</string>
     <string name="native_debug_summary">Generate useful logs / bug reports from crashes and permit debugging native code.</string>
+    <string name="security_settings_fingerprint_settings_screen_lock_category">Screen lock</string>
+    <string name="security_settings_fingerprint_settings_use_fingerprint_unlock_phone_title">Allow fingerprint unlocking</string>
+    <string name="security_settings_fingerprint_settings_use_fingerprint_unlock_phone_summary">Allow fingerprints to unlock the screen lock. If this is disabled, fingerprints can still be used in apps.</string>
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -13614,4 +13614,6 @@
     <string name="scramble_pin_summary">Controls PIN scrambling option when inputting PIN on screen lock.</string>
     <string name="deny_new_usb_title">USB accessories</string>
     <string name="deny_new_usb_summary">Control support for USB peripherals such as input (mice, keyboards, joysticks) and storage devices.</string>
+    <string name="keyguard_camera_title">Screen lock camera access</string>
+    <string name="keyguard_camera_summary">Allow camera access when the device is locked</string>
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -7689,6 +7689,8 @@
     <string name="user_enable_calling">Turn on phone calls</string>
     <!-- Title of preference to enable calling and SMS [CHAR LIMIT=45] -->
     <string name="user_enable_calling_sms">Turn on phone calls &amp; SMS</string>
+    <!-- Title of preference to disallow installing apps [CHAR LIMIT=45] -->
+    <string name="user_disallow_install_apps">Disallow installing apps</string>
     <!-- Title of preference to remove the user [CHAR LIMIT=35] -->
     <string name="user_remove_user">Delete user</string>
     <!-- Title for confirmation of turning on calls [CHAR LIMIT=40] -->

--- a/res/xml/connected_devices.xml
+++ b/res/xml/connected_devices.xml
@@ -47,6 +47,14 @@
         settings:useAdminDisabledSummary="true"
         settings:controller="com.android.settings.connecteddevice.AddDevicePreferenceController"/>
 
+    <androidx.preference.ListPreference
+        android:key="bluetooth_timeout"
+        android:title="@string/bluetooth_timeout"
+        android:summary="@string/summary_placeholder"
+        android:entries="@array/bluetooth_timeout_entries"
+        android:entryValues="@array/bluetooth_timeout_values"
+        settings:controller="com.android.settings.bluetooth.BluetoothTimeoutPreferenceController"/>
+
     <PreferenceCategory
         android:key="previously_connected_devices"
         android:title="@string/connected_device_previously_connected_title"

--- a/res/xml/display_settings.xml
+++ b/res/xml/display_settings.xml
@@ -122,6 +122,12 @@
             settings:controller="com.android.settings.display.PeakRefreshRatePreferenceController"/>
 
         <SwitchPreference
+            android:key="touch_sensitivity"
+            android:title="@string/touch_sensitivity_title"
+            android:summary="@string/touch_sensitivity_summary"
+            settings:controller="com.android.settings.display.TouchSensitivityPreferenceController" />
+
+        <SwitchPreference
             android:key="show_operator_name"
             android:title="@string/show_operator_name_title"
             android:summary="@string/show_operator_name_summary"/>

--- a/res/xml/firmware_version.xml
+++ b/res/xml/firmware_version.xml
@@ -46,6 +46,15 @@
         settings:enableCopying="true"
         settings:controller="com.android.settings.deviceinfo.firmwareversion.BasebandVersionPreferenceController"/>
 
+    <!-- Bootloader -->
+    <Preference
+        android:key="boot_loader"
+        android:title="@string/bootloader_version"
+        android:summary="@string/summary_placeholder"
+        android:selectable="false"
+        settings:enableCopying="true"
+        settings:controller="com.android.settings.deviceinfo.firmwareversion.BootloaderVersionPreferenceController"/>
+
     <!-- Kernel -->
     <Preference
         android:key="kernel_version"

--- a/res/xml/firmware_version.xml
+++ b/res/xml/firmware_version.xml
@@ -37,14 +37,6 @@
         settings:enableCopying="true"
         settings:controller="com.android.settings.deviceinfo.firmwareversion.SecurityPatchLevelPreferenceController"/>
 
-    <!-- Mainline module version -->
-    <Preference
-        android:key="module_version"
-        android:title="@string/module_version"
-        android:summary="@string/summary_placeholder"
-        settings:enableCopying="true"
-        settings:controller="com.android.settings.deviceinfo.firmwareversion.MainlineModuleVersionPreferenceController"/>
-
     <!-- Baseband -->
     <Preference
         android:key="base_band"

--- a/res/xml/security_dashboard_settings.xml
+++ b/res/xml/security_dashboard_settings.xml
@@ -55,6 +55,14 @@
             android:summary="@string/summary_placeholder"
             settings:keywords="@string/keywords_face_settings" />
 
+        <ListPreference
+            android:key="scramble_pin_layout"
+            android:title="@string/scramble_pin_title"
+            android:summary="@string/scramble_pin_summary"
+            android:persistent="false"
+            android:entries="@array/scramble_pin_entries"
+            android:entryValues="@array/scramble_pin_values" />
+
         <com.android.settingslib.RestrictedPreference
             android:key="biometric_settings"
             android:title="@string/security_settings_biometric_preference_title"

--- a/res/xml/security_dashboard_settings.xml
+++ b/res/xml/security_dashboard_settings.xml
@@ -71,6 +71,12 @@
             android:entries="@array/scramble_pin_entries"
             android:entryValues="@array/scramble_pin_values" />
 
+        <SwitchPreference
+            android:key="keyguard_camera"
+            android:title="@string/keyguard_camera_title"
+            android:summary="@string/keyguard_camera_summary"
+            android:persistent="false" />
+
         <com.android.settingslib.RestrictedPreference
             android:key="biometric_settings"
             android:title="@string/security_settings_biometric_preference_title"

--- a/res/xml/security_dashboard_settings.xml
+++ b/res/xml/security_dashboard_settings.xml
@@ -56,6 +56,14 @@
             settings:keywords="@string/keywords_face_settings" />
         
         <ListPreference
+            android:key="auto_reboot"
+            android:title="@string/auto_reboot_title"
+            android:summary="@string/auto_reboot_summary"
+            android:persistent="false"
+            android:entries="@array/auto_reboot_entries"
+            android:entryValues="@array/auto_reboot_values" />
+
+        <ListPreference
             android:key="deny_new_usb"
             android:title="@string/deny_new_usb_title"
             android:summary="@string/deny_new_usb_summary"

--- a/res/xml/security_dashboard_settings.xml
+++ b/res/xml/security_dashboard_settings.xml
@@ -63,6 +63,12 @@
             android:entries="@array/deny_new_usb_entries"
             android:entryValues="@array/deny_new_usb_values" />
 
+        <SwitchPreference
+            android:key="native_debug"
+            android:title="@string/native_debug_title"
+            android:summary="@string/native_debug_summary"
+            android:persistent="false" />
+
         <ListPreference
             android:key="scramble_pin_layout"
             android:title="@string/scramble_pin_title"

--- a/res/xml/security_dashboard_settings.xml
+++ b/res/xml/security_dashboard_settings.xml
@@ -54,6 +54,14 @@
             android:title="@string/security_settings_face_preference_title"
             android:summary="@string/summary_placeholder"
             settings:keywords="@string/keywords_face_settings" />
+        
+        <ListPreference
+            android:key="deny_new_usb"
+            android:title="@string/deny_new_usb_title"
+            android:summary="@string/deny_new_usb_summary"
+            android:persistent="false"
+            android:entries="@array/deny_new_usb_entries"
+            android:entryValues="@array/deny_new_usb_values" />
 
         <ListPreference
             android:key="scramble_pin_layout"

--- a/res/xml/security_settings_fingerprint.xml
+++ b/res/xml/security_settings_fingerprint.xml
@@ -16,5 +16,18 @@
 
 <PreferenceScreen
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:title="@string/security_settings_fingerprint_preference_title"/>
+    android:title="@string/security_settings_fingerprint_preference_title">
+
+    <PreferenceCategory
+        android:title="@string/security_settings_fingerprint_settings_screen_lock_category"
+        android:order="10"
+        android:key="security_settings_fingerprint_unlock_category">
+
+        <SwitchPreference
+            android:key="security_settings_fingerprint_keyguard"
+            android:title="@string/security_settings_fingerprint_settings_use_fingerprint_unlock_phone_title"
+            android:summary="@string/security_settings_fingerprint_settings_use_fingerprint_unlock_phone_summary" />
+    </PreferenceCategory>
+
+</PreferenceScreen>
 

--- a/res/xml/top_level_settings.xml
+++ b/res/xml/top_level_settings.xml
@@ -18,7 +18,8 @@
 <PreferenceScreen
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:settings="http://schemas.android.com/apk/res-auto"
-    android:key="top_level_settings">
+    android:key="top_level_settings"
+    android:title="Settings">
 
     <Preference
         android:fragment="com.android.settings.network.NetworkDashboardFragment"

--- a/res/xml/user_details_settings.xml
+++ b/res/xml/user_details_settings.xml
@@ -29,6 +29,10 @@
             android:key="app_and_content_access"
             android:icon="@drawable/ic_lock_closed"
             android:title="@string/user_restrictions_title" />
+    <SwitchPreference
+            android:icon="@drawable/ic_settings_install"
+            android:key="disallow_install_apps"
+            android:title="@string/user_disallow_install_apps" />
     <com.android.settingslib.RestrictedPreference
             android:key="remove_user"
             android:icon="@drawable/ic_delete"

--- a/res/xml/wifi_configure_settings.xml
+++ b/res/xml/wifi_configure_settings.xml
@@ -26,6 +26,14 @@
         android:summary="@string/wifi_wakeup_summary"
         settings:controller="com.android.settings.wifi.WifiWakeupPreferenceController"/>
 
+    <ListPreference
+        android:key="wifi_timeout"
+        android:title="@string/wifi_timeout"
+        android:summary="@string/wifi_timeout_summary"
+        android:entries="@array/wifi_timeout_entries"
+        android:entryValues="@array/wifi_timeout_values"
+        settings:controller="com.android.settings.wifi.WifiTimeoutPreferenceController"/>
+
     <SwitchPreference
         android:key="notify_open_networks"
         android:title="@string/wifi_notify_open_networks"

--- a/res/xml/wifi_network_details_fragment2.xml
+++ b/res/xml/wifi_network_details_fragment2.xml
@@ -69,7 +69,7 @@
         android:key="privacy"
         android:icon="@drawable/ic_wifi_privacy_24dp"
         android:title="@string/wifi_privacy_settings"
-        android:entries="@array/wifi_privacy_entries"
+        android:entries="@array/wifi_privacy_entries_extended"
         android:entryValues="@array/wifi_privacy_values"/>
 
     <Preference

--- a/src/com/android/settings/applications/appinfo/AppButtonsPreferenceController.java
+++ b/src/com/android/settings/applications/appinfo/AppButtonsPreferenceController.java
@@ -587,6 +587,7 @@ public class AppButtonsPreferenceController extends BasePreferenceController imp
         // by not allowing disabling of apps signed with the
         // system cert and any launcher app in the system.
         if (mHomePackages.contains(mAppEntry.info.packageName)
+                || mAppEntry.info.packageName.equals("com.android.inputmethod.latin")
                 || isSystemPackage(mActivity.getResources(), mPm, mPackageInfo)) {
             // Disable button for core system applications.
             mButtonsPref.setButton2Text(R.string.disable_text)

--- a/src/com/android/settings/applications/appinfo/AppButtonsPreferenceController.java
+++ b/src/com/android/settings/applications/appinfo/AppButtonsPreferenceController.java
@@ -588,6 +588,7 @@ public class AppButtonsPreferenceController extends BasePreferenceController imp
         // system cert and any launcher app in the system.
         if (mHomePackages.contains(mAppEntry.info.packageName)
                 || mAppEntry.info.packageName.equals("com.android.inputmethod.latin")
+                || mAppEntry.info.packageName.equals("app.vanadium.webview")
                 || isSystemPackage(mActivity.getResources(), mPm, mPackageInfo)) {
             // Disable button for core system applications.
             mButtonsPref.setButton2Text(R.string.disable_text)

--- a/src/com/android/settings/biometrics/fingerprint/FingerprintSettings.java
+++ b/src/com/android/settings/biometrics/fingerprint/FingerprintSettings.java
@@ -36,6 +36,7 @@ import android.os.UserHandle;
 import android.os.UserManager;
 import android.text.InputFilter;
 import android.text.Spanned;
+import android.provider.Settings;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.View;
@@ -51,6 +52,7 @@ import androidx.preference.Preference.OnPreferenceChangeListener;
 import androidx.preference.PreferenceGroup;
 import androidx.preference.PreferenceScreen;
 import androidx.preference.PreferenceViewHolder;
+import androidx.preference.SwitchPreference;
 
 import com.android.settings.R;
 import com.android.settings.SettingsPreferenceFragment;
@@ -115,8 +117,10 @@ public class FingerprintSettings extends SubSettings {
         private static final String TAG = "FingerprintSettings";
         private static final String KEY_FINGERPRINT_ITEM_PREFIX = "key_fingerprint_item";
         private static final String KEY_FINGERPRINT_ADD = "key_fingerprint_add";
+        private static final String KEY_FINGERPRINT_SCREEN_LOCK_OPTIONS_CATEGORY =
+                "security_settings_fingerprint_unlock_category";
         private static final String KEY_FINGERPRINT_ENABLE_KEYGUARD_TOGGLE =
-                "fingerprint_enable_keyguard_toggle";
+                "security_settings_fingerprint_keyguard";
         private static final String KEY_LAUNCHED_CONFIRM = "launched_confirm";
 
         private static final int MSG_REFRESH_FINGERPRINT_TEMPLATES = 1000;
@@ -399,6 +403,24 @@ public class FingerprintSettings extends SubSettings {
             root = getPreferenceScreen();
             addFingerprintItemPreferences(root);
             setPreferenceScreen(root);
+
+            // Need to add back the keyguard preferences, since addFingerprintItemPreferences
+            // calls root.removeAll() again.
+            addPreferencesFromResource(R.xml.security_settings_fingerprint);
+
+            // Don't show keyguard preferences for work profile settings.
+            if (UserManager.get(getContext()).isManagedProfile(mUserId)) {
+                removePreference(KEY_FINGERPRINT_SCREEN_LOCK_OPTIONS_CATEGORY);
+            } else {
+                SwitchPreference lockScreenFingerprintPreference =
+                        (SwitchPreference) findPreference(KEY_FINGERPRINT_ENABLE_KEYGUARD_TOGGLE);
+
+                lockScreenFingerprintPreference.setChecked(Settings.Secure.getInt(
+                        getContext().getContentResolver(),
+                        Settings.Secure.BIOMETRIC_KEYGUARD_ENABLED, 1) == 1);
+                lockScreenFingerprintPreference.setOnPreferenceChangeListener(this);
+            }
+
             return root;
         }
 
@@ -413,6 +435,7 @@ public class FingerprintSettings extends SubSettings {
                 pref.setKey(genKey(item.getBiometricId()));
                 pref.setTitle(item.getName());
                 pref.setFingerprint(item);
+                pref.setOrder(1);
                 pref.setPersistent(false);
                 pref.setIcon(R.drawable.ic_fingerprint_24dp);
                 if (mRemovalSidecar.isRemovingFingerprint(item.getBiometricId())) {
@@ -428,6 +451,7 @@ public class FingerprintSettings extends SubSettings {
             addPreference.setKey(KEY_FINGERPRINT_ADD);
             addPreference.setTitle(R.string.fingerprint_add_title);
             addPreference.setIcon(R.drawable.ic_add_24dp);
+            addPreference.setOrder(2);
             root.addPreference(addPreference);
             addPreference.setOnPreferenceChangeListener(this);
             updateAddPreference();
@@ -582,7 +606,10 @@ public class FingerprintSettings extends SubSettings {
             boolean result = true;
             final String key = preference.getKey();
             if (KEY_FINGERPRINT_ENABLE_KEYGUARD_TOGGLE.equals(key)) {
-                // TODO
+                boolean enableFingerprintUnlock = (boolean) value;
+                Settings.Secure.putInt(getContext().getContentResolver(),
+                        Settings.Secure.BIOMETRIC_KEYGUARD_ENABLED,
+                        (enableFingerprintUnlock) ? 1 : 0);
             } else {
                 Log.v(TAG, "Unknown key:" + key);
             }

--- a/src/com/android/settings/bluetooth/BluetoothTimeoutPreferenceController.java
+++ b/src/com/android/settings/bluetooth/BluetoothTimeoutPreferenceController.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2020 The Calyx Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.bluetooth;
+
+import android.bluetooth.BluetoothAdapter;
+import android.content.Context;
+import android.provider.Settings;
+import android.util.Log;
+
+import androidx.preference.ListPreference;
+import androidx.preference.Preference;
+
+import com.android.settings.R;
+import com.android.settings.core.BasePreferenceController;
+import com.android.settings.core.PreferenceControllerMixin;
+
+public class BluetoothTimeoutPreferenceController extends BasePreferenceController implements
+        PreferenceControllerMixin, Preference.OnPreferenceChangeListener {
+    private static final String TAG = "BluetoothTimeoutPrefCtrl";
+
+    public static final int FALLBACK_BLUETOOTH_TIMEOUT_VALUE = 0;
+
+    private final String mBluetoothTimeoutKey;
+
+    protected BluetoothAdapter mBluetoothAdapter;
+
+    public BluetoothTimeoutPreferenceController(Context context, String key) {
+        super(context, key);
+        mBluetoothTimeoutKey = key;
+
+        mBluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
+        if (mBluetoothAdapter == null) {
+            Log.e(TAG, "Bluetooth is not supported on this device");
+            return;
+        }
+    }
+
+    @Override
+    public int getAvailabilityStatus() {
+        return mBluetoothAdapter != null ? AVAILABLE : UNSUPPORTED_ON_DEVICE;
+    }
+
+    @Override
+    public String getPreferenceKey() {
+        return mBluetoothTimeoutKey;
+    }
+
+    @Override
+    public void updateState(Preference preference) {
+        final ListPreference timeoutListPreference = (ListPreference) preference;
+        final long currentTimeout = Settings.Global.getLong(mContext.getContentResolver(),
+                Settings.Global.BLUETOOTH_OFF_TIMEOUT, FALLBACK_BLUETOOTH_TIMEOUT_VALUE);
+        timeoutListPreference.setValue(String.valueOf(currentTimeout));
+        updateTimeoutPreferenceDescription(timeoutListPreference,
+                Long.parseLong(timeoutListPreference.getValue()));
+    }
+
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object newValue) {
+        try {
+            long value = Long.parseLong((String) newValue);
+            Settings.Global.putLong(mContext.getContentResolver(), Settings.Global.BLUETOOTH_OFF_TIMEOUT, value);
+            updateTimeoutPreferenceDescription((ListPreference) preference, value);
+        } catch (NumberFormatException e) {
+            Log.e(TAG, "could not persist bluetooth timeout setting", e);
+        }
+        return true;
+    }
+
+    public static CharSequence getTimeoutDescription(
+            long currentTimeout, CharSequence[] entries, CharSequence[] values) {
+        if (currentTimeout < 0 || entries == null || values == null
+                || values.length != entries.length) {
+            return null;
+        }
+
+        for (int i = 0; i < values.length; i++) {
+            long timeout = Long.parseLong(values[i].toString());
+            if (currentTimeout == timeout) {
+                return entries[i];
+            }
+        }
+        return null;
+    }
+
+    private void updateTimeoutPreferenceDescription(ListPreference preference,
+                                                    long currentTimeout) {
+        final CharSequence[] entries = preference.getEntries();
+        final CharSequence[] values = preference.getEntryValues();
+        final CharSequence timeoutDescription = getTimeoutDescription(
+                currentTimeout, entries, values);
+        String summary = "";
+        if (timeoutDescription != null) {
+            if (currentTimeout != 0)
+                summary = mContext.getString(R.string.bluetooth_timeout_summary, timeoutDescription);
+            else
+                summary = mContext.getString(R.string.bluetooth_timeout_summary2);
+        }
+        preference.setSummary(summary);
+    }
+}

--- a/src/com/android/settings/deviceinfo/StorageSummaryPreference.java
+++ b/src/com/android/settings/deviceinfo/StorageSummaryPreference.java
@@ -27,6 +27,7 @@ import androidx.preference.Preference;
 import androidx.preference.PreferenceViewHolder;
 
 import com.android.settings.R;
+import com.android.settingslib.Utils;
 
 public class StorageSummaryPreference extends Preference {
     private int mPercent = -1;
@@ -55,7 +56,8 @@ public class StorageSummaryPreference extends Preference {
         }
 
         final TextView summary = (TextView) view.findViewById(android.R.id.summary);
-        summary.setTextColor(Color.parseColor("#8a000000"));
+        summary.setTextColor(Utils.getColorAttrDefaultColor(getContext(),
+                android.R.attr.textColorSecondary));
 
         super.onBindViewHolder(view);
     }

--- a/src/com/android/settings/deviceinfo/firmwareversion/BootloaderVersionPreferenceController.java
+++ b/src/com/android/settings/deviceinfo/firmwareversion/BootloaderVersionPreferenceController.java
@@ -1,0 +1,28 @@
+package com.android.settings.deviceinfo.firmwareversion;
+
+import android.content.Context;
+import android.os.SystemProperties;
+
+import com.android.settings.R;
+import com.android.settings.Utils;
+import com.android.settings.core.BasePreferenceController;
+
+public class BootloaderVersionPreferenceController extends BasePreferenceController {
+
+    static final String BOOTLOADER_PROPERTY = "ro.bootloader";
+
+    public BootloaderVersionPreferenceController(Context context, String preferenceKey) {
+        super(context, preferenceKey);
+    }
+
+    @Override
+    public int getAvailabilityStatus() {
+        return AVAILABLE;
+    }
+
+    @Override
+    public CharSequence getSummary() {
+        return SystemProperties.get(BOOTLOADER_PROPERTY,
+                mContext.getString(R.string.device_info_default));
+    }
+}

--- a/src/com/android/settings/display/TouchSensitivityPreferenceController.java
+++ b/src/com/android/settings/display/TouchSensitivityPreferenceController.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2021 The Proton AOSP Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.display;
+
+import android.content.Context;
+import android.os.SystemProperties;
+import android.provider.Settings;
+
+import com.android.settings.core.TogglePreferenceController;
+
+public class TouchSensitivityPreferenceController extends TogglePreferenceController {
+
+    // Settings can only set the debug.* property, so we need to persist it
+    // in system settings. Match the stock setting name for backup compatibility.
+    private static final String SETTINGS_KEY = "touch_sensitivity_enabled";
+    private static final String PROP_NAME = "debug.touch_sensitivity_mode";
+
+    public TouchSensitivityPreferenceController(Context context, String preferenceKey) {
+        super(context, preferenceKey);
+    }
+
+    @Override
+    public int getAvailabilityStatus() {
+        return mContext.getResources().getBoolean(com.android.internal.R.bool.config_supportGloveMode)
+            ? AVAILABLE
+            : UNSUPPORTED_ON_DEVICE;
+    }
+
+    @Override
+    public boolean setChecked(boolean value) {
+        Settings.Secure.putInt(mContext.getContentResolver(), SETTINGS_KEY, value ? 1 : 0);
+        SystemProperties.set(PROP_NAME, value ? "1" : "0");
+        return true;
+    }
+
+    @Override
+    public boolean isChecked() {
+        // debug prop isn't persistent
+        return Settings.Secure.getInt(mContext.getContentResolver(), SETTINGS_KEY, 0) == 1;
+    }
+}

--- a/src/com/android/settings/network/ConnectivityCheckPreferenceController.java
+++ b/src/com/android/settings/network/ConnectivityCheckPreferenceController.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.network;
+
+import android.content.ContentResolver;
+import android.content.Context;
+import android.content.res.Resources;
+import android.database.ContentObserver;
+import android.net.LinkProperties;
+import android.net.Network;
+import android.os.Handler;
+import android.os.Looper;
+import android.os.UserHandle;
+import android.os.UserManager;
+import android.provider.Settings;
+import androidx.preference.ListPreference;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceScreen;
+import com.android.internal.util.ArrayUtils;
+import com.android.settings.R;
+import com.android.settings.core.BasePreferenceController;
+import com.android.settings.core.PreferenceControllerMixin;
+import com.android.settingslib.RestrictedLockUtils.EnforcedAdmin;
+import com.android.settingslib.RestrictedLockUtilsInternal;
+import com.android.settingslib.core.lifecycle.events.OnResume;
+
+public class ConnectivityCheckPreferenceController
+        extends BasePreferenceController
+        implements PreferenceControllerMixin, Preference.OnPreferenceChangeListener,
+        OnResume {
+
+    private static final String GRAPHENEOS_CAPTIVE_PORTAL_HTTPS_URL =
+            "https://connectivitycheck.grapheneos.network/generate_204";
+    private static final String GRAPHENEOS_CAPTIVE_PORTAL_HTTP_URL =
+            "http://connectivitycheck.grapheneos.network/generate_204";
+    private static final String GRAPHENEOS_CAPTIVE_PORTAL_FALLBACK_URL =
+            "http://grapheneos.online/gen_204";
+    private static final String GRAPHENEOS_CAPTIVE_PORTAL_OTHER_FALLBACK_URL =
+            "http://grapheneos.online/generate_204";
+
+    // imported defaults from AOSP NetworkStack
+    private static final String STANDARD_HTTPS_URL =
+            "https://www.google.com/generate_204";
+    private static final String STANDARD_HTTP_URL =
+            "http://connectivitycheck.gstatic.com/generate_204";
+    private static final String STANDARD_FALLBACK_URL =
+            "http://www.google.com/gen_204";
+    private static final String STANDARD_OTHER_FALLBACK_URLS =
+            "http://play.googleapis.com/generate_204";
+
+    private static final int GRAPHENEOS_CAPTIVE_PORTAL_HTTP_URL_INTVAL = 0;
+    private static final int STANDARD_CAPTIVE_PORTAL_HTTP_URL_INTVAL = 1;
+    private static final int DISABLED_CAPTIVE_PORTAL_INTVAL = 2;
+
+    private static final String KEY_CONNECTIVITY_CHECK_SETTINGS =
+            "connectivity_check_settings";
+
+    private ListPreference mConnectivityPreference;
+
+    public ConnectivityCheckPreferenceController(Context context) {
+        super(context, KEY_CONNECTIVITY_CHECK_SETTINGS);
+    }
+
+    @Override
+    public int getAvailabilityStatus() {
+        if (isDisabledByAdmin()) {
+            return BasePreferenceController.DISABLED_FOR_USER;
+        }
+        return BasePreferenceController.AVAILABLE;
+    }
+
+    @Override
+    public void displayPreference(PreferenceScreen screen) {
+        ListPreference captiveList = new ListPreference(screen.getContext());
+        captiveList.setKey(KEY_CONNECTIVITY_CHECK_SETTINGS);
+        captiveList.setOrder(30);
+        captiveList.setIcon(R.drawable.ic_settings_language);
+        captiveList.setTitle(R.string.connectivity_check_title);
+        captiveList.setSummary(R.string.connectivity_check_summary);
+        captiveList.setEntries(R.array.connectivity_check_entries);
+        captiveList.setEntryValues(R.array.connectivity_check_values);
+
+        if(mConnectivityPreference == null){
+            screen.addPreference(captiveList);
+            mConnectivityPreference = captiveList;
+        }
+        super.displayPreference(screen);
+        updatePreferenceState();
+    }
+
+    @Override
+    public String getPreferenceKey() {
+        return KEY_CONNECTIVITY_CHECK_SETTINGS;
+    }
+
+    private void updatePreferenceState() {
+        if (Settings.Global.getInt(mContext.getContentResolver(),
+                Settings.Global.CAPTIVE_PORTAL_MODE, Settings.Global.CAPTIVE_PORTAL_MODE_PROMPT)
+                == Settings.Global.CAPTIVE_PORTAL_MODE_IGNORE) {
+            mConnectivityPreference.setValueIndex(DISABLED_CAPTIVE_PORTAL_INTVAL);
+            return;
+        }
+
+        String pref = Settings.Global.getString(
+                mContext.getContentResolver(), Settings.Global.CAPTIVE_PORTAL_HTTP_URL);
+        if (STANDARD_HTTP_URL.equals(pref)) {
+            mConnectivityPreference.setValueIndex(
+                    STANDARD_CAPTIVE_PORTAL_HTTP_URL_INTVAL);
+        } else {
+            mConnectivityPreference.setValueIndex(
+                    GRAPHENEOS_CAPTIVE_PORTAL_HTTP_URL_INTVAL);
+        }
+    }
+
+    @Override
+    public void onResume() {
+        updatePreferenceState();
+        if (mConnectivityPreference != null) {
+            setCaptivePortalURLs(
+                    mContext.getContentResolver(),
+                    Integer.parseInt(mConnectivityPreference.getValue()));
+        }
+    }
+
+    private void setCaptivePortalURLs(ContentResolver cr, int mode) {
+        switch (mode) {
+            case STANDARD_CAPTIVE_PORTAL_HTTP_URL_INTVAL:
+                Settings.Global.putString(cr, Settings.Global.CAPTIVE_PORTAL_HTTP_URL,
+                        STANDARD_HTTP_URL);
+                Settings.Global.putString(cr, Settings.Global.CAPTIVE_PORTAL_HTTPS_URL,
+                        STANDARD_HTTPS_URL);
+                Settings.Global.putString(cr, Settings.Global.CAPTIVE_PORTAL_FALLBACK_URL,
+                        STANDARD_FALLBACK_URL);
+                Settings.Global.putString(
+                        cr, Settings.Global.CAPTIVE_PORTAL_OTHER_FALLBACK_URLS,
+                        STANDARD_OTHER_FALLBACK_URLS);
+                Settings.Global.putInt(cr, Settings.Global.CAPTIVE_PORTAL_MODE,
+                        Settings.Global.CAPTIVE_PORTAL_MODE_PROMPT);
+                break;
+            case GRAPHENEOS_CAPTIVE_PORTAL_HTTP_URL_INTVAL:
+                Settings.Global.putString(cr, Settings.Global.CAPTIVE_PORTAL_HTTP_URL,
+                        GRAPHENEOS_CAPTIVE_PORTAL_HTTP_URL);
+                Settings.Global.putString(cr, Settings.Global.CAPTIVE_PORTAL_HTTPS_URL,
+                        GRAPHENEOS_CAPTIVE_PORTAL_HTTPS_URL);
+                Settings.Global.putString(cr, Settings.Global.CAPTIVE_PORTAL_FALLBACK_URL,
+                        GRAPHENEOS_CAPTIVE_PORTAL_FALLBACK_URL);
+                Settings.Global.putString(
+                        cr, Settings.Global.CAPTIVE_PORTAL_OTHER_FALLBACK_URLS,
+                        GRAPHENEOS_CAPTIVE_PORTAL_OTHER_FALLBACK_URL);
+                Settings.Global.putInt(cr, Settings.Global.CAPTIVE_PORTAL_MODE,
+                        Settings.Global.CAPTIVE_PORTAL_MODE_PROMPT);
+                break;
+            default:
+                // GrapheneOS URLs as placeholder
+                Settings.Global.putString(cr, Settings.Global.CAPTIVE_PORTAL_HTTP_URL,
+                        GRAPHENEOS_CAPTIVE_PORTAL_HTTP_URL);
+                Settings.Global.putString(cr, Settings.Global.CAPTIVE_PORTAL_HTTPS_URL,
+                        GRAPHENEOS_CAPTIVE_PORTAL_HTTPS_URL);
+                Settings.Global.putString(cr, Settings.Global.CAPTIVE_PORTAL_FALLBACK_URL,
+                        GRAPHENEOS_CAPTIVE_PORTAL_FALLBACK_URL);
+                Settings.Global.putString(
+                        cr, Settings.Global.CAPTIVE_PORTAL_OTHER_FALLBACK_URLS,
+                        GRAPHENEOS_CAPTIVE_PORTAL_OTHER_FALLBACK_URL);
+                Settings.Global.putInt(cr, Settings.Global.CAPTIVE_PORTAL_MODE,
+                        Settings.Global.CAPTIVE_PORTAL_MODE_IGNORE);
+        }
+    }
+
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object value) {
+        final String key = preference.getKey();
+        if (KEY_CONNECTIVITY_CHECK_SETTINGS.equals(key)) {
+            setCaptivePortalURLs(mContext.getContentResolver(),
+                    Integer.parseInt((String)value));
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    private EnforcedAdmin getEnforcedAdmin() {
+        return RestrictedLockUtilsInternal.checkIfRestrictionEnforced(
+                mContext, UserManager.DISALLOW_CONFIG_PRIVATE_DNS,
+                UserHandle.myUserId());
+    }
+
+    private boolean isDisabledByAdmin() { return getEnforcedAdmin() != null; }
+}

--- a/src/com/android/settings/network/NetworkDashboardFragment.java
+++ b/src/com/android/settings/network/NetworkDashboardFragment.java
@@ -142,6 +142,9 @@ public class NetworkDashboardFragment extends DashboardFragment implements
         if (Utils.isProviderModelEnabled(context)) {
             controllers.add(new NetworkProviderCallsSmsController(context, lifecycle));
         }
+        ConnectivityCheckPreferenceController connectivityCheck =
+                new ConnectivityCheckPreferenceController(context);
+        controllers.add(connectivityCheck);
         return controllers;
     }
 

--- a/src/com/android/settings/network/telephony/EnabledNetworkModePreferenceController.java
+++ b/src/com/android/settings/network/telephony/EnabledNetworkModePreferenceController.java
@@ -78,7 +78,7 @@ public class EnabledNetworkModePreferenceController extends
                 CarrierConfigManager.KEY_HIDE_CARRIER_NETWORK_SETTINGS_BOOL)
                 || carrierConfig.getBoolean(
                 CarrierConfigManager.KEY_HIDE_PREFERRED_NETWORK_TYPE_BOOL)) {
-            visible = false;
+            visible = true;
         } else if (carrierConfig.getBoolean(CarrierConfigManager.KEY_WORLD_PHONE_BOOL)) {
             visible = false;
         } else {
@@ -248,6 +248,7 @@ public class EnabledNetworkModePreferenceController extends
                     }
                     add5gEntry(addNrToLteNetworkType(entryValuesInt[0]));
                     addLteEntry(entryValuesInt[0]);
+                    addLteOnlyEntry();
                     add3gEntry(entryValuesInt[1]);
                     add1xEntry(entryValuesInt[2]);
                     addGlobalEntry(entryValuesInt[3]);
@@ -272,6 +273,7 @@ public class EnabledNetworkModePreferenceController extends
                                 "ENABLED_NETWORKS_CDMA_ONLY_LTE_CHOICES index error.");
                     }
                     addLteEntry(entryValuesInt[0]);
+                    addLteOnlyEntry();
                     addGlobalEntry(entryValuesInt[1]);
                     break;
                 case ENABLED_NETWORKS_TDSCDMA_CHOICES:
@@ -284,6 +286,7 @@ public class EnabledNetworkModePreferenceController extends
                     }
                     add5gEntry(addNrToLteNetworkType(entryValuesInt[0]));
                     addLteEntry(entryValuesInt[0]);
+                    addLteOnlyEntry();
                     add3gEntry(entryValuesInt[1]);
                     add2gEntry(entryValuesInt[2]);
                     break;
@@ -307,6 +310,7 @@ public class EnabledNetworkModePreferenceController extends
                     }
                     add5gEntry(addNrToLteNetworkType(entryValuesInt[0]));
                     add4gEntry(entryValuesInt[0]);
+                    add4gOnlyEntry();
                     add3gEntry(entryValuesInt[1]);
                     break;
                 case ENABLED_NETWORKS_EXCEPT_GSM_CHOICES:
@@ -319,6 +323,7 @@ public class EnabledNetworkModePreferenceController extends
                     }
                     add5gEntry(addNrToLteNetworkType(entryValuesInt[0]));
                     addLteEntry(entryValuesInt[0]);
+                    addLteOnlyEntry();
                     add3gEntry(entryValuesInt[1]);
                     break;
                 case ENABLED_NETWORKS_EXCEPT_LTE_CHOICES:
@@ -343,6 +348,7 @@ public class EnabledNetworkModePreferenceController extends
                     add5gEntry(addNrToLteNetworkType(
                             entryValuesInt[0]));
                     add4gEntry(entryValuesInt[0]);
+                    add4gOnlyEntry();
                     add3gEntry(entryValuesInt[1]);
                     add2gEntry(entryValuesInt[2]);
                     break;
@@ -355,6 +361,7 @@ public class EnabledNetworkModePreferenceController extends
                     }
                     add5gEntry(addNrToLteNetworkType(entryValuesInt[0]));
                     addLteEntry(entryValuesInt[0]);
+                    addLteOnlyEntry();
                     add3gEntry(entryValuesInt[1]);
                     add2gEntry(entryValuesInt[2]);
                     break;
@@ -366,6 +373,7 @@ public class EnabledNetworkModePreferenceController extends
                         throw new IllegalArgumentException(
                                 "PREFERRED_NETWORK_MODE_CHOICES_WORLD_MODE index error.");
                     }
+                    addLteOnlyEntry();
                     addGlobalEntry(entryValuesInt[0]);
 
                     addCustomEntry(
@@ -505,7 +513,6 @@ public class EnabledNetworkModePreferenceController extends
                                 R.string.preferred_network_mode_lte_gsm_umts_summary);
                         break;
                     }
-                case TelephonyManagerConstants.NETWORK_MODE_LTE_ONLY:
                 case TelephonyManagerConstants.NETWORK_MODE_LTE_WCDMA:
                     if (!mIsGlobalCdma) {
                         setSelectedEntry(
@@ -522,6 +529,11 @@ public class EnabledNetworkModePreferenceController extends
                                 TelephonyManagerConstants.NETWORK_MODE_LTE_CDMA_EVDO_GSM_WCDMA);
                         setSummary(R.string.network_global);
                     }
+                    break;
+                case TelephonyManagerConstants.NETWORK_MODE_LTE_ONLY:
+                    setSelectedEntry(TelephonyManagerConstants.NETWORK_MODE_LTE_ONLY);
+                    setSummary(mShow4gForLTE
+                            ? R.string.network_4G_only : R.string.network_lte_only);
                     break;
                 case TelephonyManagerConstants.NETWORK_MODE_LTE_CDMA_EVDO:
                     if (MobileNetworkUtils.isWorldMode(mContext, mSubId)) {
@@ -730,6 +742,22 @@ public class EnabledNetworkModePreferenceController extends
 
         private boolean showNrList() {
             return mSupported5gRadioAccessFamily && mAllowed5gNetworkType;
+        }
+
+        /**
+         * Add LTE only entry.
+         */
+        private void addLteOnlyEntry() {
+            mEntries.add(mContext.getString(R.string.network_lte_only));
+            mEntriesValue.add(TelephonyManagerConstants.NETWORK_MODE_LTE_ONLY);
+        }
+
+        /**
+         * Add 4G only entry
+         */
+        private void add4gOnlyEntry() {
+            mEntries.add(mContext.getString(R.string.network_4G_only));
+            mEntriesValue.add(TelephonyManagerConstants.NETWORK_MODE_LTE_ONLY);
         }
 
         /**

--- a/src/com/android/settings/network/telephony/PreferredNetworkModePreferenceController.java
+++ b/src/com/android/settings/network/telephony/PreferredNetworkModePreferenceController.java
@@ -131,7 +131,7 @@ public class PreferredNetworkModePreferenceController extends TelephonyBasePrefe
             case TelephonyManagerConstants.NETWORK_MODE_LTE_TDSCDMA:
                 return R.string.preferred_network_mode_lte_tdscdma_summary;
             case TelephonyManagerConstants.NETWORK_MODE_LTE_ONLY:
-                return R.string.preferred_network_mode_lte_summary;
+                return R.string.preferred_network_mode_lte_only_summary;
             case TelephonyManagerConstants.NETWORK_MODE_LTE_TDSCDMA_GSM:
                 return R.string.preferred_network_mode_lte_tdscdma_gsm_summary;
             case TelephonyManagerConstants.NETWORK_MODE_LTE_TDSCDMA_GSM_WCDMA:

--- a/src/com/android/settings/password/ChooseLockGenericController.java
+++ b/src/com/android/settings/password/ChooseLockGenericController.java
@@ -175,8 +175,9 @@ public class ChooseLockGenericController {
                     && !managedProfile; // Swipe doesn't make sense for profiles.
             case MANAGED:
                 return mManagedPasswordProvider.isManagedPasswordChoosable();
-            case PIN:
             case PATTERN:
+                return false;
+            case PIN:
             case PASSWORD:
                 // Hide the secure lock screen options if the device doesn't support the secure lock
                 // screen feature.

--- a/src/com/android/settings/security/AutoRebootPreferenceController.java
+++ b/src/com/android/settings/security/AutoRebootPreferenceController.java
@@ -1,0 +1,82 @@
+package com.android.settings.security;
+
+import android.content.Context;
+import android.os.UserManager;
+import android.provider.Settings;
+import android.util.Log;
+
+import androidx.preference.ListPreference;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceCategory;
+import androidx.preference.PreferenceScreen;
+
+import com.android.settings.core.PreferenceControllerMixin;
+import com.android.settingslib.core.AbstractPreferenceController;
+import com.android.settingslib.core.lifecycle.events.OnResume;
+
+public class AutoRebootPreferenceController extends AbstractPreferenceController
+    implements PreferenceControllerMixin, OnResume,
+           Preference.OnPreferenceChangeListener {
+
+    private static final String KEY_AUTO_REBOOT = "auto_reboot";
+    private static final String PREF_KEY_SECURITY_CATEGORY = "security_category";
+
+    private PreferenceCategory mSecurityCategory;
+    private boolean mIsAdmin;
+    private final UserManager mUm;
+
+    public AutoRebootPreferenceController(Context context) {
+        super(context);
+        mUm = UserManager.get(context);
+    }
+
+    @Override
+    public void displayPreference(PreferenceScreen screen) {
+        super.displayPreference(screen);
+        mSecurityCategory = screen.findPreference(PREF_KEY_SECURITY_CATEGORY);
+        updatePreferenceState();
+    }
+
+    @Override
+    public boolean isAvailable() {
+        mIsAdmin = mUm.isAdminUser();
+        return mIsAdmin;
+    }
+
+    @Override
+    public String getPreferenceKey() {
+        return KEY_AUTO_REBOOT;
+    }
+
+    // TODO: should we use onCreatePreferences() instead?
+    private void updatePreferenceState() {
+        if (mSecurityCategory == null) {
+            return;
+        }
+
+        if (mIsAdmin) {
+            ListPreference autoReboot =
+                    (ListPreference) mSecurityCategory.findPreference(KEY_AUTO_REBOOT);
+            autoReboot.setValue(Long.toString(Settings.Global.getLong(
+                    mContext.getContentResolver(), Settings.Global.SETTINGS_REBOOT_AFTER_TIMEOUT, 0)));
+        } else {
+            mSecurityCategory.removePreference(
+                    mSecurityCategory.findPreference(KEY_AUTO_REBOOT));
+        }
+    }
+
+    @Override
+    public void onResume() {
+        updatePreferenceState();
+    }
+
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object value) {
+        final String key = preference.getKey();
+        if (KEY_AUTO_REBOOT.equals(key) && mIsAdmin) {
+            long timeout = Long.parseLong((String) value);
+            Settings.Global.putLong(mContext.getContentResolver(), Settings.Global.SETTINGS_REBOOT_AFTER_TIMEOUT, timeout);
+        }
+        return true;
+    }
+}

--- a/src/com/android/settings/security/DenyNewUsbPreferenceController.java
+++ b/src/com/android/settings/security/DenyNewUsbPreferenceController.java
@@ -1,0 +1,103 @@
+package com.android.settings.security;
+
+import android.content.Context;
+
+import android.os.UserHandle;
+import android.os.UserManager;
+import android.os.SystemProperties;
+
+import android.provider.Settings;
+
+
+import androidx.preference.ListPreference;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceCategory;
+import androidx.preference.PreferenceGroup;
+import androidx.preference.PreferenceScreen;
+
+
+import com.android.internal.widget.LockPatternUtils;
+import com.android.settings.core.PreferenceControllerMixin;
+import com.android.settingslib.core.AbstractPreferenceController;
+import com.android.settingslib.core.lifecycle.events.OnResume;
+
+public class DenyNewUsbPreferenceController extends AbstractPreferenceController
+        implements PreferenceControllerMixin, OnResume, Preference.OnPreferenceChangeListener {
+
+    private static final String KEY_DENY_NEW_USB = "deny_new_usb";
+    private static final String DENY_NEW_USB_PROP = "security.deny_new_usb";
+    private static final String DENY_NEW_USB_PERSIST_PROP = "persist.security.deny_new_usb";
+    private static final String PREF_KEY_SECURITY_CATEGORY = "security_category";
+
+    private PreferenceCategory mSecurityCategory;
+    private ListPreference mDenyNewUsb;
+    private boolean mIsAdmin;
+    private final UserManager mUm;
+
+    public DenyNewUsbPreferenceController(Context context) {
+        super(context);
+        mUm = UserManager.get(context);
+    }
+
+    @Override
+    public void displayPreference(PreferenceScreen screen) {
+        super.displayPreference(screen);
+        mSecurityCategory = screen.findPreference(PREF_KEY_SECURITY_CATEGORY);
+        updatePreferenceState();
+    }
+
+    @Override
+    public boolean isAvailable() {
+        mIsAdmin = mUm.isAdminUser();
+        return mIsAdmin;
+    }
+
+    @Override
+    public String getPreferenceKey() {
+        return KEY_DENY_NEW_USB;
+    }
+
+    // TODO: should we use onCreatePreferences() instead?
+    private void updatePreferenceState() {
+        if (mSecurityCategory == null) {
+            return;
+        }
+
+        if (mIsAdmin) {
+            mDenyNewUsb = (ListPreference) mSecurityCategory.findPreference(KEY_DENY_NEW_USB);
+            mDenyNewUsb.setValue(SystemProperties.get(DENY_NEW_USB_PERSIST_PROP, "disabled"));
+        } else {
+            mSecurityCategory.removePreference(mSecurityCategory.findPreference(KEY_DENY_NEW_USB));
+        }
+    }
+
+    @Override
+    public void onResume() {
+        updatePreferenceState();
+
+        if (mDenyNewUsb != null) {
+            String mode = mDenyNewUsb.getValue();
+            if (mode.equals("dynamic") || mode.equals("disabled")) {
+                SystemProperties.set(DENY_NEW_USB_PROP, "0");
+            } else {
+                SystemProperties.set(DENY_NEW_USB_PROP, "1");
+            }
+        }
+    }
+
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object value) {
+        final String key = preference.getKey();
+        if (KEY_DENY_NEW_USB.equals(key)) {
+            String mode = (String) value;
+            SystemProperties.set(DENY_NEW_USB_PERSIST_PROP, mode);
+            // The dynamic mode defaults to the disabled state
+            if (mode.equals("dynamic") || mode.equals("disabled")) {
+                SystemProperties.set(DENY_NEW_USB_PROP, "0");
+            } else {
+                SystemProperties.set(DENY_NEW_USB_PROP, "1");
+            }
+        }
+        return true;
+    }
+}

--- a/src/com/android/settings/security/KeyguardCameraPreferenceController.java
+++ b/src/com/android/settings/security/KeyguardCameraPreferenceController.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.android.settings.security;
+
+import android.content.Context;
+
+import android.os.UserHandle;
+import android.os.UserManager;
+import android.os.SystemProperties;
+
+import android.provider.Settings;
+
+import androidx.preference.Preference;
+import androidx.preference.PreferenceCategory;
+import androidx.preference.PreferenceGroup;
+import androidx.preference.PreferenceScreen;
+import androidx.preference.TwoStatePreference;
+import androidx.preference.SwitchPreference;
+
+import com.android.internal.widget.LockPatternUtils;
+import com.android.settings.core.PreferenceControllerMixin;
+import com.android.settingslib.core.AbstractPreferenceController;
+import com.android.settingslib.core.lifecycle.events.OnResume;
+
+public class KeyguardCameraPreferenceController extends AbstractPreferenceController
+        implements PreferenceControllerMixin, OnResume, Preference.OnPreferenceChangeListener {
+
+    private static final String SYS_KEY_KEYGUARD_CAMERA = "persist.keyguard.camera";
+    private static final String PREF_KEY_KEYGUARD_CAMERA = "keyguard_camera";
+    private static final String PREF_KEY_SECURITY_CATEGORY = "security_category";
+
+    private PreferenceCategory mSecurityCategory;
+    private SwitchPreference mKeyguardCamera;
+
+    public KeyguardCameraPreferenceController(Context context) {
+        super(context);
+    }
+
+    @Override
+    public void displayPreference(PreferenceScreen screen) {
+        super.displayPreference(screen);
+        mSecurityCategory = screen.findPreference(PREF_KEY_SECURITY_CATEGORY);
+        updatePreferenceState();
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return true;
+    }
+
+    @Override
+    public String getPreferenceKey() {
+        return PREF_KEY_KEYGUARD_CAMERA;
+    }
+
+    // TODO: should we use onCreatePreferences() instead?
+    private void updatePreferenceState() {
+        if (mSecurityCategory == null) {
+            return;
+        }
+        mKeyguardCamera = (SwitchPreference) mSecurityCategory.findPreference(PREF_KEY_KEYGUARD_CAMERA);
+        mKeyguardCamera.setChecked(SystemProperties.getBoolean(SYS_KEY_KEYGUARD_CAMERA, true));
+    }
+
+    @Override
+    public void onResume() {
+        updatePreferenceState();
+        if (mKeyguardCamera != null) {
+            boolean mode = mKeyguardCamera.isChecked();
+            SystemProperties.set(SYS_KEY_KEYGUARD_CAMERA, Boolean.toString(mode));
+        }
+    }
+
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object value) {
+        final String key = preference.getKey();
+        if (PREF_KEY_KEYGUARD_CAMERA.equals(key)) {
+            final boolean mode = !mKeyguardCamera.isChecked();
+            SystemProperties.set(SYS_KEY_KEYGUARD_CAMERA, Boolean.toString(mode));
+        }
+        return true;
+    }
+}

--- a/src/com/android/settings/security/NativeDebugPreferenceController.java
+++ b/src/com/android/settings/security/NativeDebugPreferenceController.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.android.settings.security;
+
+import android.content.Context;
+
+import android.os.UserHandle;
+import android.os.UserManager;
+import android.os.SystemProperties;
+
+import android.provider.Settings;
+
+import androidx.preference.Preference;
+import androidx.preference.PreferenceCategory;
+import androidx.preference.PreferenceGroup;
+import androidx.preference.PreferenceScreen;
+import androidx.preference.TwoStatePreference;
+import androidx.preference.SwitchPreference;
+
+import com.android.internal.widget.LockPatternUtils;
+import com.android.settings.core.PreferenceControllerMixin;
+import com.android.settingslib.core.AbstractPreferenceController;
+import com.android.settingslib.core.lifecycle.events.OnResume;
+
+public class NativeDebugPreferenceController extends AbstractPreferenceController
+        implements PreferenceControllerMixin, OnResume, Preference.OnPreferenceChangeListener {
+
+    private static final String SYS_KEY_NATIVE_DEBUG = "persist.native_debug";
+    private static final String PREF_KEY_NATIVE_DEBUG = "native_debug";
+    private static final String PREF_KEY_SECURITY_CATEGORY = "security_category";
+
+    private PreferenceCategory mSecurityCategory;
+    private SwitchPreference mNativeDebug;
+    private boolean mIsAdmin;
+    private UserManager mUm;
+
+    public NativeDebugPreferenceController(Context context) {
+        super(context);
+        mUm = UserManager.get(context);
+    }
+
+    @Override
+    public void displayPreference(PreferenceScreen screen) {
+        super.displayPreference(screen);
+        mSecurityCategory = screen.findPreference(PREF_KEY_SECURITY_CATEGORY);
+        updatePreferenceState();
+    }
+
+    @Override
+    public boolean isAvailable() {
+        mIsAdmin = mUm.isAdminUser();
+        return mIsAdmin;
+    }
+
+    @Override
+    public String getPreferenceKey() {
+        return PREF_KEY_NATIVE_DEBUG;
+    }
+
+    // TODO: should we use onCreatePreferences() instead?
+    private void updatePreferenceState() {
+        if (mSecurityCategory == null) {
+            return;
+        }
+
+        if (mIsAdmin) {
+            mNativeDebug = (SwitchPreference) mSecurityCategory.findPreference(PREF_KEY_NATIVE_DEBUG);
+            mNativeDebug.setChecked(SystemProperties.getBoolean(SYS_KEY_NATIVE_DEBUG, true));
+        } else {
+            mSecurityCategory.removePreference(mSecurityCategory.findPreference(PREF_KEY_NATIVE_DEBUG));
+        }
+    }
+
+    @Override
+    public void onResume() {
+        updatePreferenceState();
+        if (mNativeDebug != null) {
+                boolean mode = mNativeDebug.isChecked();
+                SystemProperties.set(SYS_KEY_NATIVE_DEBUG, Boolean.toString(mode));
+        }
+    }
+
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object value) {
+        final String key = preference.getKey();
+        if (PREF_KEY_NATIVE_DEBUG.equals(key)) {
+            final boolean mode = !mNativeDebug.isChecked();
+            SystemProperties.set(SYS_KEY_NATIVE_DEBUG, Boolean.toString(mode));
+        }
+        return true;
+    }
+}

--- a/src/com/android/settings/security/PinScramblePreferenceController.java
+++ b/src/com/android/settings/security/PinScramblePreferenceController.java
@@ -1,0 +1,79 @@
+package com.android.settings.security;
+
+import android.content.Context;
+
+import android.os.UserHandle;
+import android.os.UserManager;
+import android.os.SystemProperties;
+
+import android.provider.Settings;
+
+import androidx.preference.ListPreference;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceCategory;
+import androidx.preference.PreferenceGroup;
+import androidx.preference.PreferenceScreen;
+
+import com.android.internal.widget.LockPatternUtils;
+import com.android.settings.core.PreferenceControllerMixin;
+import com.android.settingslib.core.AbstractPreferenceController;
+import com.android.settingslib.core.lifecycle.events.OnResume;
+
+public class PinScramblePreferenceController extends AbstractPreferenceController
+        implements PreferenceControllerMixin, OnResume, Preference.OnPreferenceChangeListener {
+
+    private static final String KEY_SCRAMBLE_PIN_LAYOUT = "scramble_pin_layout";
+    private static final String PREF_KEY_SECURITY_CATEGORY = "security_category";
+
+    private PreferenceCategory mSecurityCategory;
+    private ListPreference mScramblePin;
+
+    public PinScramblePreferenceController(Context context) {
+        super(context);
+    }
+
+    @Override
+    public void displayPreference(PreferenceScreen screen) {
+        super.displayPreference(screen);
+        mSecurityCategory = screen.findPreference(PREF_KEY_SECURITY_CATEGORY);
+        updatePreferenceState();
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return true;
+    }
+
+    @Override
+    public String getPreferenceKey() {
+        return KEY_SCRAMBLE_PIN_LAYOUT;
+    }
+
+    // TODO: should we use onCreatePreferences() instead?
+    private void updatePreferenceState() {
+        if (mSecurityCategory == null) {
+            return;
+        }
+        mScramblePin = (ListPreference) mSecurityCategory.findPreference(KEY_SCRAMBLE_PIN_LAYOUT);
+        mScramblePin.setValue(Boolean.toString(Settings.Secure.getInt(mContext.getContentResolver(), Settings.Secure.SCRAMBLE_PIN_LAYOUT, 0) != 0));
+    }
+
+    @Override
+    public void onResume() {
+        updatePreferenceState();
+        if (mScramblePin != null) {
+            boolean mode = Boolean.parseBoolean(mScramblePin.getValue());
+            Settings.Secure.putInt(mContext.getContentResolver(), Settings.Secure.SCRAMBLE_PIN_LAYOUT, (mode) ? 0 : 1);
+        }
+    }
+
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object value) {
+        final String key = preference.getKey();
+        if (KEY_SCRAMBLE_PIN_LAYOUT.equals(key)) {
+            boolean mode = Boolean.parseBoolean((String) value);
+            Settings.Secure.putInt(mContext.getContentResolver(), Settings.Secure.SCRAMBLE_PIN_LAYOUT, (mode) ? 1 : 0);
+        }
+        return true;
+    }
+}

--- a/src/com/android/settings/security/SecuritySettings.java
+++ b/src/com/android/settings/security/SecuritySettings.java
@@ -122,6 +122,7 @@ public class SecuritySettings extends DashboardFragment {
         securityPreferenceControllers.add(new CombinedBiometricStatusPreferenceController(
                 context, lifecycle));
         securityPreferenceControllers.add(new ChangeScreenLockPreferenceController(context, host));
+        securityPreferenceControllers.add(new PinScramblePreferenceController(context));
         controllers.add(new PreferenceCategoryController(context, SECURITY_CATEGORY)
                 .setChildren(securityPreferenceControllers));
         controllers.addAll(securityPreferenceControllers);

--- a/src/com/android/settings/security/SecuritySettings.java
+++ b/src/com/android/settings/security/SecuritySettings.java
@@ -123,6 +123,7 @@ public class SecuritySettings extends DashboardFragment {
                 context, lifecycle));
         securityPreferenceControllers.add(new ChangeScreenLockPreferenceController(context, host));
         securityPreferenceControllers.add(new PinScramblePreferenceController(context));
+        securityPreferenceControllers.add(new DenyNewUsbPreferenceController(context));
         controllers.add(new PreferenceCategoryController(context, SECURITY_CATEGORY)
                 .setChildren(securityPreferenceControllers));
         controllers.addAll(securityPreferenceControllers);

--- a/src/com/android/settings/security/SecuritySettings.java
+++ b/src/com/android/settings/security/SecuritySettings.java
@@ -123,6 +123,7 @@ public class SecuritySettings extends DashboardFragment {
                 context, lifecycle));
         securityPreferenceControllers.add(new ChangeScreenLockPreferenceController(context, host));
         securityPreferenceControllers.add(new PinScramblePreferenceController(context));
+        securityPreferenceControllers.add(new AutoRebootPreferenceController(context));
         securityPreferenceControllers.add(new DenyNewUsbPreferenceController(context));
         securityPreferenceControllers.add(new KeyguardCameraPreferenceController(context));
         securityPreferenceControllers.add(new NativeDebugPreferenceController(context));

--- a/src/com/android/settings/security/SecuritySettings.java
+++ b/src/com/android/settings/security/SecuritySettings.java
@@ -124,6 +124,7 @@ public class SecuritySettings extends DashboardFragment {
         securityPreferenceControllers.add(new ChangeScreenLockPreferenceController(context, host));
         securityPreferenceControllers.add(new PinScramblePreferenceController(context));
         securityPreferenceControllers.add(new DenyNewUsbPreferenceController(context));
+        securityPreferenceControllers.add(new KeyguardCameraPreferenceController(context));
         controllers.add(new PreferenceCategoryController(context, SECURITY_CATEGORY)
                 .setChildren(securityPreferenceControllers));
         controllers.addAll(securityPreferenceControllers);

--- a/src/com/android/settings/security/SecuritySettings.java
+++ b/src/com/android/settings/security/SecuritySettings.java
@@ -125,6 +125,7 @@ public class SecuritySettings extends DashboardFragment {
         securityPreferenceControllers.add(new PinScramblePreferenceController(context));
         securityPreferenceControllers.add(new DenyNewUsbPreferenceController(context));
         securityPreferenceControllers.add(new KeyguardCameraPreferenceController(context));
+        securityPreferenceControllers.add(new NativeDebugPreferenceController(context));
         controllers.add(new PreferenceCategoryController(context, SECURITY_CATEGORY)
                 .setChildren(securityPreferenceControllers));
         controllers.addAll(securityPreferenceControllers);

--- a/src/com/android/settings/vpn2/AppManagementFragment.java
+++ b/src/com/android/settings/vpn2/AppManagementFragment.java
@@ -81,6 +81,7 @@ public class AppManagementFragment extends SettingsPreferenceFragment
     private RestrictedSwitchPreference mPreferenceAlwaysOn;
     private RestrictedSwitchPreference mPreferenceLockdown;
     private RestrictedPreference mPreferenceForget;
+    private boolean mIsAlwaysOnToggledToOn = false;
 
     // Listener
     private final AppDialogFragment.Listener mForgetVpnDialogFragmentListener =
@@ -162,7 +163,8 @@ public class AppManagementFragment extends SettingsPreferenceFragment
     public boolean onPreferenceChange(Preference preference, Object newValue) {
         switch (preference.getKey()) {
             case KEY_ALWAYS_ON_VPN:
-                return onAlwaysOnVpnClick((Boolean) newValue, mPreferenceLockdown.isChecked());
+                if ((Boolean) newValue) mIsAlwaysOnToggledToOn = true;
+                return onAlwaysOnVpnClick((Boolean) newValue, (Boolean) newValue);
             case KEY_LOCKDOWN_VPN:
                 return onAlwaysOnVpnClick(mPreferenceAlwaysOn.isChecked(), (Boolean) newValue);
             default:
@@ -189,7 +191,7 @@ public class AppManagementFragment extends SettingsPreferenceFragment
     private boolean onAlwaysOnVpnClick(final boolean alwaysOnSetting, final boolean lockdown) {
         final boolean replacing = isAnotherVpnActive();
         final boolean wasLockdown = VpnUtils.isAnyLockdownActive(getActivity());
-        if (ConfirmLockdownFragment.shouldShow(replacing, wasLockdown, lockdown)) {
+        if (!mIsAlwaysOnToggledToOn && (ConfirmLockdownFragment.shouldShow(replacing, wasLockdown, lockdown))) {
             // Place a dialog to confirm that traffic should be locked down.
             final Bundle options = null;
             ConfirmLockdownFragment.show(

--- a/src/com/android/settings/wifi/WifiTimeoutPreferenceController.java
+++ b/src/com/android/settings/wifi/WifiTimeoutPreferenceController.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2020 The Calyx Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.wifi;
+
+import android.content.Context;
+import android.net.wifi.WifiManager;
+import android.provider.Settings;
+import android.util.Log;
+
+import androidx.preference.ListPreference;
+import androidx.preference.Preference;
+
+import com.android.settings.R;
+import com.android.settings.core.BasePreferenceController;
+import com.android.settings.core.PreferenceControllerMixin;
+
+public class WifiTimeoutPreferenceController extends BasePreferenceController implements
+        PreferenceControllerMixin, Preference.OnPreferenceChangeListener {
+    private static final String TAG = "WifiTimeoutPrefCtrl";
+
+    public static final int FALLBACK_WIFI_TIMEOUT_VALUE = 0;
+
+    private final String mWifiTimeoutKey;
+
+    protected WifiManager mWifiManager;
+
+    public WifiTimeoutPreferenceController(Context context, String key) {
+        super(context, key);
+        mWifiTimeoutKey = key;
+
+        mWifiManager = context.getSystemService(WifiManager.class);
+        if (mWifiManager == null) {
+            Log.e(TAG, "Wifi is not supported on this device");
+            return;
+        }
+    }
+
+    @Override
+    public int getAvailabilityStatus() {
+        return mWifiManager != null ? AVAILABLE : UNSUPPORTED_ON_DEVICE;
+    }
+
+    @Override
+    public String getPreferenceKey() {
+        return mWifiTimeoutKey;
+    }
+
+    @Override
+    public void updateState(Preference preference) {
+        final ListPreference timeoutListPreference = (ListPreference) preference;
+        final long currentTimeout = Settings.Global.getLong(mContext.getContentResolver(),
+                Settings.Global.WIFI_OFF_TIMEOUT, FALLBACK_WIFI_TIMEOUT_VALUE);
+        timeoutListPreference.setValue(String.valueOf(currentTimeout));
+        updateTimeoutPreferenceDescription(timeoutListPreference,
+                Long.parseLong(timeoutListPreference.getValue()));
+    }
+
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object newValue) {
+        try {
+            long value = Long.parseLong((String) newValue);
+            Settings.Global.putLong(mContext.getContentResolver(), Settings.Global.WIFI_OFF_TIMEOUT, value);
+            updateTimeoutPreferenceDescription((ListPreference) preference, value);
+        } catch (NumberFormatException e) {
+            Log.e(TAG, "could not persist wifi timeout setting", e);
+        }
+        return true;
+    }
+
+    public static CharSequence getTimeoutDescription(
+            long currentTimeout, CharSequence[] entries, CharSequence[] values) {
+        if (currentTimeout < 0 || entries == null || values == null
+                || values.length != entries.length) {
+            return null;
+        }
+
+        for (int i = 0; i < values.length; i++) {
+            long timeout = Long.parseLong(values[i].toString());
+            if (currentTimeout == timeout) {
+                return entries[i];
+            }
+        }
+        return null;
+    }
+
+    private void updateTimeoutPreferenceDescription(ListPreference preference,
+                                                    long currentTimeout) {
+        final CharSequence[] entries = preference.getEntries();
+        final CharSequence[] values = preference.getEntryValues();
+        final CharSequence timeoutDescription = getTimeoutDescription(
+                currentTimeout, entries, values);
+        String summary = "";
+        if (timeoutDescription != null) {
+            if (currentTimeout != 0)
+                summary = mContext.getString(R.string.wifi_timeout_summary, timeoutDescription);
+            else
+                summary = mContext.getString(R.string.wifi_timeout_summary2);
+        }
+        preference.setSummary(summary);
+    }
+}

--- a/src/com/android/settings/wifi/details2/WifiDetailPreferenceController2.java
+++ b/src/com/android/settings/wifi/details2/WifiDetailPreferenceController2.java
@@ -799,7 +799,7 @@ public class WifiDetailPreferenceController2 extends AbstractPreferenceControlle
     }
 
     private int getMacAddressTitle() {
-        if (mWifiEntry.getPrivacy() == WifiEntry.PRIVACY_RANDOMIZED_MAC) {
+        if (mWifiEntry.getPrivacy() != WifiEntry.PRIVACY_DEVICE_MAC) {
             return mWifiEntry.getConnectedState() == WifiEntry.CONNECTED_STATE_CONNECTED
                     ? R.string.wifi_advanced_randomized_mac_address_title
                     : R.string.wifi_advanced_randomized_mac_address_disconnected_title;

--- a/src/com/android/settings/wifi/details2/WifiPrivacyPreferenceController2.java
+++ b/src/com/android/settings/wifi/details2/WifiPrivacyPreferenceController2.java
@@ -42,6 +42,10 @@ public class WifiPrivacyPreferenceController2 extends BasePreferenceController i
     private WifiEntry mWifiEntry;
     private Preference mPreference;
 
+    private static final int PREF_RANDOMIZATION_ALWAYS = 0;
+    private static final int PREF_RANDOMIZATION_PERSISTENT = 1;
+    private static final int PREF_RANDOMIZATION_NONE = 2;
+
     public WifiPrivacyPreferenceController2(Context context) {
         super(context, KEY_WIFI_PRIVACY);
 
@@ -99,8 +103,6 @@ public class WifiPrivacyPreferenceController2 extends BasePreferenceController i
         return mWifiEntry.getPrivacy();
     }
 
-    private static final int PREF_RANDOMIZATION_PERSISTENT = 0;
-    private static final int PREF_RANDOMIZATION_NONE = 1;
 
     /**
      * Returns preference index value.
@@ -109,8 +111,14 @@ public class WifiPrivacyPreferenceController2 extends BasePreferenceController i
      * @return index value of preference
      */
     public static int translateMacRandomizedValueToPrefValue(int macRandomized) {
-        return (macRandomized == WifiEntry.PRIVACY_RANDOMIZED_MAC)
-            ? PREF_RANDOMIZATION_PERSISTENT : PREF_RANDOMIZATION_NONE;
+        switch (macRandomized) {
+            case WifiEntry.PRIVACY_RANDOMIZED_MAC:
+                return PREF_RANDOMIZATION_PERSISTENT;
+            case WifiEntry.PRIVACY_DEVICE_MAC:
+                return PREF_RANDOMIZATION_NONE;
+            default:
+                return PREF_RANDOMIZATION_ALWAYS;
+        }
     }
 
     /**
@@ -120,8 +128,14 @@ public class WifiPrivacyPreferenceController2 extends BasePreferenceController i
      * @return mac randomized value
      */
     public static int translatePrefValueToMacRandomizedValue(int prefMacRandomized) {
-        return (prefMacRandomized == PREF_RANDOMIZATION_PERSISTENT)
-            ? WifiEntry.PRIVACY_RANDOMIZED_MAC : WifiEntry.PRIVACY_DEVICE_MAC;
+        switch (prefMacRandomized) {
+            case PREF_RANDOMIZATION_PERSISTENT:
+                return WifiEntry.PRIVACY_RANDOMIZED_MAC;
+            case PREF_RANDOMIZATION_NONE:
+                return WifiEntry.PRIVACY_DEVICE_MAC;
+            default:
+                return WifiEntry.PRIVACY_RANDOMIZATION_ALWAYS;
+        }
     }
 
     private void updateSummary(DropDownPreference preference, int macRandomized) {
@@ -151,6 +165,8 @@ public class WifiPrivacyPreferenceController2 extends BasePreferenceController i
                 return WifiEntry.PRIVACY_DEVICE_MAC;
             case WifiConfiguration.RANDOMIZATION_PERSISTENT:
                 return WifiEntry.PRIVACY_RANDOMIZED_MAC;
+            case WifiConfiguration.RANDOMIZATION_ALWAYS:
+                return WifiEntry.PRIVACY_RANDOMIZATION_ALWAYS;
             default:
                 return WifiEntry.PRIVACY_UNKNOWN;
         }


### PR DESCRIPTION
This commit enables VPN lockdown by default when Always-On is toggled on (and the dialog is not shown even if lockdown is toggled on to maintain parity on upstream), and still keeps the user able to use Network without VPN. This extends the chained toggle of always-on and lockdown to both toggled on too, instead of just both being toggled off when always on is toggled off.
