### PR TITLE
fixup! add base class for ListPreference controllers

### DIFF
--- a/src/com/android/settings/ext/RadioButtonPickerFragment2.java
+++ b/src/com/android/settings/ext/RadioButtonPickerFragment2.java
@@ -68,6 +68,8 @@ public class RadioButtonPickerFragment2 extends RadioButtonPickerFragment {
             userCredentialConfirmed = savedInstanceState.getBoolean(
                     KEY_USER_CREDENTIAL_CONFIRMED, false);
         }
+
+        updateCandidates();
     }
 
     @Override
@@ -189,10 +191,18 @@ public class RadioButtonPickerFragment2 extends RadioButtonPickerFragment {
         prefController.onPause(this);
     }
 
+    private boolean updateCandidatesOnResume;
+
     @Override
     public void onResume() {
         super.onResume();
         prefController.onResume(this);
-        updateCandidates();
+
+        if (updateCandidatesOnResume) {
+            updateCandidates();
+        } else {
+            // updateCandidates() is called from onCreatePrefences() right before the first onResume()
+            updateCandidatesOnResume = true;
+        }
     }
 }


### PR DESCRIPTION
In order for fragment instance state to be automatically restored after configuration change, updateCandidates() has to be called before state restoration is performed by the framework.

Before this commit, updateCandidates() was called from onResume(), which happens after state restoration. This led to list scrolling position being reset after activity configuration change, such as after device rotation.

Instead, call updateCandidates() from onCreatePreferences(), which is called before state restoration.

To avoid slowing down fragment startup, skip updateCandidates() during the first onResume(), which is called almost immediately after onCreatePreferences().