### PR TITLE
require device restart to disable eUICC LPA

### DIFF
--- a/res/values/strings_ext.xml
+++ b/res/values/strings_ext.xml
@@ -30,6 +30,8 @@
 
     <string name="privileged_euicc_management_title">Enable privileged eSIM management</string>
     <string name="privileged_euicc_management_summary">Requires sandboxed Google Play installation</string>
+    <string name="privileged_euicc_management_restart_to_disable_dialog">Device restart is required to disable this setting.</string>
+    <string name="privileged_euicc_management_restart_button">Restart</string>
 
     <string name="remote_provisioning_title">Attestation key provisioning</string>
     <string name="remote_provisioning_enabled_grapheneos_proxy">Enabled (GrapheneOS proxy)</string>


### PR DESCRIPTION
OS code expects LPA to remain present once it had been detected.

If LPA is disabled without rebooting the device, OS code in some cases tries to connect to it in an infinite loop.