### PR TITLE
fixup! support protecting list setting value with the user credential

### DIFF
--- a/src/com/android/settings/ext/RadioButtonPickerFragment2.java
+++ b/src/com/android/settings/ext/RadioButtonPickerFragment2.java
@@ -148,6 +148,10 @@ public class RadioButtonPickerFragment2 extends RadioButtonPickerFragment {
 
     @Override
     protected boolean setDefaultKey(String key) {
+        if (key.equals(getDefaultKey())) {
+            return true;
+        }
+
         if (!userCredentialConfirmed && prefController.isCredentialConfirmationRequired()) {
             Context ctx = requireContext();
             LockPatternUtils lpu = FeatureFactory.getFeatureFactory()


### PR DESCRIPTION
Before this commit, tapping on the currently selected item had needlessly rewritten the current setting value, which triggered the credential prompt for credential-protected settings.