### PR TITLE
fix accessibility settings links in SetupWizard

### DIFF
--- a/src/com/android/settings/accessibility/TextReadingPreferenceFragmentForSetupWizard.java
+++ b/src/com/android/settings/accessibility/TextReadingPreferenceFragmentForSetupWizard.java
@@ -43,22 +43,7 @@ public class TextReadingPreferenceFragmentForSetupWizard extends TextReadingPref
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        final GlifPreferenceLayout layout = (GlifPreferenceLayout) view;
-        final String title = getContext().getString(
-                R.string.accessibility_text_reading_options_title);
-        final Drawable icon = getContext().getDrawable(R.drawable.ic_accessibility_visibility);
-        icon.setTintList(Utils.getColorAttr(getContext(), android.R.attr.colorPrimary));
-        AccessibilitySetupWizardUtils.updateGlifPreferenceLayout(getContext(), layout, title,
-                /* description= */ null, icon);
-
         updateResetButtonPadding();
-    }
-
-    @Override
-    public RecyclerView onCreateRecyclerView(LayoutInflater inflater, ViewGroup parent,
-            Bundle savedInstanceState) {
-        final GlifPreferenceLayout layout = (GlifPreferenceLayout) parent;
-        return layout.onCreateRecyclerView(inflater, parent, savedInstanceState);
     }
 
     @Override

--- a/src/com/android/settings/accessibility/ToggleScreenMagnificationPreferenceFragmentForSetupWizard.java
+++ b/src/com/android/settings/accessibility/ToggleScreenMagnificationPreferenceFragmentForSetupWizard.java
@@ -36,14 +36,6 @@ public class ToggleScreenMagnificationPreferenceFragmentForSetupWizard
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        final GlifPreferenceLayout layout = (GlifPreferenceLayout) view;
-        final String title = getContext().getString(
-                R.string.accessibility_screen_magnification_title);
-        final String description = getContext().getString(
-                R.string.accessibility_screen_magnification_intro_text);
-        final Drawable icon = getContext().getDrawable(R.drawable.ic_accessibility_visibility);
-        AccessibilitySetupWizardUtils.updateGlifPreferenceLayout(getContext(), layout, title,
-                description, icon);
         hidePreferenceSettingComponents();
     }
 
@@ -63,13 +55,6 @@ public class ToggleScreenMagnificationPreferenceFragmentForSetupWizard
         if (mFollowingTypingSwitchPreference != null) {
             mFollowingTypingSwitchPreference.setVisible(false);
         }
-    }
-
-    @Override
-    public RecyclerView onCreateRecyclerView(LayoutInflater inflater, ViewGroup parent,
-            Bundle savedInstanceState) {
-        final GlifPreferenceLayout layout = (GlifPreferenceLayout) parent;
-        return layout.onCreateRecyclerView(inflater, parent, savedInstanceState);
     }
 
     @Override

--- a/src/com/android/settings/accessibility/ToggleScreenReaderPreferenceFragmentForSetupWizard.java
+++ b/src/com/android/settings/accessibility/ToggleScreenReaderPreferenceFragmentForSetupWizard.java
@@ -38,24 +38,10 @@ public class ToggleScreenReaderPreferenceFragmentForSetupWizard
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        final GlifPreferenceLayout layout = (GlifPreferenceLayout) view;
-        final String title = getArguments().getString(AccessibilitySettings.EXTRA_TITLE);
-        final String description = getContext().getString(R.string.talkback_summary);
-        final Drawable icon = getContext().getDrawable(R.drawable.ic_accessibility_visibility);
-        AccessibilitySetupWizardUtils.updateGlifPreferenceLayout(getContext(), layout, title,
-                description, icon);
-
         mToggleSwitchWasInitiallyChecked = mToggleServiceSwitchPreference.isChecked();
         if (mTopIntroPreference != null) {
             mTopIntroPreference.setVisible(false);
         }
-    }
-
-    @Override
-    public RecyclerView onCreateRecyclerView(LayoutInflater inflater, ViewGroup parent,
-            Bundle savedInstanceState) {
-        final GlifPreferenceLayout layout = (GlifPreferenceLayout) parent;
-        return layout.onCreateRecyclerView(inflater, parent, savedInstanceState);
     }
 
     @Override


### PR DESCRIPTION
These fragments depend on SettingsGoogle components that are missing from AOSP Settings.

Closes https://github.com/GrapheneOS/os-issue-tracker/issues/1967