### PR TITLE
fix footer formatting issue on App pinning screen

### DIFF
--- a/res/xml/screen_pinning_settings.xml
+++ b/res/xml/screen_pinning_settings.xml
@@ -30,7 +30,6 @@
 
     <com.android.settingslib.widget.FooterPreference
         android:key="screen_pinning_settings_screen_footer"
-        android:title="@string/screen_pinning_description"
         settings:searchable="false" />
 
 </PreferenceScreen>

--- a/src/com/android/settings/security/ScreenPinningSettings.java
+++ b/src/com/android/settings/security/ScreenPinningSettings.java
@@ -234,9 +234,9 @@ public class ScreenPinningSettings extends SettingsPreferenceFragment
             mUseScreenLock.setChecked(isScreenLockUsed());
             mUseScreenLock.setTitle(getCurrentSecurityTitle());
         } else {
-            mFooterPreference.setSummary(getAppPinningContent());
             mUseScreenLock.setEnabled(false);
         }
+        mFooterPreference.setSummary(getAppPinningContent());
     }
 
     private boolean isGuestModeSupported() {


### PR DESCRIPTION
Since 20976c3a53802a8b78cab20e49154244ddaf9ddd screen_pinning_description is a formatted string, it can't be used directly from XML.