### PR TITLE
Settings: Pass empty lottie resource for quickly open camera animation

### DIFF
--- a/res/drawable/quickly_open_camera.xml
+++ b/res/drawable/quickly_open_camera.xml
@@ -1,3 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape>
-</shape>

--- a/res/xml/double_tap_power_settings.xml
+++ b/res/xml/double_tap_power_settings.xml
@@ -24,7 +24,7 @@
     <com.android.settingslib.widget.IllustrationPreference
         android:key="gesture_double_tap_power_video"
         settings:searchable="false"
-        app:lottie_rawRes="@drawable/quickly_open_camera"/>
+        app:lottie_rawRes="@raw/lottie_quickly_open_camera"/>
 
     <SwitchPreference
         android:key="gesture_double_tap_power"


### PR DESCRIPTION
This lets us hide it properly.

Change-Id: I02ac031a835236811b82a7de283335390ffebab9