### PR TITLE
Do not initialize obb toggle on privileged apps

### DIFF
--- a/src/com/android/settings/applications/appinfo/ExternalSourcesDetails.java
+++ b/src/com/android/settings/applications/appinfo/ExternalSourcesDetails.java
@@ -156,6 +156,9 @@ public class ExternalSourcesDetails extends AppInfoWithHeader
     private void setupObbToggle() {
         RestrictedSwitchPreference p = mObbPref;
         if (p == null) {
+            if (!GosPackageState.attachableToPackage(mPackageName)) {
+                return;
+            }
             p = createObbToggle();
             mSwitchPref.getParent().addPreference(p);
             mObbPref = p;


### PR DESCRIPTION
Otherwise it throws IllegalStateException due to initialization of
listener that sets the GosPackageState on non-attachable apps