### PR TITLE
don't sort user profiles by serial number, sort alphabetically

### DIFF
--- a/src/com/android/settings/users/UserSettings.java
+++ b/src/com/android/settings/users/UserSettings.java
@@ -1273,8 +1273,7 @@ public class UserSettings extends SettingsPreferenceFragment
         }
 
 
-        // Sort list of users by serialNum
-        Collections.sort(userPreferences, UserPreference.SERIAL_NUMBER_COMPARATOR);
+        Collections.sort(userPreferences);
 
         getActivity().invalidateOptionsMenu();
 


### PR DESCRIPTION
The default behaviour of `Collections.sort` is to sort alphabetically ascending if only 1 argument is passed. Sorting by profile serial number isn't very useful and the user can't easily see this anyways

Solves https://github.com/GrapheneOS/os-issue-tracker/issues/1355