### PR TITLE
Battery share feature implementation for android 14 

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -101,6 +101,7 @@ android_library {
         "Settings-change-ids",
         "androidx.room_room-runtime",
         "SystemUIUnfoldLib",
+        "ReverseWirelessCharging"
     ],
 
     plugins: ["androidx.room_room-compiler-plugin"],

--- a/src/com/android/settings/display/BatterySharePreferenceController.java
+++ b/src/com/android/settings/display/BatterySharePreferenceController.java
@@ -12,12 +12,13 @@ import androidx.preference.PreferenceScreen;
 import androidx.preference.SwitchPreference;
 
 import com.android.internal.R;
-import com.android.internal.batteryShare.ReverseWirelessCharger;
 import com.android.settings.core.BasePreferenceController;
 import com.android.settings.core.PreferenceControllerMixin;
 import com.android.settingslib.core.lifecycle.LifecycleObserver;
 import com.android.settingslib.core.lifecycle.events.OnStart;
 import com.android.settingslib.core.lifecycle.events.OnStop;
+
+import vendor.google.wireless_charger.ReverseWirelessCharger;
 
 public class BatterySharePreferenceController extends BasePreferenceController implements
         PreferenceControllerMixin, Preference.OnPreferenceChangeListener, LifecycleObserver,


### PR DESCRIPTION
depends on [#415](https://github.com/GrapheneOS/platform_frameworks_base/pull/415)