### PR TITLE
fixup! check app control restrictions before enabling "Disable" button for user apps

### DIFF
--- a/src/com/android/settings/spa/app/appinfo/AppDisableButton.kt
+++ b/src/com/android/settings/spa/app/appinfo/AppDisableButton.kt
@@ -99,10 +99,13 @@ class AppDisableButton(
         ) {
             // Currently we apply the same device policy for both the uninstallation and disable
             // button.
-            if (!app.isSystemApp) {
-                packageInfoPresenter.disable()
-            } else if (!appButtonRepository.isUninstallBlockedByAdmin(app)) {
-                dialogPresenter.open()
+            if (!appButtonRepository.isUninstallBlockedByAdmin(app)) {
+                if (app.isSystemApp) {
+                    dialogPresenter.open()
+                } else {
+                    packageInfoPresenter.disable()
+                }
+
             }
         }
     }


### PR DESCRIPTION
The previous commit addressed DISALLOW_APPS_CONTROL base user restriction, but not the device policy DISALLOW_APPS_CONTROL restriction, which has completely separate handling.

DISALLOW_APPS_CONTROL base user restriction simply grays out the Disable button, while the 
DISALLOW_APPS_CONTROL device policy restriction shows a "Blocked by work policy" dialog when Disable button is tapped.