### PR TITLE
add config for setupdesign and setupcompat libraries

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -4962,6 +4962,12 @@
                        android:value="UsageStats"/>
         </activity-alias>
 
+        <provider
+            android:name="com.android.settings.SetupDesignConfigProvider"
+            android:authorities="com.google.android.setupwizard.partner"
+            android:directBootAware="true"
+            android:exported="true" />
+
         <!-- [b/197780098] Disable eager initialization of Jetpack libraries. -->
         <provider
             android:name="androidx.startup.InitializationProvider"

--- a/src/com/android/settings/SetupDesignConfigProvider.java
+++ b/src/com/android/settings/SetupDesignConfigProvider.java
@@ -1,0 +1,75 @@
+package com.android.settings;
+
+import android.content.ContentProvider;
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Bundle;
+import android.provider.Settings;
+import android.text.TextUtils;
+import android.util.Log;
+
+public class SetupDesignConfigProvider extends ContentProvider {
+    private static final String TAG = SetupDesignConfigProvider.class.getSimpleName();
+
+    @Override
+    public boolean onCreate() {
+        return true;
+    }
+
+    @Override
+    public Bundle call(String method, String arg, Bundle extras) {
+        Log.d(TAG, "method: " + method + ", caller: " + getCallingPackage());
+
+        var res = new Bundle();
+        switch (method) {
+            case "suwDefaultThemeString" ->
+                res.putString(method, "glif_v4_light");
+
+            case
+                    "applyGlifThemeControlledTransition",
+                    "isDynamicColorEnabled",
+                    "isEmbeddedActivityOnePaneEnabled",
+                    "isFullDynamicColorEnabled",
+                    "IsMaterialYouStyleEnabled",
+                    "isNeutralButtonStyleEnabled",
+                    "isSuwDayNightEnabled" ->
+                res.putBoolean(method, true);
+
+            case "getDeviceName" -> {
+                String name = Settings.Global.getString(getContext().getContentResolver(), Settings.Global.DEVICE_NAME);
+                if (TextUtils.isEmpty(name)) {
+                    name = Build.MODEL;
+                }
+                res.putCharSequence(method, name);
+            }
+        }
+        return res;
+    }
+
+    @Override
+    public Cursor query(Uri uri, String[] strings, String s, String[] strings1, String s1) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getType(Uri uri) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Uri insert(Uri uri, ContentValues contentValues) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int delete(Uri uri, String s, String[] strings) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int update(Uri uri, ContentValues contentValues, String s, String[] strings) {
+        throw new UnsupportedOperationException();
+    }
+}


### PR DESCRIPTION
These libraries are used by several AOSP components and proprietary Google apps for creating consistent SetupWizard-like UIs.

For more info, see methods that call "com.google.android.setupwizard.partner" ContentProvider in external/setupcompat and external/setupdesign.