### PR TITLE
improvements to UserManager restriction settings

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -8067,7 +8067,7 @@
     <!-- Title of preference to disallow installing apps [CHAR LIMIT=45] -->
     <string name="user_allow_install_apps">Allow installing apps</string>
     <!-- Title of preference to disallow installing apps [CHAR LIMIT=45] -->
-    <string name="user_allow_install_apps_unknown_sources">Allow installing apps from third party sources</string>
+    <string name="user_disallow_install_apps_unknown_sources">Disallow installing apps from third party sources</string>
     <!-- Title of preference to remove the user [CHAR LIMIT=35] -->
     <string name="user_remove_user">Delete user</string>
     <!-- Title for confirmation of turning on calls [CHAR LIMIT=40] -->

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -8065,7 +8065,7 @@
     <!-- Title of preference to enable calling and SMS [CHAR LIMIT=45] -->
     <string name="user_enable_calling_sms">Turn on phone calls &amp; SMS</string>
     <!-- Title of preference to disallow installing apps [CHAR LIMIT=45] -->
-    <string name="user_allow_install_apps">Allow installing apps</string>
+    <string name="user_disallow_install_apps">Disallow installing apps</string>
     <!-- Title of preference to disallow installing apps [CHAR LIMIT=45] -->
     <string name="user_disallow_install_apps_unknown_sources">Disallow installing apps from third party sources</string>
     <!-- Title of preference to remove the user [CHAR LIMIT=35] -->

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -8066,8 +8066,6 @@
     <string name="user_enable_calling_sms">Turn on phone calls &amp; SMS</string>
     <!-- Title of preference to disallow installing apps [CHAR LIMIT=45] -->
     <string name="user_disallow_install_apps">Disallow installing apps</string>
-    <!-- Title of preference to disallow installing apps [CHAR LIMIT=45] -->
-    <string name="user_disallow_install_apps_unknown_sources">Disallow installing apps from third party sources</string>
     <!-- Title of preference to remove the user [CHAR LIMIT=35] -->
     <string name="user_remove_user">Delete user</string>
     <!-- Title for confirmation of turning on calls [CHAR LIMIT=40] -->

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -8068,8 +8068,6 @@
     <string name="user_allow_install_apps">Allow installing apps</string>
     <!-- Title of preference to disallow installing apps [CHAR LIMIT=45] -->
     <string name="user_allow_install_apps_unknown_sources">Allow installing apps from third party sources</string>
-    <!-- Title of preference to disallow user running from background [CHAR LIMIT=45] -->
-    <string name="user_allow_run_in_background">Allow running in background</string>
     <!-- Title of preference to remove the user [CHAR LIMIT=35] -->
     <string name="user_remove_user">Delete user</string>
     <!-- Title for confirmation of turning on calls [CHAR LIMIT=40] -->

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -8064,8 +8064,6 @@
     <string name="user_enable_calling">Turn on phone calls</string>
     <!-- Title of preference to enable calling and SMS [CHAR LIMIT=45] -->
     <string name="user_enable_calling_sms">Turn on phone calls &amp; SMS</string>
-    <!-- Title of preference to disallow installing apps [CHAR LIMIT=45] -->
-    <string name="user_disallow_install_apps">Disallow installing apps</string>
     <!-- Title of preference to remove the user [CHAR LIMIT=35] -->
     <string name="user_remove_user">Delete user</string>
     <!-- Title for confirmation of turning on calls [CHAR LIMIT=40] -->

--- a/res/values/strings_ext.xml
+++ b/res/values/strings_ext.xml
@@ -114,5 +114,7 @@ Disabling native debugging might break some apps, most notably banking apps.
     <string name="user_app_install_enabled_desc">Enable app installs and updates</string>
     <string name="user_app_install_enabled_first_party_sources_desc">Enable app installs and updates from first party sources only</string>
     <string name="user_app_install_disabled_desc">Disable app installs and updates</string>
+    <!-- Title of preference to enable running in background [CHAR LIMIT=40] -->
+    <string name="user_run_in_background">Allow running in background</string>
 
 </resources>

--- a/res/values/strings_ext.xml
+++ b/res/values/strings_ext.xml
@@ -104,4 +104,15 @@ This feature slightly weakens the app sandbox.
 Disabling native debugging might break some apps, most notably banking apps.
     </string>
 
+    <!-- Title of preference to enable app installs and updates [CHAR LIMIT=40] -->
+    <string name="user_app_install">App installs and updates</string>
+    <!-- Options for setting app install and updates per user -->
+    <string name="user_app_install_enabled">Enabled</string>
+    <string name="user_app_install_enabled_first_party_sources">Enabled for first party sources</string>
+    <string name="user_app_install_disabled">Disabled</string>
+    <!-- Description for options for setting app installs and updates per user -->
+    <string name="user_app_install_enabled_desc">Enable app installs and updates</string>
+    <string name="user_app_install_enabled_first_party_sources_desc">Enable app installs and updates from first party sources only</string>
+    <string name="user_app_install_disabled_desc">Disable app installs and updates</string>
+
 </resources>

--- a/res/xml/user_details_settings.xml
+++ b/res/xml/user_details_settings.xml
@@ -22,6 +22,10 @@
             android:key="switch_user"
             android:icon="@drawable/ic_swap" />
     <SwitchPreference
+            android:icon="@drawable/ic_sync"
+            android:key="allow_run_in_background"
+            android:title="@string/user_run_in_background" />
+    <SwitchPreference
             android:key="enable_calling"
             android:icon="@drawable/ic_phone"
             android:title="@string/user_enable_calling_sms" />

--- a/res/xml/user_details_settings.xml
+++ b/res/xml/user_details_settings.xml
@@ -32,7 +32,7 @@
     <SwitchPreference
             android:icon="@drawable/ic_settings_install"
             android:key="disallow_install_apps"
-            android:title="@string/user_allow_install_apps" />
+            android:title="@string/user_disallow_install_apps" />
     <SwitchPreference
             android:icon="@drawable/ic_settings_install"
             android:key="disallow_install_apps_unknown_sources"

--- a/res/xml/user_details_settings.xml
+++ b/res/xml/user_details_settings.xml
@@ -36,7 +36,7 @@
     <SwitchPreference
             android:icon="@drawable/ic_settings_install"
             android:key="disallow_install_apps_unknown_sources"
-            android:title="@string/user_allow_install_apps_unknown_sources" />
+            android:title="@string/user_disallow_install_apps_unknown_sources" />
     <com.android.settingslib.RestrictedPreference
             android:key="app_copying"
             android:icon="@drawable/ic_apps"

--- a/res/xml/user_details_settings.xml
+++ b/res/xml/user_details_settings.xml
@@ -30,6 +30,10 @@
             android:icon="@drawable/ic_lock_closed"
             android:title="@string/user_restrictions_title" />
     <com.android.settingslib.RestrictedPreference
+            android:key="app_installs"
+            android:icon="@drawable/ic_settings_install"
+            android:title="@string/user_app_install" />
+    <com.android.settingslib.RestrictedPreference
             android:key="app_copying"
             android:icon="@drawable/ic_apps"
             android:title="@string/user_copy_apps_menu_title" />

--- a/res/xml/user_details_settings.xml
+++ b/res/xml/user_details_settings.xml
@@ -33,10 +33,6 @@
             android:icon="@drawable/ic_settings_install"
             android:key="disallow_install_apps"
             android:title="@string/user_disallow_install_apps" />
-    <SwitchPreference
-            android:icon="@drawable/ic_settings_install"
-            android:key="disallow_install_apps_unknown_sources"
-            android:title="@string/user_disallow_install_apps_unknown_sources" />
     <com.android.settingslib.RestrictedPreference
             android:key="app_copying"
             android:icon="@drawable/ic_apps"

--- a/res/xml/user_details_settings.xml
+++ b/res/xml/user_details_settings.xml
@@ -29,10 +29,6 @@
             android:key="app_and_content_access"
             android:icon="@drawable/ic_lock_closed"
             android:title="@string/user_restrictions_title" />
-    <SwitchPreference
-            android:icon="@drawable/ic_settings_install"
-            android:key="disallow_install_apps"
-            android:title="@string/user_disallow_install_apps" />
     <com.android.settingslib.RestrictedPreference
             android:key="app_copying"
             android:icon="@drawable/ic_apps"

--- a/res/xml/user_details_settings.xml
+++ b/res/xml/user_details_settings.xml
@@ -37,10 +37,6 @@
             android:icon="@drawable/ic_settings_install"
             android:key="disallow_install_apps_unknown_sources"
             android:title="@string/user_allow_install_apps_unknown_sources" />
-    <SwitchPreference
-            android:icon="@drawable/ic_sync"
-            android:key="disallow_run_in_background"
-            android:title="@string/user_allow_run_in_background" />
     <com.android.settingslib.RestrictedPreference
             android:key="app_copying"
             android:icon="@drawable/ic_apps"

--- a/src/com/android/settings/users/UserAppsInstallSettings.java
+++ b/src/com/android/settings/users/UserAppsInstallSettings.java
@@ -1,0 +1,166 @@
+package com.android.settings.users;
+
+import static com.android.settings.users.UserDetailsSettings.EXTRA_USER_ID;
+
+import android.app.settings.SettingsEnums;
+import android.content.Context;
+import android.content.pm.UserInfo;
+import android.os.Bundle;
+import android.os.UserHandle;
+import android.os.UserManager;
+
+import androidx.preference.Preference;
+import androidx.preference.PreferenceScreen;
+
+import com.android.settings.R;
+import com.android.settings.core.SubSettingLauncher;
+import com.android.settings.dashboard.DashboardFragment;
+import com.android.settings.utils.CandidateInfoExtra;
+import com.android.settings.widget.RadioButtonPickerFragment;
+import com.android.settingslib.core.instrumentation.MetricsFeatureProvider;
+import com.android.settingslib.widget.CandidateInfo;
+import com.android.settingslib.widget.SelectorWithWidgetPreference;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class UserAppsInstallSettings extends RadioButtonPickerFragment {
+
+    private static final String INSTALL_ENABLED = "install_apps_enabled";
+    private static final String INSTALL_FIRST_PARTY_ENABLED = "install_apps_first_party_enabled";
+    private static final String INSTALL_DISABLED = "install_apps_disabled";
+    private UserRestrictions userRestrictions;
+
+    static void launch(Preference preference, int userId) {
+
+        Bundle extras = preference.getExtras();
+        extras.putInt(EXTRA_USER_ID, userId);
+
+        new SubSettingLauncher(preference.getContext())
+                .setDestination(UserAppsInstallSettings.class.getName())
+                .setSourceMetricsCategory(extras.getInt(DashboardFragment.CATEGORY,
+                        SettingsEnums.PAGE_UNKNOWN))
+                .setTitleText(preference.getTitle())
+                .setArguments(extras)
+                .launch();
+    }
+
+    private static String getCurrentInstallRestriction(UserRestrictions userRestrictions) {
+        if (userRestrictions.isSet(UserManager.DISALLOW_INSTALL_APPS)) {
+            return INSTALL_DISABLED;
+        }
+
+        if (userRestrictions.isSet(UserManager.DISALLOW_INSTALL_UNKNOWN_SOURCES)) {
+            return INSTALL_FIRST_PARTY_ENABLED;
+        }
+
+        return INSTALL_ENABLED;
+    }
+
+    static String getDescription(Context context, UserRestrictions userRestrictions) {
+        switch (getCurrentInstallRestriction(userRestrictions)) {
+            case INSTALL_ENABLED:
+                return context.getString(R.string.user_app_install_enabled);
+            case INSTALL_FIRST_PARTY_ENABLED:
+                return context.getString(R.string.user_app_install_enabled_first_party_sources);
+            case INSTALL_DISABLED:
+                return context.getString(R.string.user_app_install_disabled);
+            default:
+                throw new IllegalStateException();
+        }
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        Bundle args = requireArguments();
+        int userId = args.getInt(EXTRA_USER_ID, UserHandle.USER_NULL);
+
+        Context ctx = requireContext();
+        UserManager userManager = ctx.getSystemService(UserManager.class);
+        UserInfo userInfo = userManager.getUserInfo(userId);
+        userRestrictions = new UserRestrictions(userManager, userInfo);
+
+        super.onCreate(savedInstanceState);
+    }
+
+    @Override
+    public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
+        PreferenceScreen ps = getPreferenceManager().createPreferenceScreen(requireContext());
+        setPreferenceScreen(ps);
+    }
+
+    @Override
+    protected int getPreferenceScreenResId() {
+        return -1;
+    }
+
+    @Override
+    protected List<? extends CandidateInfo> getCandidates() {
+        Context ctx = requireContext();
+        ArrayList<CandidateInfoExtra> candidates = new ArrayList<>(3);
+        if (!userRestrictions.userInfo.isGuest()) {
+            candidates.add(new CandidateInfoExtra(ctx.getString(R.string.user_app_install_enabled),
+                    ctx.getString(R.string.user_app_install_enabled_desc),
+                    INSTALL_ENABLED, true));
+        }
+        candidates.add(new CandidateInfoExtra(ctx.getString(R.string.user_app_install_enabled_first_party_sources),
+                        ctx.getString(R.string.user_app_install_enabled_first_party_sources_desc),
+                INSTALL_FIRST_PARTY_ENABLED, true));
+        candidates.add(new CandidateInfoExtra(ctx.getString(R.string.user_app_install_disabled),
+                        ctx.getString(R.string.user_app_install_disabled_desc),
+                INSTALL_DISABLED, true));
+        return candidates;
+    }
+
+    @Override
+    public void bindPreferenceExtra(SelectorWithWidgetPreference pref, String key, CandidateInfo info,
+                                    String defaultKey, String systemDefaultKey) {
+        pref.setSingleLineTitle(false);
+
+        if (info instanceof CandidateInfoExtra) {
+            var cie = (CandidateInfoExtra) info;
+            pref.setSummary(cie.loadSummary());
+        }
+    }
+
+    @Override
+    protected String getDefaultKey() {
+        return getCurrentInstallRestriction(userRestrictions);
+    }
+
+    @Override
+    protected boolean setDefaultKey(String key) {
+        if (key == null) {
+            return false;
+        }
+
+        switch (key) {
+            case INSTALL_ENABLED:
+                userRestrictions.set(UserManager.DISALLOW_INSTALL_APPS, false);
+                userRestrictions.set(UserManager.DISALLOW_INSTALL_UNKNOWN_SOURCES, false);
+                return true;
+            case INSTALL_FIRST_PARTY_ENABLED:
+                userRestrictions.set(UserManager.DISALLOW_INSTALL_APPS, false);
+                userRestrictions.set(UserManager.DISALLOW_INSTALL_UNKNOWN_SOURCES, true);
+                return true;
+            case INSTALL_DISABLED:
+                userRestrictions.set(UserManager.DISALLOW_INSTALL_APPS, true);
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    @Override
+    public int getMetricsCategory() {
+        return requireActivity().getIntent().getIntExtra(
+                MetricsFeatureProvider.EXTRA_SOURCE_METRICS_CATEGORY, METRICS_CATEGORY_UNKNOWN);
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        updateCandidates();
+    }
+}

--- a/src/com/android/settings/users/UserDetailsSettings.java
+++ b/src/com/android/settings/users/UserDetailsSettings.java
@@ -77,7 +77,7 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
     private static final int DIALOG_CONFIRM_RESET_GUEST_AND_SWITCH_USER = 6;
 
     /** Whether to enable the app_copying fragment. */
-    private static final boolean SHOW_APP_COPYING_PREF = true;
+    private static final boolean SHOW_APP_COPYING_PREF = false;
 
     private UserManager mUserManager;
     private UserCapabilities mUserCaps;
@@ -358,6 +358,7 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
                 mPhonePref.setChecked(!mUserManager.hasUserRestriction(
                         UserManager.DISALLOW_OUTGOING_CALLS, new UserHandle(userId)));
                 mRemoveUserPref.setTitle(R.string.user_remove_user);
+                removePreference(KEY_APP_COPYING);
                 mInstallAppsPref.setChecked(mUserManager.hasUserRestriction(
                         UserManager.DISALLOW_INSTALL_APPS, new UserHandle(userId)));
             }

--- a/src/com/android/settings/users/UserDetailsSettings.java
+++ b/src/com/android/settings/users/UserDetailsSettings.java
@@ -179,7 +179,28 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
         } else if (preference == mInstallAppsPref) {
             setUserRestriction(UserManager.DISALLOW_INSTALL_APPS, !((boolean) newValue));
         } else if (preference == mInstallAppsUnknownSourcesPref) {
-            setUserRestriction(UserManager.DISALLOW_INSTALL_UNKNOWN_SOURCES, !((boolean) newValue));
+            if (mUserInfo.isGuest()) {
+                mDefaultGuestRestrictions.putBoolean(UserManager.DISALLOW_INSTALL_UNKNOWN_SOURCES, (Boolean) newValue);
+                mUserManager.setDefaultGuestRestrictions(mDefaultGuestRestrictions);
+
+                // Update the guest's restrictions, if there is a guest
+                // TODO: Maybe setDefaultGuestRestrictions() can internally just set the restrictions
+                // on any existing guest rather than do it here with multiple Binder calls.
+                List<UserInfo> users = mUserManager.getUsers(true);
+                for (UserInfo user: users) {
+                    if (user.isGuest()) {
+                        UserHandle userHandle = UserHandle.of(user.id);
+                        for (String key : mDefaultGuestRestrictions.keySet()) {
+                            mUserManager.setUserRestriction(
+                                    key, mDefaultGuestRestrictions.getBoolean(key), userHandle);
+                        }
+                    }
+                }
+            } else {
+                UserHandle userHandle = UserHandle.of(mUserInfo.id);
+                mUserManager.setUserRestriction(UserManager.DISALLOW_INSTALL_UNKNOWN_SOURCES, (Boolean) newValue,
+                        userHandle);
+            }
         }
         return true;
     }
@@ -347,7 +368,7 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
                 mRemoveUserPref.setTitle(R.string.user_remove_user);
                 mInstallAppsPref.setChecked(!mUserManager.hasUserRestriction(
                         UserManager.DISALLOW_INSTALL_APPS, new UserHandle(userId)));
-                mInstallAppsUnknownSourcesPref.setChecked(!mUserManager.hasUserRestriction(
+                mInstallAppsUnknownSourcesPref.setChecked(mUserManager.hasUserRestriction(
                         UserManager.DISALLOW_INSTALL_UNKNOWN_SOURCES, new UserHandle(userId)));
             }
             if (RestrictedLockUtilsInternal.hasBaseUserRestriction(context,

--- a/src/com/android/settings/users/UserDetailsSettings.java
+++ b/src/com/android/settings/users/UserDetailsSettings.java
@@ -76,7 +76,7 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
     private static final int DIALOG_CONFIRM_RESET_GUEST_AND_SWITCH_USER = 6;
 
     /** Whether to enable the app_copying fragment. */
-    private static final boolean SHOW_APP_COPYING_PREF = false;
+    private static final boolean SHOW_APP_COPYING_PREF = true;
 
     private UserManager mUserManager;
     private UserCapabilities mUserCaps;
@@ -328,7 +328,6 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
                 mPhonePref.setChecked(!mUserManager.hasUserRestriction(
                         UserManager.DISALLOW_OUTGOING_CALLS, new UserHandle(userId)));
                 mRemoveUserPref.setTitle(R.string.user_remove_user);
-                removePreference(KEY_APP_COPYING);
             }
             if (RestrictedLockUtilsInternal.hasBaseUserRestriction(context,
                     UserManager.DISALLOW_REMOVE_USER, UserHandle.myUserId())) {

--- a/src/com/android/settings/users/UserDetailsSettings.java
+++ b/src/com/android/settings/users/UserDetailsSettings.java
@@ -132,6 +132,7 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
         }
         mAppsInstallsPref.setSummary(UserAppsInstallSettings.getDescription(
                 requireContext(), userRestrictions));
+        mAppCopyingPref.setEnabled(!userRestrictions.isSet(UserManager.DISALLOW_INSTALL_APPS));
     }
 
     @Override

--- a/src/com/android/settings/users/UserDetailsSettings.java
+++ b/src/com/android/settings/users/UserDetailsSettings.java
@@ -65,7 +65,6 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
     private static final String KEY_APP_AND_CONTENT_ACCESS = "app_and_content_access";
     private static final String KEY_APP_COPYING = "app_copying";
     private static final String KEY_DISALLOW_INSTALL_APPS = "disallow_install_apps";
-    private static final String KEY_DISALLOW_INSTALL_APPS_UNKNOWN_SOURCES = "disallow_install_apps_unknown_sources";
 
     /** Integer extra containing the userId to manage */
     static final String EXTRA_USER_ID = "user_id";
@@ -96,7 +95,6 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
     @VisibleForTesting
     Preference mRemoveUserPref;
     private SwitchPreference mInstallAppsPref;
-    private SwitchPreference mInstallAppsUnknownSourcesPref;
 
     @VisibleForTesting
     /** The user being studied (not the user doing the studying). */
@@ -197,29 +195,6 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
             } else {
                 UserHandle userHandle = UserHandle.of(mUserInfo.id);
                 mUserManager.setUserRestriction(UserManager.DISALLOW_INSTALL_APPS, (Boolean) newValue,
-                        userHandle);
-            }
-        } else if (preference == mInstallAppsUnknownSourcesPref) {
-            if (mUserInfo.isGuest()) {
-                mDefaultGuestRestrictions.putBoolean(UserManager.DISALLOW_INSTALL_UNKNOWN_SOURCES, (Boolean) newValue);
-                mUserManager.setDefaultGuestRestrictions(mDefaultGuestRestrictions);
-
-                // Update the guest's restrictions, if there is a guest
-                // TODO: Maybe setDefaultGuestRestrictions() can internally just set the restrictions
-                // on any existing guest rather than do it here with multiple Binder calls.
-                List<UserInfo> users = mUserManager.getUsers(true);
-                for (UserInfo user: users) {
-                    if (user.isGuest()) {
-                        UserHandle userHandle = UserHandle.of(user.id);
-                        for (String key : mDefaultGuestRestrictions.keySet()) {
-                            mUserManager.setUserRestriction(
-                                    key, mDefaultGuestRestrictions.getBoolean(key), userHandle);
-                        }
-                    }
-                }
-            } else {
-                UserHandle userHandle = UserHandle.of(mUserInfo.id);
-                mUserManager.setUserRestriction(UserManager.DISALLOW_INSTALL_UNKNOWN_SOURCES, (Boolean) newValue,
                         userHandle);
             }
         }
@@ -326,7 +301,6 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
         mAppAndContentAccessPref = findPreference(KEY_APP_AND_CONTENT_ACCESS);
         mAppCopyingPref = findPreference(KEY_APP_COPYING);
         mInstallAppsPref = findPreference(KEY_DISALLOW_INSTALL_APPS);
-        mInstallAppsUnknownSourcesPref = findPreference(KEY_DISALLOW_INSTALL_APPS_UNKNOWN_SOURCES);
 
         mSwitchUserPref.setTitle(
                 context.getString(com.android.settingslib.R.string.user_switch_to_user,
@@ -346,7 +320,6 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
             removePreference(KEY_APP_AND_CONTENT_ACCESS);
             removePreference(KEY_APP_COPYING);
             removePreference(KEY_DISALLOW_INSTALL_APPS);
-            removePreference(KEY_DISALLOW_INSTALL_APPS_UNKNOWN_SOURCES);
         } else {
             if (!Utils.isVoiceCapable(context)) { // no telephony
                 removePreference(KEY_ENABLE_TELEPHONY);
@@ -381,15 +354,12 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
                     removePreference(KEY_APP_COPYING);
                 }
                 removePreference(KEY_DISALLOW_INSTALL_APPS);
-                removePreference(KEY_DISALLOW_INSTALL_APPS_UNKNOWN_SOURCES);
             } else {
                 mPhonePref.setChecked(!mUserManager.hasUserRestriction(
                         UserManager.DISALLOW_OUTGOING_CALLS, new UserHandle(userId)));
                 mRemoveUserPref.setTitle(R.string.user_remove_user);
                 mInstallAppsPref.setChecked(mUserManager.hasUserRestriction(
                         UserManager.DISALLOW_INSTALL_APPS, new UserHandle(userId)));
-                mInstallAppsUnknownSourcesPref.setChecked(mUserManager.hasUserRestriction(
-                        UserManager.DISALLOW_INSTALL_UNKNOWN_SOURCES, new UserHandle(userId)));
             }
             if (RestrictedLockUtilsInternal.hasBaseUserRestriction(context,
                     UserManager.DISALLOW_REMOVE_USER, UserHandle.myUserId())) {
@@ -401,7 +371,6 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
             mAppAndContentAccessPref.setOnPreferenceClickListener(this);
             mAppCopyingPref.setOnPreferenceClickListener(this);
             mInstallAppsPref.setOnPreferenceChangeListener(this);
-            mInstallAppsUnknownSourcesPref.setOnPreferenceChangeListener(this);
         }
     }
 

--- a/src/com/android/settings/users/UserDetailsSettings.java
+++ b/src/com/android/settings/users/UserDetailsSettings.java
@@ -65,6 +65,7 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
     private static final String KEY_APP_COPYING = "app_copying";
 
     private static final String KEY_APP_INSTALLS = "app_installs";
+    private static final String KEY_RUN_IN_BACKGROUND = "allow_run_in_background";
 
     /** Integer extra containing the userId to manage */
     static final String EXTRA_USER_ID = "user_id";
@@ -95,6 +96,7 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
     @VisibleForTesting
     Preference mRemoveUserPref;
     Preference mAppsInstallsPref;
+    private SwitchPreference mRunInBackgroundPref;
 
     @VisibleForTesting
     /** The user being studied (not the user doing the studying). */
@@ -172,12 +174,18 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
 
     @Override
     public boolean onPreferenceChange(Preference preference, Object newValue) {
-        if (Boolean.TRUE.equals(newValue)) {
-            showDialog(mUserInfo.isGuest() ? DIALOG_CONFIRM_ENABLE_CALLING
-                    : DIALOG_CONFIRM_ENABLE_CALLING_AND_SMS);
-            return false;
+        if (preference == mPhonePref) {
+            if (Boolean.TRUE.equals(newValue)) {
+                showDialog(mUserInfo.isGuest() ? DIALOG_CONFIRM_ENABLE_CALLING
+                        : DIALOG_CONFIRM_ENABLE_CALLING_AND_SMS);
+                return false;
+            }
+            enableCallsAndSms(false);
         }
-        enableCallsAndSms(false);
+        if (preference == mRunInBackgroundPref) {
+            userRestrictions.set(UserManager.DISALLOW_RUN_IN_BACKGROUND, !((boolean) newValue));
+            return true;
+        }
         return true;
     }
 
@@ -282,6 +290,7 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
         mAppAndContentAccessPref = findPreference(KEY_APP_AND_CONTENT_ACCESS);
         mAppCopyingPref = findPreference(KEY_APP_COPYING);
         mAppsInstallsPref = findPreference(KEY_APP_INSTALLS);
+        mRunInBackgroundPref = findPreference(KEY_RUN_IN_BACKGROUND);
 
         mSwitchUserPref.setTitle(
                 context.getString(com.android.settingslib.R.string.user_switch_to_user,
@@ -301,6 +310,7 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
             removePreference(KEY_APP_AND_CONTENT_ACCESS);
             removePreference(KEY_APP_COPYING);
             removePreference(KEY_APP_INSTALLS);
+            removePreference(KEY_RUN_IN_BACKGROUND);
         } else {
             if (!Utils.isVoiceCapable(context)) { // no telephony
                 removePreference(KEY_ENABLE_TELEPHONY);
@@ -332,8 +342,11 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
                 if (!SHOW_APP_COPYING_PREF) {
                     removePreference(KEY_APP_COPYING);
                 }
+                removePreference(KEY_RUN_IN_BACKGROUND);
             } else {
                 mRemoveUserPref.setTitle(R.string.user_remove_user);
+                mRunInBackgroundPref.setChecked(!userRestrictions.isSet(
+                        UserManager.DISALLOW_RUN_IN_BACKGROUND));
             }
             if (RestrictedLockUtilsInternal.hasBaseUserRestriction(context,
                     UserManager.DISALLOW_REMOVE_USER, UserHandle.myUserId())) {
@@ -345,6 +358,7 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
             mPhonePref.setOnPreferenceChangeListener(this);
             mAppAndContentAccessPref.setOnPreferenceClickListener(this);
             mAppCopyingPref.setOnPreferenceClickListener(this);
+            mRunInBackgroundPref.setOnPreferenceChangeListener(this);
         }
     }
 

--- a/src/com/android/settings/users/UserDetailsSettings.java
+++ b/src/com/android/settings/users/UserDetailsSettings.java
@@ -66,7 +66,6 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
     private static final String KEY_APP_COPYING = "app_copying";
     private static final String KEY_DISALLOW_INSTALL_APPS = "disallow_install_apps";
     private static final String KEY_DISALLOW_INSTALL_APPS_UNKNOWN_SOURCES = "disallow_install_apps_unknown_sources";
-    private static final String KEY_DISALLOW_RUN_IN_BACKGROUND = "disallow_run_in_background";
 
     /** Integer extra containing the userId to manage */
     static final String EXTRA_USER_ID = "user_id";
@@ -98,7 +97,6 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
     Preference mRemoveUserPref;
     private SwitchPreference mInstallAppsPref;
     private SwitchPreference mInstallAppsUnknownSourcesPref;
-    private SwitchPreference mRunInBackgroundPref;
 
     @VisibleForTesting
     /** The user being studied (not the user doing the studying). */
@@ -182,8 +180,6 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
             setUserRestriction(UserManager.DISALLOW_INSTALL_APPS, !((boolean) newValue));
         } else if (preference == mInstallAppsUnknownSourcesPref) {
             setUserRestriction(UserManager.DISALLOW_INSTALL_UNKNOWN_SOURCES, !((boolean) newValue));
-        } else if (preference == mRunInBackgroundPref) {
-            setUserRestriction(UserManager.DISALLOW_RUN_IN_BACKGROUND, !((boolean) newValue));
         }
         return true;
     }
@@ -289,7 +285,6 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
         mAppCopyingPref = findPreference(KEY_APP_COPYING);
         mInstallAppsPref = findPreference(KEY_DISALLOW_INSTALL_APPS);
         mInstallAppsUnknownSourcesPref = findPreference(KEY_DISALLOW_INSTALL_APPS_UNKNOWN_SOURCES);
-        mRunInBackgroundPref = findPreference(KEY_DISALLOW_RUN_IN_BACKGROUND);
 
         mSwitchUserPref.setTitle(
                 context.getString(com.android.settingslib.R.string.user_switch_to_user,
@@ -310,7 +305,6 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
             removePreference(KEY_APP_COPYING);
             removePreference(KEY_DISALLOW_INSTALL_APPS);
             removePreference(KEY_DISALLOW_INSTALL_APPS_UNKNOWN_SOURCES);
-            removePreference(KEY_DISALLOW_RUN_IN_BACKGROUND);
         } else {
             if (!Utils.isVoiceCapable(context)) { // no telephony
                 removePreference(KEY_ENABLE_TELEPHONY);
@@ -347,7 +341,6 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
                     removePreference(KEY_APP_COPYING);
                 }
                 removePreference(KEY_DISALLOW_INSTALL_APPS_UNKNOWN_SOURCES);
-                removePreference(KEY_DISALLOW_RUN_IN_BACKGROUND);
             } else {
                 mPhonePref.setChecked(!mUserManager.hasUserRestriction(
                         UserManager.DISALLOW_OUTGOING_CALLS, new UserHandle(userId)));
@@ -356,8 +349,6 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
                         UserManager.DISALLOW_INSTALL_APPS, new UserHandle(userId)));
                 mInstallAppsUnknownSourcesPref.setChecked(!mUserManager.hasUserRestriction(
                         UserManager.DISALLOW_INSTALL_UNKNOWN_SOURCES, new UserHandle(userId)));
-                mRunInBackgroundPref.setChecked(!mUserManager.hasUserRestriction(
-                        UserManager.DISALLOW_RUN_IN_BACKGROUND, new UserHandle(userId)));
             }
             if (RestrictedLockUtilsInternal.hasBaseUserRestriction(context,
                     UserManager.DISALLOW_REMOVE_USER, UserHandle.myUserId())) {
@@ -370,7 +361,6 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
             mAppCopyingPref.setOnPreferenceClickListener(this);
             mInstallAppsPref.setOnPreferenceChangeListener(this);
             mInstallAppsUnknownSourcesPref.setOnPreferenceChangeListener(this);
-            mRunInBackgroundPref.setOnPreferenceChangeListener(this);
         }
     }
 

--- a/src/com/android/settings/users/UserDetailsSettings.java
+++ b/src/com/android/settings/users/UserDetailsSettings.java
@@ -533,25 +533,4 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
         //  return true so there will be no setup prompt dialog shown to the user anymore.
         return isSecondaryUser(mUserInfo) && !mUserInfo.isInitialized();
     }
-
-    private void setUserRestriction(String userManagerKey, boolean enabled) {
-        if (mUserInfo.isGuest()) {
-            mDefaultGuestRestrictions.putBoolean(userManagerKey, enabled);
-            mUserManager.setDefaultGuestRestrictions(mDefaultGuestRestrictions);
-
-            List<UserInfo> users = mUserManager.getUsers(true);
-            for (UserInfo user: users) {
-                if (user.isGuest()) {
-                    UserHandle userHandle = UserHandle.of(user.id);
-                    for (String key : mDefaultGuestRestrictions.keySet()) {
-                        mUserManager.setUserRestriction(
-                                key, mDefaultGuestRestrictions.getBoolean(key), userHandle);
-                    }
-                }
-            }
-        } else {
-            UserHandle userHandle = UserHandle.of(mUserInfo.id);
-            mUserManager.setUserRestriction(userManagerKey, enabled, userHandle);
-        }
-    }
 }

--- a/src/com/android/settings/users/UserDetailsSettings.java
+++ b/src/com/android/settings/users/UserDetailsSettings.java
@@ -42,7 +42,6 @@ import com.android.settingslib.RestrictedLockUtils;
 import com.android.settingslib.RestrictedLockUtilsInternal;
 import com.android.settingslib.RestrictedPreference;
 
-import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -64,6 +63,8 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
     private static final String KEY_REMOVE_USER = "remove_user";
     private static final String KEY_APP_AND_CONTENT_ACCESS = "app_and_content_access";
     private static final String KEY_APP_COPYING = "app_copying";
+
+    private static final String KEY_APP_INSTALLS = "app_installs";
 
     /** Integer extra containing the userId to manage */
     static final String EXTRA_USER_ID = "user_id";
@@ -93,6 +94,7 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
     Preference mAppCopyingPref;
     @VisibleForTesting
     Preference mRemoveUserPref;
+    Preference mAppsInstallsPref;
 
     @VisibleForTesting
     /** The user being studied (not the user doing the studying). */
@@ -126,6 +128,8 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
         if (mGuestUserAutoCreated) {
             mRemoveUserPref.setEnabled((mUserInfo.flags & UserInfo.FLAG_INITIALIZED) != 0);
         }
+        mAppsInstallsPref.setSummary(UserAppsInstallSettings.getDescription(
+                requireContext(), userRestrictions));
     }
 
     @Override
@@ -158,6 +162,9 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
             return true;
         } else if (preference == mAppCopyingPref) {
             openAppCopyingScreen();
+            return true;
+        } else if (preference == mAppsInstallsPref) {
+            UserAppsInstallSettings.launch(preference, mUserInfo.id);
             return true;
         }
         return false;
@@ -274,6 +281,7 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
         mRemoveUserPref = findPreference(KEY_REMOVE_USER);
         mAppAndContentAccessPref = findPreference(KEY_APP_AND_CONTENT_ACCESS);
         mAppCopyingPref = findPreference(KEY_APP_COPYING);
+        mAppsInstallsPref = findPreference(KEY_APP_INSTALLS);
 
         mSwitchUserPref.setTitle(
                 context.getString(com.android.settingslib.R.string.user_switch_to_user,
@@ -292,6 +300,7 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
             removePreference(KEY_REMOVE_USER);
             removePreference(KEY_APP_AND_CONTENT_ACCESS);
             removePreference(KEY_APP_COPYING);
+            removePreference(KEY_APP_INSTALLS);
         } else {
             if (!Utils.isVoiceCapable(context)) { // no telephony
                 removePreference(KEY_ENABLE_TELEPHONY);
@@ -332,6 +341,7 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
             }
 
             mRemoveUserPref.setOnPreferenceClickListener(this);
+            mAppsInstallsPref.setOnPreferenceClickListener(this);
             mPhonePref.setOnPreferenceChangeListener(this);
             mAppAndContentAccessPref.setOnPreferenceClickListener(this);
             mAppCopyingPref.setOnPreferenceClickListener(this);

--- a/src/com/android/settings/users/UserDetailsSettings.java
+++ b/src/com/android/settings/users/UserDetailsSettings.java
@@ -64,7 +64,6 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
     private static final String KEY_REMOVE_USER = "remove_user";
     private static final String KEY_APP_AND_CONTENT_ACCESS = "app_and_content_access";
     private static final String KEY_APP_COPYING = "app_copying";
-    private static final String KEY_DISALLOW_INSTALL_APPS = "disallow_install_apps";
 
     /** Integer extra containing the userId to manage */
     static final String EXTRA_USER_ID = "user_id";
@@ -94,7 +93,6 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
     Preference mAppCopyingPref;
     @VisibleForTesting
     Preference mRemoveUserPref;
-    private SwitchPreference mInstallAppsPref;
 
     @VisibleForTesting
     /** The user being studied (not the user doing the studying). */
@@ -167,37 +165,12 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
 
     @Override
     public boolean onPreferenceChange(Preference preference, Object newValue) {
-        if (preference == mPhonePref) {
-            if (Boolean.TRUE.equals(newValue)) {
-                showDialog(mUserInfo.isGuest() ? DIALOG_CONFIRM_ENABLE_CALLING
-                        : DIALOG_CONFIRM_ENABLE_CALLING_AND_SMS);
-                return false;
-            }
-            enableCallsAndSms(false);
-        } else if (preference == mInstallAppsPref) {
-            if (mUserInfo.isGuest()) {
-                mDefaultGuestRestrictions.putBoolean(UserManager.DISALLOW_INSTALL_APPS, (Boolean) newValue);
-                mUserManager.setDefaultGuestRestrictions(mDefaultGuestRestrictions);
-
-                // Update the guest's restrictions, if there is a guest
-                // TODO: Maybe setDefaultGuestRestrictions() can internally just set the restrictions
-                // on any existing guest rather than do it here with multiple Binder calls.
-                List<UserInfo> users = mUserManager.getUsers(true);
-                for (UserInfo user: users) {
-                    if (user.isGuest()) {
-                        UserHandle userHandle = UserHandle.of(user.id);
-                        for (String key : mDefaultGuestRestrictions.keySet()) {
-                            mUserManager.setUserRestriction(
-                                    key, mDefaultGuestRestrictions.getBoolean(key), userHandle);
-                        }
-                    }
-                }
-            } else {
-                UserHandle userHandle = UserHandle.of(mUserInfo.id);
-                mUserManager.setUserRestriction(UserManager.DISALLOW_INSTALL_APPS, (Boolean) newValue,
-                        userHandle);
-            }
+        if (Boolean.TRUE.equals(newValue)) {
+            showDialog(mUserInfo.isGuest() ? DIALOG_CONFIRM_ENABLE_CALLING
+                    : DIALOG_CONFIRM_ENABLE_CALLING_AND_SMS);
+            return false;
         }
+        enableCallsAndSms(false);
         return true;
     }
 
@@ -300,7 +273,6 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
         mRemoveUserPref = findPreference(KEY_REMOVE_USER);
         mAppAndContentAccessPref = findPreference(KEY_APP_AND_CONTENT_ACCESS);
         mAppCopyingPref = findPreference(KEY_APP_COPYING);
-        mInstallAppsPref = findPreference(KEY_DISALLOW_INSTALL_APPS);
 
         mSwitchUserPref.setTitle(
                 context.getString(com.android.settingslib.R.string.user_switch_to_user,
@@ -319,7 +291,6 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
             removePreference(KEY_REMOVE_USER);
             removePreference(KEY_APP_AND_CONTENT_ACCESS);
             removePreference(KEY_APP_COPYING);
-            removePreference(KEY_DISALLOW_INSTALL_APPS);
         } else {
             if (!Utils.isVoiceCapable(context)) { // no telephony
                 removePreference(KEY_ENABLE_TELEPHONY);
@@ -353,14 +324,11 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
                 if (!SHOW_APP_COPYING_PREF) {
                     removePreference(KEY_APP_COPYING);
                 }
-                removePreference(KEY_DISALLOW_INSTALL_APPS);
             } else {
                 mPhonePref.setChecked(!mUserManager.hasUserRestriction(
                         UserManager.DISALLOW_OUTGOING_CALLS, new UserHandle(userId)));
                 mRemoveUserPref.setTitle(R.string.user_remove_user);
                 removePreference(KEY_APP_COPYING);
-                mInstallAppsPref.setChecked(mUserManager.hasUserRestriction(
-                        UserManager.DISALLOW_INSTALL_APPS, new UserHandle(userId)));
             }
             if (RestrictedLockUtilsInternal.hasBaseUserRestriction(context,
                     UserManager.DISALLOW_REMOVE_USER, UserHandle.myUserId())) {
@@ -371,7 +339,6 @@ public class UserDetailsSettings extends SettingsPreferenceFragment
             mPhonePref.setOnPreferenceChangeListener(this);
             mAppAndContentAccessPref.setOnPreferenceClickListener(this);
             mAppCopyingPref.setOnPreferenceClickListener(this);
-            mInstallAppsPref.setOnPreferenceChangeListener(this);
         }
     }
 

--- a/src/com/android/settings/users/UserRestrictions.java
+++ b/src/com/android/settings/users/UserRestrictions.java
@@ -1,0 +1,49 @@
+package com.android.settings.users;
+
+import android.content.pm.UserInfo;
+import android.os.Bundle;
+import android.os.UserHandle;
+import android.os.UserManager;
+
+import java.util.List;
+
+final class UserRestrictions {
+
+    final UserManager userManager;
+    final UserInfo userInfo;
+
+    UserRestrictions(UserManager userManager, UserInfo userInfo) {
+        this.userManager = userManager;
+        this.userInfo = userInfo;
+    }
+
+    boolean isSet(String restrictionKey) {
+        final boolean isSetFromUser = userManager.hasUserRestriction(restrictionKey, userInfo.getUserHandle());
+        if (userInfo.isGuest()) {
+            return isSetFromUser || userManager.getDefaultGuestRestrictions().getBoolean(restrictionKey);
+        }
+
+        return isSetFromUser;
+    }
+
+    void set(String restrictionKey, boolean enableRestriction) {
+        Bundle defaultGuestRestrictions = userManager.getDefaultGuestRestrictions();
+        if (userInfo.isGuest()) {
+            defaultGuestRestrictions.putBoolean(restrictionKey, enableRestriction);
+            userManager.setDefaultGuestRestrictions(defaultGuestRestrictions);
+
+            List<UserInfo> users = userManager.getAliveUsers();
+            for (UserInfo user : users) {
+                if (user.isGuest()) {
+                    UserHandle userHandle = userInfo.getUserHandle();
+                    for (String key : defaultGuestRestrictions.keySet()) {
+                        userManager.setUserRestriction(
+                                key, defaultGuestRestrictions.getBoolean(key), userHandle);
+                    }
+                }
+            }
+        } else {
+            userManager.setUserRestriction(restrictionKey, enableRestriction, userInfo.getUserHandle());
+        }
+    }
+}


### PR DESCRIPTION
Changes from previous UserManager settings implementation:

- Move run in background settings right below switch user settings.
- Unify app install settings into three options for non-guest users, and two for guest users. This has also been moved right above the install available apps settings.
- Helper class for fetching and setting UserManager restrictions exposed to users.
- Remove incorrect caching of default guest' user manager restrictions.