### PR TITLE
enable "Confirm SIM deletion" by default

### DIFF
--- a/res/values/config.xml
+++ b/res/values/config.xml
@@ -260,7 +260,7 @@
     </string>
 
     <!-- Whether the confirmation for sim deletion is defaulted to be on or off-->
-    <bool name="config_sim_deletion_confirmation_default_on">false</bool>
+    <bool name="config_sim_deletion_confirmation_default_on">true</bool>
 
     <!-- Package Installer package name -->
     <string name="config_package_installer_package_name" translatable="false">


### PR DESCRIPTION
Tested manually on bluejay. closes [#3167 ](https://github.com/GrapheneOS/os-issue-tracker/issues/3167)