### PR TITLE
Do not allow disabling GrapheneOS Camera

### DIFF
--- a/src/com/android/settings/applications/appinfo/AppButtonsPreferenceController.java
+++ b/src/com/android/settings/applications/appinfo/AppButtonsPreferenceController.java
@@ -627,6 +627,7 @@ public class AppButtonsPreferenceController extends BasePreferenceController imp
         if (mHomePackages.contains(mAppEntry.info.packageName)
                 || mAppEntry.info.packageName.equals("com.android.inputmethod.latin")
                 || mAppEntry.info.packageName.equals("app.vanadium.webview")
+                || mAppEntry.info.packageName.equals("app.grapheneos.camera")
                 || mAppEntry.info.packageName.equals(GmsCompatApp.PKG_NAME)
                 || mAppEntry.info.packageName.equals(GmsCompatApp.PKG_NAME + ".config")
                 || isSystemPackage(mActivity.getResources(), mPm, mPackageInfo)) {


### PR DESCRIPTION
since Android 11, only the system camera app is allowed to provide system media capture intents (e.g. camera and video capture). unfortunately too many people are disabling the built in camera app in favour of their own not realising this.

Signed-off-by: r3g_5z <june@girlboss.ceo>

https://github.com/GrapheneOS/Camera/issues/247
https://github.com/GrapheneOS/Camera/issues/126