### PR TITLE
AppSwitch UI: Use supplied application info's userId for settings summary

### DIFF
--- a/src/com/android/settings/applications/AswAdapter.kt
+++ b/src/com/android/settings/applications/AswAdapter.kt
@@ -12,6 +12,7 @@ import com.android.settings.applications.appinfo.AppInfoDashboardFragment
 import com.android.settings.spa.SpaActivity.Companion.startSpaActivity
 import com.android.settings.spa.app.appinfo.AppInfoSettingsProvider
 import com.android.settings.spa.app.appinfo.AswAppListPageProvider
+import com.android.settingslib.spaprivileged.model.app.userId
 import kotlin.reflect.KClass
 
 abstract class AswAdapter<T : AppSwitch> {
@@ -26,7 +27,7 @@ abstract class AswAdapter<T : AppSwitch> {
     fun getPreferenceSummary(ctx: Context, appInfo: ApplicationInfo): CharSequence {
         val asw = getAppSwitch()
         val si = AppSwitch.StateInfo()
-        val userId = ctx.userId
+        val userId = appInfo.userId
         val isOn = asw.get(ctx, userId, appInfo, GosPackageState.get(appInfo.packageName, userId), si)
         return if (si.isUsingDefaultValue) {
             getDefaultTitle(ctx, isOn)


### PR DESCRIPTION


The app info page opened by settings using AppSwitch's infrastructure is launched with respect to supplied ApplicationInfo uid as its userId to launch the page, see AppInfoDashboardFragment#startAppInfoFragment