### PR TITLE
Revert "don't handle APP_ALL_FILES_ACCESS_PERMISSION and MANAGE_MEDIA intents"

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -3628,7 +3628,7 @@
             android:exported="true"
             android:label="@string/manage_external_storage_title">
             <intent-filter android:priority="1">
-                <action android:name="android.settings.MANAGE_APP_ALL_FILES_ACCESS_PERMISSION_INNER" />
+                <action android:name="android.settings.MANAGE_APP_ALL_FILES_ACCESS_PERMISSION" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:scheme="package" />
             </intent-filter>
@@ -3659,7 +3659,7 @@
             android:exported="true"
             android:label="@string/media_management_apps_title">
             <intent-filter android:priority="1">
-                <action android:name="android.settings.REQUEST_MANAGE_MEDIA_INNER" />
+                <action android:name="android.settings.REQUEST_MANAGE_MEDIA" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:scheme="package" />
             </intent-filter>


### PR DESCRIPTION
Showing a permission prompt each time they are launched is not ideal, they aren't always launched
to ask for permission. A special "_PROMPT" intent suffix is now used instead.