### PR TITLE
SudConfigProvider: return sysprop setupwizard.theme if set

### DIFF
--- a/src/com/android/settings/sudconfig/SudConfigProvider.kt
+++ b/src/com/android/settings/sudconfig/SudConfigProvider.kt
@@ -2,6 +2,7 @@ package com.android.settings.sudconfig
 
 import android.os.Build
 import android.os.Bundle
+import android.os.SystemProperties
 import android.provider.Settings
 import android.text.TextUtils
 import android.util.Log
@@ -26,7 +27,11 @@ class SudConfigProvider : NonRelationalProvider() {
         )
     }
 
+    private lateinit var defaultThemeString: String
+
     override fun onCreate(): Boolean {
+        defaultThemeString = SystemProperties.get("setupwizard.theme")
+        if (TextUtils.isEmpty(defaultThemeString)) defaultThemeString = "glif_v4_light"
         return true
     }
 
@@ -34,7 +39,7 @@ class SudConfigProvider : NonRelationalProvider() {
         Log.d(TAG, "method: $method, caller: $callingPackage")
         val bundle = Bundle()
         when (method) {
-            "suwDefaultThemeString" -> bundle.putString(method, "glif_v4_light")
+            "suwDefaultThemeString" -> bundle.putString(method, defaultThemeString)
 
             "applyGlifThemeControlledTransition",
             "isDynamicColorEnabled",


### PR DESCRIPTION
this introduces consistency between legacy APIs which use the sysprop and newer APIs which use this content provider

requires: https://github.com/GrapheneOS/platform_build/pull/56
fixes: https://github.com/GrapheneOS/os-issue-tracker/issues/3471