### PR TITLE
15: add Private Space sandboxed Google Play link

### DIFF
--- a/res/xml/private_space_settings.xml
+++ b/res/xml/private_space_settings.xml
@@ -68,6 +68,11 @@
             android:summary="@string/private_space_sensitive_notifications_description"
             settings:controller="com.android.settings.privatespace.HidePrivateSpaceSensitiveNotificationsController" />
 
+        <Preference
+            android:key="sandboxed_google_play_private_space"
+            android:title="@string/sandboxed_google_play"
+            settings:controller="com.android.settings.applications.GmsCompatAppController"/>
+
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/src/com/android/settings/applications/GmsCompatAppController.java
+++ b/src/com/android/settings/applications/GmsCompatAppController.java
@@ -1,16 +1,19 @@
 package com.android.settings.applications;
 
+import android.annotation.Nullable;
 import android.app.compat.gms.GmsCompat;
 import android.content.Context;
 import android.content.Intent;
 import android.os.UserHandle;
 import android.text.TextUtils;
+import android.util.Log;
 
 import androidx.preference.Preference;
 
 import com.android.internal.gmscompat.GmsCompatApp;
 import com.android.internal.gmscompat.GmsInfo;
 import com.android.settings.core.BasePreferenceController;
+import com.android.settings.privatespace.PrivateSpaceMaintainer;
 
 public class GmsCompatAppController extends BasePreferenceController {
 
@@ -18,14 +21,28 @@ public class GmsCompatAppController extends BasePreferenceController {
         super(context, key);
     }
 
+    @Nullable
+    private UserHandle getUser() {
+        if ("sandboxed_google_play_private_space".equals(getPreferenceKey())) {
+            return PrivateSpaceMaintainer.getInstance(mContext).getPrivateProfileHandle();
+        }
+
+        UserHandle workProfileUser = getWorkProfileUser();
+        if (workProfileUser != null) {
+            return workProfileUser;
+        }
+
+        return mContext.getUser();
+    }
+
     @Override
     public int getAvailabilityStatus() {
-        UserHandle workProfile = getWorkProfileUser();
-        int userId = workProfile != null ?
-                workProfile.getIdentifier() :
-                UserHandle.myUserId();
+        UserHandle user = getUser();
+        if (user == null) {
+            return DISABLED_FOR_USER;
+        }
 
-        return GmsCompat.isEnabledFor(GmsInfo.PACKAGE_GMS_CORE, userId) ?
+        return GmsCompat.isEnabledFor(GmsInfo.PACKAGE_GMS_CORE, user.getIdentifier()) ?
                 AVAILABLE : DISABLED_FOR_USER;
     }
 
@@ -34,15 +51,15 @@ public class GmsCompatAppController extends BasePreferenceController {
         if (!TextUtils.equals(preference.getKey(), getPreferenceKey())) {
             return false;
         }
+
+        UserHandle user = getUser();
+        if (user == null) {
+            throw new IllegalStateException("getUser() returned null, key: " + getPreferenceKey());
+        }
+
         Intent intent = new Intent(GmsCompatApp.PKG_NAME + ".SETTINGS_LINK");
         intent.setPackage(GmsCompatApp.PKG_NAME);
-
-        UserHandle workProfile = getWorkProfileUser();
-        if (workProfile != null) {
-            mContext.startActivityAsUser(intent, workProfile);
-        } else {
-            mContext.startActivity(intent);
-        }
+        mContext.startActivityAsUser(intent, user);
         return true;
     }
 }


### PR DESCRIPTION
It's added to Private Space screen instead of the Apps screen (where regular and work profile links are) to avoid revealing whether the Private Space is present when the "Hide when locked" Private Space option is enabled.