### PR TITLE
bugfix: always initialize tethering preferences

### DIFF
--- a/src/com/android/settings/network/tether/TetherSettings.java
+++ b/src/com/android/settings/network/tether/TetherSettings.java
@@ -149,11 +149,11 @@ public class TetherSettings extends RestrictedSettingsFragment
     public void onCreate(Bundle icicle) {
         super.onCreate(icicle);
         setIfOnlyAvailableForAdmins(true);
+        addPreferencesFromResource(R.xml.tether_prefs);
         if (isUiRestricted()) {
             return;
         }
 
-        addPreferencesFromResource(R.xml.tether_prefs);
         mContext = getContext();
         mDataSaverBackend = new DataSaverBackend(mContext);
         mDataSaverEnabled = mDataSaverBackend.isDataSaverEnabled();


### PR DESCRIPTION
This is necessary to properly remove the tethering settings and indicate its unavailability in non-admin users.