### PR TITLE
add support for "SPA" UI rewrites

### DIFF
--- a/src/com/android/settings/applications/appinfo/AppExtendedVaSpace.kt
+++ b/src/com/android/settings/applications/appinfo/AppExtendedVaSpace.kt
@@ -1,10 +1,15 @@
 package com.android.settings.applications.appinfo
 
 import android.content.Context
+import android.content.pm.ApplicationInfo
 import android.ext.settings.app.AppSwitch
 import android.ext.settings.app.AswUseExtendedVaSpace
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
 import com.android.settings.R
+import com.android.settings.core.BasePreferenceController
 import com.android.settings.ext.ExtSettingControllerHelper
+import com.android.settings.spa.app.appinfo.AswPreference
 import com.android.settingslib.widget.FooterPreference
 
 class AswAdapterUseExtendedVaSpace(ctx: Context) : AswAdapter<AswUseExtendedVaSpace>(ctx) {
@@ -12,6 +17,8 @@ class AswAdapterUseExtendedVaSpace(ctx: Context) : AswAdapter<AswUseExtendedVaSp
     override fun getAppSwitch() = AswUseExtendedVaSpace.I
 
     override fun getAswTitle() = getText(R.string.aep_ext_va_space)
+
+    override fun getDetailFragmentClass() = AppExtendedVaSpaceFragment::class
 }
 
 class AppExtendedVaSpacePrefController(ctx: Context, key: String) :
@@ -20,6 +27,16 @@ class AppExtendedVaSpacePrefController(ctx: Context, key: String) :
     override fun getDetailFragmentClass() = AppExtendedVaSpaceFragment::class.java
 
     override fun getAvailabilityStatus() = ExtSettingControllerHelper.getDevModeSettingAvailability(mContext)
+}
+
+@Composable
+fun AppExtendedVaSpacePreference(app: ApplicationInfo) {
+    val context = LocalContext.current
+    if (ExtSettingControllerHelper.getDevModeSettingAvailability(context) != BasePreferenceController.AVAILABLE) {
+        return
+    }
+
+    AswPreference(context, app, AswAdapterUseExtendedVaSpace(context))
 }
 
 class AppExtendedVaSpaceFragment : AswExploitProtectionFragment<AswUseExtendedVaSpace>() {

--- a/src/com/android/settings/applications/appinfo/AppHardenedMalloc.kt
+++ b/src/com/android/settings/applications/appinfo/AppHardenedMalloc.kt
@@ -1,9 +1,13 @@
 package com.android.settings.applications.appinfo
 
 import android.content.Context
+import android.content.pm.ApplicationInfo
 import android.ext.settings.app.AppSwitch
 import android.ext.settings.app.AswUseHardenedMalloc
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
 import com.android.settings.R
+import com.android.settings.spa.app.appinfo.AswPreference
 import com.android.settingslib.widget.FooterPreference
 
 class AswAdapterUseHardenedMalloc(ctx: Context) : AswAdapter<AswUseHardenedMalloc>(ctx) {
@@ -11,12 +15,20 @@ class AswAdapterUseHardenedMalloc(ctx: Context) : AswAdapter<AswUseHardenedMallo
     override fun getAppSwitch() = AswUseHardenedMalloc.I
 
     override fun getAswTitle() = getText(R.string.aep_hmalloc)
+
+    override fun getDetailFragmentClass() = AppHardenedMallocFragment::class
 }
 
 class AppHardenedMallocPrefController(ctx: Context, key: String) :
         AswPrefController<AswUseHardenedMalloc>(ctx, key, AswAdapterUseHardenedMalloc(ctx)) {
 
     override fun getDetailFragmentClass() = AppHardenedMallocFragment::class.java
+}
+
+@Composable
+fun AppHardenedMallocPreference(app: ApplicationInfo) {
+    val context = LocalContext.current
+    AswPreference(context, app, AswAdapterUseHardenedMalloc(context))
 }
 
 class AppHardenedMallocFragment : AswExploitProtectionFragment<AswUseHardenedMalloc>() {

--- a/src/com/android/settings/applications/appinfo/AppMemoryTagging.kt
+++ b/src/com/android/settings/applications/appinfo/AppMemoryTagging.kt
@@ -1,10 +1,14 @@
 package com.android.settings.applications.appinfo
 
 import android.content.Context
-import android.ext.settings.app.AswUseMemoryTagging
+import android.content.pm.ApplicationInfo
 import android.ext.settings.app.AppSwitch
+import android.ext.settings.app.AswUseMemoryTagging
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
 import com.android.internal.os.Zygote
 import com.android.settings.R
+import com.android.settings.spa.app.appinfo.AswPreference
 import com.android.settingslib.widget.FooterPreference
 
 class AswAdapterUseMemoryTagging(ctx: Context) : AswAdapter<AswUseMemoryTagging>(ctx) {
@@ -12,15 +16,28 @@ class AswAdapterUseMemoryTagging(ctx: Context) : AswAdapter<AswUseMemoryTagging>
     override fun getAppSwitch() = AswUseMemoryTagging.I
 
     override fun getAswTitle() = getText(R.string.aep_memtag)
+
+    override fun getDetailFragmentClass() = AppMemtagFragment::class
 }
+
+private val isMemoryTaggingSupported = Zygote.nativeSupportsMemoryTagging()
 
 class AppMemtagPrefController(ctx: Context, key: String) :
         AswPrefController<AswUseMemoryTagging>(ctx, key, AswAdapterUseMemoryTagging(ctx)) {
 
     override fun getDetailFragmentClass() = AppMemtagFragment::class.java
 
-    private val isSupported = Zygote.nativeSupportsMemoryTagging()
-    override fun getAvailabilityStatus() = if (isSupported) AVAILABLE else UNSUPPORTED_ON_DEVICE
+    override fun getAvailabilityStatus() = if (isMemoryTaggingSupported) AVAILABLE else UNSUPPORTED_ON_DEVICE
+}
+
+@Composable
+fun AppMemtagPreference(app: ApplicationInfo) {
+    if (!isMemoryTaggingSupported) {
+        return
+    }
+
+    val context = LocalContext.current
+    AswPreference(context, app, AswAdapterUseMemoryTagging(context))
 }
 
 class AppMemtagFragment : AswExploitProtectionFragment<AswUseMemoryTagging>() {

--- a/src/com/android/settings/applications/appinfo/AppNativeDebugging.kt
+++ b/src/com/android/settings/applications/appinfo/AppNativeDebugging.kt
@@ -1,9 +1,13 @@
 package com.android.settings.applications.appinfo
 
 import android.content.Context
-import android.ext.settings.app.AswDenyNativeDebug
+import android.content.pm.ApplicationInfo
 import android.ext.settings.app.AppSwitch
+import android.ext.settings.app.AswDenyNativeDebug
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
 import com.android.settings.R
+import com.android.settings.spa.app.appinfo.AswPreference
 import com.android.settingslib.widget.FooterPreference
 
 class AswAdapterNativeDebugging(ctx: Context) : AswAdapter<AswDenyNativeDebug>(ctx) {
@@ -14,12 +18,20 @@ class AswAdapterNativeDebugging(ctx: Context) : AswAdapter<AswDenyNativeDebug>(c
 
     override fun getOnTitle() = getText(R.string.aep_blocked)
     override fun getOffTitle() = getText(R.string.aep_allowed)
+
+    override fun getDetailFragmentClass() = AppNativeDebuggingFragment::class
 }
 
 class AppNativeDebuggingPrefController(ctx: Context, key: String) :
         AswPrefController<AswDenyNativeDebug>(ctx, key, AswAdapterNativeDebugging(ctx)) {
 
     override fun getDetailFragmentClass() = AppNativeDebuggingFragment::class.java
+}
+
+@Composable
+fun AppNativeDebuggingPreference(app: ApplicationInfo) {
+    val context = LocalContext.current
+    AswPreference(context, app, AswAdapterNativeDebugging(context))
 }
 
 class AppNativeDebuggingFragment : AswExploitProtectionFragment<AswDenyNativeDebug>() {

--- a/src/com/android/settings/applications/appinfo/AswAdapter.kt
+++ b/src/com/android/settings/applications/appinfo/AswAdapter.kt
@@ -6,6 +6,8 @@ import android.content.pm.GosPackageState
 import android.ext.settings.app.AppSwitch
 import androidx.annotation.StringRes
 import com.android.settings.R
+import com.android.settings.SettingsPreferenceFragment
+import kotlin.reflect.KClass
 
 abstract class AswAdapter<T : AppSwitch>(val context: Context, val userId: Int = context.userId) {
     abstract fun getAppSwitch(): T
@@ -35,4 +37,6 @@ abstract class AswAdapter<T : AppSwitch>(val context: Context, val userId: Int =
     protected fun getText(@StringRes id: Int): CharSequence = context.getText(id)
 
     protected fun getString(@StringRes id: Int): String = context.getString(id)
+
+    abstract fun getDetailFragmentClass(): KClass<out SettingsPreferenceFragment>
 }

--- a/src/com/android/settings/spa/app/AppUtil.kt
+++ b/src/com/android/settings/spa/app/AppUtil.kt
@@ -37,6 +37,7 @@ fun Context.startUninstallActivity(
 
     val intent = Intent(Intent.ACTION_UNINSTALL_PACKAGE, packageUri).apply {
         putExtra(Intent.EXTRA_UNINSTALL_ALL_USERS, forAllUsers)
+        putExtra(Intent.EXTRA_UNINSTALL_SHOW_MORE_OPTIONS_BUTTON, false)
     }
     startActivityAsUser(intent, userHandle)
 }

--- a/src/com/android/settings/spa/app/appinfo/AppContactScopesPreference.kt
+++ b/src/com/android/settings/spa/app/appinfo/AppContactScopesPreference.kt
@@ -1,0 +1,29 @@
+package com.android.settings.spa.app.appinfo
+
+import android.content.pm.ApplicationInfo
+import android.content.pm.GosPackageState
+import android.ext.cscopes.ContactScopesApi
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import com.android.settings.R
+import com.android.settingslib.spa.widget.preference.Preference
+import com.android.settingslib.spa.widget.preference.PreferenceModel
+
+@Composable
+fun AppContactScopesPreference(app: ApplicationInfo) {
+    val pkgName = app.packageName
+    if (GosPackageState.get(pkgName)?.hasFlags(GosPackageState.FLAG_CONTACT_SCOPES_ENABLED) != true) {
+        return
+    }
+
+    val context = LocalContext.current
+
+    Preference(object : PreferenceModel {
+        override val title = stringResource(R.string.contact_scopes)
+        override val onClick = {
+            val intent = ContactScopesApi.createConfigActivityIntent(pkgName)
+            context.startActivity(intent)
+        }
+    })
+}

--- a/src/com/android/settings/spa/app/appinfo/AppDisableButton.kt
+++ b/src/com/android/settings/spa/app/appinfo/AppDisableButton.kt
@@ -31,6 +31,7 @@ import com.android.settingslib.spa.widget.dialog.AlertDialogButton
 import com.android.settingslib.spa.widget.dialog.rememberAlertDialogPresenter
 import com.android.settingslib.spaprivileged.framework.common.devicePolicyManager
 import com.android.settingslib.spaprivileged.framework.common.userManager
+import com.android.settingslib.spaprivileged.model.app.installed
 import com.android.settingslib.spaprivileged.model.app.isDisabledUntilUsed
 import com.android.settingslib.Utils as SettingsLibUtils
 
@@ -48,7 +49,7 @@ class AppDisableButton(
 
     @Composable
     fun getActionButton(app: ApplicationInfo): ActionButton? {
-        if (!app.isSystemApp) return null
+        if (!app.installed) return null
 
         return when {
             app.enabled && !app.isDisabledUntilUsed -> {
@@ -63,6 +64,7 @@ class AppDisableButton(
      * Gets whether a package can be disabled.
      */
     private fun ApplicationInfo.canBeDisabled(): Boolean = when {
+        !isSystemApp -> true
         // Try to prevent the user from bricking their phone by not allowing disabling of apps
         // signed with the system certificate.
         isSignedWithPlatformKey -> false
@@ -98,7 +100,9 @@ class AppDisableButton(
         ) {
             // Currently we apply the same device policy for both the uninstallation and disable
             // button.
-            if (!appButtonRepository.isUninstallBlockedByAdmin(app)) {
+            if (!app.isSystemApp) {
+                packageInfoPresenter.disable()
+            } else if (!appButtonRepository.isUninstallBlockedByAdmin(app)) {
                 dialogPresenter.open()
             }
         }

--- a/src/com/android/settings/spa/app/appinfo/AppExploitProtectionCompatModeSwitchPreference.kt
+++ b/src/com/android/settings/spa/app/appinfo/AppExploitProtectionCompatModeSwitchPreference.kt
@@ -1,0 +1,61 @@
+package com.android.settings.spa.app.appinfo
+
+import android.content.pm.ApplicationInfo
+import android.content.pm.GosPackageState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import com.android.settings.R
+import com.android.settings.applications.appinfo.AswExploitProtectionFragment
+import com.android.settingslib.spa.framework.compose.stateOf
+import com.android.settingslib.spa.widget.preference.SwitchPreference
+import com.android.settingslib.spa.widget.preference.SwitchPreferenceModel
+import com.android.settingslib.spaprivileged.model.app.installed
+
+@Composable
+fun AppExploitProtectionCompatModeSwitchPreference(app: ApplicationInfo,
+                                                   packageInfoPresenter: PackageInfoPresenter) {
+    if (app.isSystemApp || !app.installed) {
+        return
+    }
+
+    val context = LocalContext.current
+    val pkgName = app.packageName
+    val psFlag = GosPackageState.FLAG_ENABLE_EXPLOIT_PROTECTION_COMPAT_MODE
+
+    val psFlagState = remember {
+        val initialState = GosPackageState.get(pkgName)?.hasFlag(psFlag) == true
+        mutableStateOf(initialState)
+    }
+
+    SwitchPreference(object : SwitchPreferenceModel {
+        override val title = stringResource(R.string.aep_compat_mode_title)
+        override val summary = stateOf(stringResource(R.string.aep_compat_mode_summary))
+
+        override val checked = psFlagState
+
+        override val onCheckedChange = { newChecked: Boolean ->
+            val action = Runnable {
+                GosPackageState.edit(pkgName).run {
+                    setFlagsState(psFlag, newChecked)
+                    killUidAfterApply()
+                    if (apply()) {
+                        psFlagState.value = newChecked
+                        // needed to recompose other exploit protection settings
+                        packageInfoPresenter.reloadPackageInfo()
+                    }
+                }
+            }
+
+            if (newChecked) {
+                val d = AswExploitProtectionFragment.getExploitProtectionWarningOnDisable(context, action)
+                d.show()
+            } else {
+                action.run()
+            }
+            Unit
+        }
+    })
+}

--- a/src/com/android/settings/spa/app/appinfo/AppInfoSettings.kt
+++ b/src/com/android/settings/spa/app/appinfo/AppInfoSettings.kt
@@ -36,6 +36,7 @@ import com.android.settings.applications.AppInfoBase
 import com.android.settings.applications.appinfo.AppExtendedVaSpacePreference
 import com.android.settings.applications.appinfo.AppHardenedMallocPreference
 import com.android.settings.applications.appinfo.AppInfoDashboardFragment
+import com.android.settings.applications.appinfo.AppMemtagPreference
 import com.android.settings.applications.appinfo.AppNativeDebuggingPreference
 import com.android.settings.spa.SpaActivity.Companion.startSpaActivity
 import com.android.settings.spa.app.appcompat.UserAspectRatioAppPreference
@@ -169,6 +170,7 @@ private fun AppInfoSettings(packageInfoPresenter: PackageInfoPresenter) {
         Category(title = stringResource(R.string.exploit_protection_category_title)) {
             AppExploitProtectionCompatModeSwitchPreference(app, packageInfoPresenter)
             AppHardenedMallocPreference(app)
+            AppMemtagPreference(app)
             AppExtendedVaSpacePreference(app)
             AppNativeDebuggingPreference(app)
         }

--- a/src/com/android/settings/spa/app/appinfo/AppInfoSettings.kt
+++ b/src/com/android/settings/spa/app/appinfo/AppInfoSettings.kt
@@ -36,6 +36,7 @@ import com.android.settings.applications.AppInfoBase
 import com.android.settings.applications.appinfo.AppExtendedVaSpacePreference
 import com.android.settings.applications.appinfo.AppHardenedMallocPreference
 import com.android.settings.applications.appinfo.AppInfoDashboardFragment
+import com.android.settings.applications.appinfo.AppNativeDebuggingPreference
 import com.android.settings.spa.SpaActivity.Companion.startSpaActivity
 import com.android.settings.spa.app.appcompat.UserAspectRatioAppPreference
 import com.android.settings.spa.app.specialaccess.AlarmsAndRemindersAppListProvider
@@ -169,6 +170,7 @@ private fun AppInfoSettings(packageInfoPresenter: PackageInfoPresenter) {
             AppExploitProtectionCompatModeSwitchPreference(app, packageInfoPresenter)
             AppHardenedMallocPreference(app)
             AppExtendedVaSpacePreference(app)
+            AppNativeDebuggingPreference(app)
         }
 
         Category(title = stringResource(R.string.app_install_details_group_title)) {

--- a/src/com/android/settings/spa/app/appinfo/AppInfoSettings.kt
+++ b/src/com/android/settings/spa/app/appinfo/AppInfoSettings.kt
@@ -164,6 +164,7 @@ private fun AppInfoSettings(packageInfoPresenter: PackageInfoPresenter) {
         }
 
         Category(title = stringResource(R.string.exploit_protection_category_title)) {
+            AppExploitProtectionCompatModeSwitchPreference(app, packageInfoPresenter)
         }
 
         Category(title = stringResource(R.string.app_install_details_group_title)) {

--- a/src/com/android/settings/spa/app/appinfo/AppInfoSettings.kt
+++ b/src/com/android/settings/spa/app/appinfo/AppInfoSettings.kt
@@ -138,6 +138,7 @@ private fun AppInfoSettings(packageInfoPresenter: PackageInfoPresenter) {
         AppNotificationPreference(app)
         AppPermissionPreference(app)
         AppStorageScopesPreference(app)
+        AppContactScopesPreference(app)
         AppStoragePreference(app)
         InstantAppDomainsPreference(app)
         AppDataUsagePreference(app)

--- a/src/com/android/settings/spa/app/appinfo/AppInfoSettings.kt
+++ b/src/com/android/settings/spa/app/appinfo/AppInfoSettings.kt
@@ -147,6 +147,7 @@ private fun AppInfoSettings(packageInfoPresenter: PackageInfoPresenter) {
         AppLocalePreference(app)
         AppOpenByDefaultPreference(app)
         DefaultAppShortcuts(app)
+        AppLogcatPreference(app)
 
         Category(title = stringResource(R.string.unused_apps_category)) {
             HibernationSwitchPreference(app)

--- a/src/com/android/settings/spa/app/appinfo/AppInfoSettings.kt
+++ b/src/com/android/settings/spa/app/appinfo/AppInfoSettings.kt
@@ -163,6 +163,9 @@ private fun AppInfoSettings(packageInfoPresenter: PackageInfoPresenter) {
             AlarmsAndRemindersAppListProvider.InfoPageEntryItem(app)
         }
 
+        Category(title = stringResource(R.string.exploit_protection_category_title)) {
+        }
+
         Category(title = stringResource(R.string.app_install_details_group_title)) {
             AppInstallerInfoPreference(app)
         }

--- a/src/com/android/settings/spa/app/appinfo/AppInfoSettings.kt
+++ b/src/com/android/settings/spa/app/appinfo/AppInfoSettings.kt
@@ -33,6 +33,7 @@ import androidx.navigation.NavType
 import androidx.navigation.navArgument
 import com.android.settings.R
 import com.android.settings.applications.AppInfoBase
+import com.android.settings.applications.appinfo.AppHardenedMallocPreference
 import com.android.settings.applications.appinfo.AppInfoDashboardFragment
 import com.android.settings.spa.SpaActivity.Companion.startSpaActivity
 import com.android.settings.spa.app.appcompat.UserAspectRatioAppPreference
@@ -165,6 +166,7 @@ private fun AppInfoSettings(packageInfoPresenter: PackageInfoPresenter) {
 
         Category(title = stringResource(R.string.exploit_protection_category_title)) {
             AppExploitProtectionCompatModeSwitchPreference(app, packageInfoPresenter)
+            AppHardenedMallocPreference(app)
         }
 
         Category(title = stringResource(R.string.app_install_details_group_title)) {

--- a/src/com/android/settings/spa/app/appinfo/AppInfoSettings.kt
+++ b/src/com/android/settings/spa/app/appinfo/AppInfoSettings.kt
@@ -137,6 +137,7 @@ private fun AppInfoSettings(packageInfoPresenter: PackageInfoPresenter) {
         AppAllServicesPreference(app)
         AppNotificationPreference(app)
         AppPermissionPreference(app)
+        AppStorageScopesPreference(app)
         AppStoragePreference(app)
         InstantAppDomainsPreference(app)
         AppDataUsagePreference(app)

--- a/src/com/android/settings/spa/app/appinfo/AppInfoSettings.kt
+++ b/src/com/android/settings/spa/app/appinfo/AppInfoSettings.kt
@@ -33,6 +33,7 @@ import androidx.navigation.NavType
 import androidx.navigation.navArgument
 import com.android.settings.R
 import com.android.settings.applications.AppInfoBase
+import com.android.settings.applications.appinfo.AppExtendedVaSpacePreference
 import com.android.settings.applications.appinfo.AppHardenedMallocPreference
 import com.android.settings.applications.appinfo.AppInfoDashboardFragment
 import com.android.settings.spa.SpaActivity.Companion.startSpaActivity
@@ -167,6 +168,7 @@ private fun AppInfoSettings(packageInfoPresenter: PackageInfoPresenter) {
         Category(title = stringResource(R.string.exploit_protection_category_title)) {
             AppExploitProtectionCompatModeSwitchPreference(app, packageInfoPresenter)
             AppHardenedMallocPreference(app)
+            AppExtendedVaSpacePreference(app)
         }
 
         Category(title = stringResource(R.string.app_install_details_group_title)) {

--- a/src/com/android/settings/spa/app/appinfo/AppLogcatPreference.kt
+++ b/src/com/android/settings/spa/app/appinfo/AppLogcatPreference.kt
@@ -1,0 +1,28 @@
+package com.android.settings.spa.app.appinfo
+
+import android.content.pm.ApplicationInfo
+import android.ext.LogViewerApp
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import com.android.settings.R
+import com.android.settingslib.spa.widget.preference.Preference
+import com.android.settingslib.spa.widget.preference.PreferenceModel
+import com.android.settingslib.spaprivileged.model.app.installed
+
+@Composable
+fun AppLogcatPreference(app: ApplicationInfo) {
+    if (!app.installed) {
+        return
+    }
+
+    val context = LocalContext.current
+
+    Preference(object : PreferenceModel {
+        override val title = stringResource(R.string.view_logs)
+        override val onClick = {
+            val intent = LogViewerApp.getPackageLogcatIntent(app.packageName)
+            context.startActivity(intent)
+        }
+    })
+}

--- a/src/com/android/settings/spa/app/appinfo/AppStorageScopesPreference.kt
+++ b/src/com/android/settings/spa/app/appinfo/AppStorageScopesPreference.kt
@@ -1,0 +1,29 @@
+package com.android.settings.spa.app.appinfo
+
+import android.app.StorageScope
+import android.content.pm.ApplicationInfo
+import android.content.pm.GosPackageState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import com.android.settings.R
+import com.android.settingslib.spa.widget.preference.Preference
+import com.android.settingslib.spa.widget.preference.PreferenceModel
+
+@Composable
+fun AppStorageScopesPreference(app: ApplicationInfo) {
+    val pkgName = app.packageName
+    if (GosPackageState.get(pkgName)?.hasFlags(GosPackageState.FLAG_STORAGE_SCOPES_ENABLED) != true) {
+        return
+    }
+
+    val context = LocalContext.current
+
+    Preference(object : PreferenceModel {
+        override val title = stringResource(R.string.storage_scopes)
+        override val onClick = {
+            val intent = StorageScope.createConfigActivityIntent(pkgName)
+            context.startActivity(intent)
+        }
+    })
+}

--- a/src/com/android/settings/spa/app/appinfo/AswPreference.kt
+++ b/src/com/android/settings/spa/app/appinfo/AswPreference.kt
@@ -1,0 +1,30 @@
+package com.android.settings.spa.app.appinfo
+
+import android.content.Context
+import android.content.pm.ApplicationInfo
+import android.ext.settings.app.AppSwitch
+import androidx.compose.runtime.Composable
+import com.android.settings.applications.appinfo.AppInfoDashboardFragment
+import com.android.settings.applications.appinfo.AswAdapter
+import com.android.settingslib.spa.framework.compose.stateOf
+import com.android.settingslib.spa.widget.preference.Preference
+import com.android.settingslib.spa.widget.preference.PreferenceModel
+import com.android.settingslib.spaprivileged.model.app.installed
+
+@Composable
+fun AswPreference(context: Context, app: ApplicationInfo, adapter: AswAdapter<out AppSwitch>) {
+    if (!app.installed) {
+        return
+    }
+
+    Preference(object : PreferenceModel {
+        override val title = adapter.getAswTitle().toString()
+        override val summary = stateOf(adapter.getPreferenceSummary(app).toString())
+        override val onClick = {
+            AppInfoDashboardFragment.startAppInfoFragment(
+                adapter.getDetailFragmentClass().java,
+                app, context, AppInfoSettingsProvider.METRICS_CATEGORY,
+            )
+        }
+    })
+}

--- a/src/com/android/settings/spa/app/specialaccess/AllFilesAccess.kt
+++ b/src/com/android/settings/spa/app/specialaccess/AllFilesAccess.kt
@@ -18,10 +18,17 @@ package com.android.settings.spa.app.specialaccess
 
 import android.Manifest
 import android.app.AppOpsManager
+import android.app.StorageScope
 import android.app.settings.SettingsEnums
 import android.content.Context
+import android.content.pm.PackageInfo
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import com.android.settings.R
 import com.android.settings.overlay.FeatureFactory
+import com.android.settingslib.spa.widget.preference.Preference
+import com.android.settingslib.spa.widget.preference.PreferenceModel
 import com.android.settingslib.spaprivileged.template.app.AppOpPermissionListModel
 import com.android.settingslib.spaprivileged.template.app.AppOpPermissionRecord
 import com.android.settingslib.spaprivileged.template.app.TogglePermissionAppListProvider
@@ -50,5 +57,18 @@ class AllFilesAccessListModel(context: Context) : AppOpPermissionListModel(conte
             else -> SettingsEnums.APP_SPECIAL_PERMISSION_MANAGE_EXT_STRG_DENY
         }
         FeatureFactory.getFactory(context).metricsFeatureProvider.action(context, category, "")
+    }
+
+    @Composable
+    override fun extContent(record: AppOpPermissionRecord, pkgInfo: PackageInfo) {
+        val context = LocalContext.current
+
+        Preference(object : PreferenceModel {
+            override val title = stringResource(R.string.storage_scopes)
+            override val onClick = {
+                val i = StorageScope.createConfigActivityIntent(pkgInfo.packageName)
+                context.startActivity(i)
+            }
+        })
     }
 }

--- a/src/com/android/settings/spa/app/specialaccess/InstallUnknownApps.kt
+++ b/src/com/android/settings/spa/app/specialaccess/InstallUnknownApps.kt
@@ -22,10 +22,17 @@ import android.app.AppOpsManager.MODE_DEFAULT
 import android.app.AppOpsManager.OP_REQUEST_INSTALL_PACKAGES
 import android.content.Context
 import android.content.pm.ApplicationInfo
+import android.content.pm.GosPackageState
+import android.content.pm.PackageInfo
 import android.os.UserManager
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.res.stringResource
 import com.android.settings.R
+import com.android.settingslib.spa.framework.compose.stateOf
+import com.android.settingslib.spa.widget.preference.SwitchPreference
+import com.android.settingslib.spa.widget.preference.SwitchPreferenceModel
 import com.android.settingslib.spaprivileged.model.app.AppOpsController
 import com.android.settingslib.spaprivileged.model.app.AppRecord
 import com.android.settingslib.spaprivileged.model.app.userId
@@ -43,7 +50,26 @@ object InstallUnknownAppsListProvider : TogglePermissionAppListProvider {
 data class InstallUnknownAppsRecord(
     override val app: ApplicationInfo,
     val appOpsController: AppOpsController,
-) : AppRecord
+) : AppRecord {
+    val isObbFlagSet = mutableStateOf(isObbFlagSet())
+
+    fun isObbFlagSet(): Boolean {
+        return GosPackageState.get(app.packageName)?.hasFlag(GosPackageState.FLAG_ALLOW_ACCESS_TO_OBB_DIRECTORY) == true
+    }
+
+    fun setObbFlagState(state: Boolean): Boolean {
+        GosPackageState.edit(app.packageName).run {
+            setFlagsState(GosPackageState.FLAG_ALLOW_ACCESS_TO_OBB_DIRECTORY, state)
+            killUidAfterApply()
+            if (apply()) {
+                isObbFlagSet.value = state
+                return true
+            } else {
+                return false
+            }
+        }
+    }
+}
 
 class InstallUnknownAppsListModel(private val context: Context) :
     TogglePermissionAppListModel<InstallUnknownAppsRecord> {
@@ -86,6 +112,24 @@ class InstallUnknownAppsListModel(private val context: Context) :
 
     override fun setAllowed(record: InstallUnknownAppsRecord, newAllowed: Boolean) {
         record.appOpsController.setAllowed(newAllowed)
+        if (!newAllowed) {
+            record.setObbFlagState(false)
+        }
+    }
+
+    @Composable
+    override fun extContent(record: InstallUnknownAppsRecord, pkgInfo: PackageInfo) {
+        SwitchPreference(object : SwitchPreferenceModel {
+            override val title = stringResource(R.string.allow_access_to_obb_directory_title)
+            override val summary = stateOf(stringResource(R.string.allow_access_to_obb_directory_summary))
+
+            override val changeable = record.appOpsController.isAllowed.observeAsState(false)
+            override val checked = record.isObbFlagSet
+            override val onCheckedChange = { newChecked: Boolean ->
+                record.setObbFlagState(newChecked)
+                Unit
+            }
+        })
     }
 
     companion object {


### PR DESCRIPTION
"SPA" screens are Jetpack Compose rewrites of existing Settings screens.

Depends on:
https://github.com/GrapheneOS/platform_frameworks_base/pull/486
https://github.com/GrapheneOS/adevtool/pull/118