### PR TITLE
Hide private DNS settings UI unless admin

### DIFF
--- a/src/com/android/settings/network/PrivateDnsPreferenceController.java
+++ b/src/com/android/settings/network/PrivateDnsPreferenceController.java
@@ -89,7 +89,7 @@ public class PrivateDnsPreferenceController extends BasePreferenceController
             return UNSUPPORTED_ON_DEVICE;
         }
         final UserManager userManager = mContext.getSystemService(UserManager.class);
-        if (userManager.isGuestUser()) return DISABLED_FOR_USER;
+        if (!userManager.isAdminUser()) return DISABLED_FOR_USER;
         return AVAILABLE;
     }
 

--- a/tests/robotests/src/com/android/settings/network/PrivateDnsPreferenceControllerTest.java
+++ b/tests/robotests/src/com/android/settings/network/PrivateDnsPreferenceControllerTest.java
@@ -179,8 +179,8 @@ public class PrivateDnsPreferenceControllerTest {
     }
 
     @Test
-    public void getAvailabilityStatus_disabledForGuestUser() {
-        doReturn(true).when(mUserManager).isGuestUser();
+    public void getAvailabilityStatus_disabledForNonAdminUser() {
+        doReturn(false).when(mUserManager).isAdminUser();
         assertThat(mController.getAvailabilityStatus()).isEqualTo(DISABLED_FOR_USER);
     }
 


### PR DESCRIPTION
This is a cherry-pick of a LineageOS change that I thought could fit into GrapheneOS too considering it could have a privacy impact.