### PR TITLE
hide the "Storage manager" toggle from Storage screen

### DIFF
--- a/res/values/config.xml
+++ b/res/values/config.xml
@@ -564,7 +564,7 @@
     <string name="config_documents_and_other_storage_category_uri" translatable="false">content://com.android.providers.media.documents/root/documents_root</string>
 
     <!-- Whether to show Smart Storage toggle -->
-    <bool name="config_show_smart_storage_toggle">true</bool>
+    <bool name="config_show_smart_storage_toggle">false</bool>
 
     <!-- Whether to support large screen -->
     <bool name="config_supported_large_screen">false</bool>


### PR DESCRIPTION
"Storage manager" is supposed to automatically remove backed up photos and videos. This functionality is not implemented in AOSP, i.e. this toggle doesn't actually work.