### PR TITLE
Disable support for toggling instant apps now they're formally unsupported

### DIFF
--- a/src/com/android/settings/applications/managedomainurls/InstantAppWebActionPreferenceController.java
+++ b/src/com/android/settings/applications/managedomainurls/InstantAppWebActionPreferenceController.java
@@ -36,13 +36,11 @@ public class InstantAppWebActionPreferenceController extends TogglePreferenceCon
     }
 
     public boolean isChecked() {
-        return Settings.Secure.getInt(mContext.getContentResolver(),
-                Settings.Secure.INSTANT_APPS_ENABLED, 1) == 1;
+        return false;
     }
 
     public boolean setChecked(boolean isChecked) {
-        return Settings.Secure.putInt(mContext.getContentResolver(),
-                Settings.Secure.INSTANT_APPS_ENABLED, isChecked ? 1 : 0);
+        return false;
     }
 
     @Override

--- a/src/com/android/settings/applications/managedomainurls/WebActionCategoryController.java
+++ b/src/com/android/settings/applications/managedomainurls/WebActionCategoryController.java
@@ -29,11 +29,10 @@ public class WebActionCategoryController extends BasePreferenceController {
 
     @Override
     public int getAvailabilityStatus() {
-        return isDisableWebActions(mContext) ? UNSUPPORTED_ON_DEVICE : AVAILABLE;
+        return UNSUPPORTED_ON_DEVICE;
     }
 
     public static boolean isDisableWebActions(Context context) {
-        return Settings.Global.getInt(context.getContentResolver(),
-                Settings.Global.ENABLE_EPHEMERAL_FEATURE, 1) == 0;
+        return true;
     }
 }


### PR DESCRIPTION
Depends on 
https://github.com/GrapheneOS/platform_frameworks_base/pull/318 