### PR TITLE
bugfix: Use the correct userId for toggling Exploit protection compatibility mode

### DIFF
--- a/src/com/android/settings/applications/AswAdapter.kt
+++ b/src/com/android/settings/applications/AswAdapter.kt
@@ -12,6 +12,7 @@ import com.android.settings.applications.appinfo.AppInfoDashboardFragment
 import com.android.settings.spa.SpaActivity.Companion.startSpaActivity
 import com.android.settings.spa.app.appinfo.AppInfoSettingsProvider
 import com.android.settings.spa.app.appinfo.AswAppListPageProvider
+import com.android.settingslib.spaprivileged.model.app.userId
 import kotlin.reflect.KClass
 
 abstract class AswAdapter<T : AppSwitch> {
@@ -26,7 +27,7 @@ abstract class AswAdapter<T : AppSwitch> {
     fun getPreferenceSummary(ctx: Context, appInfo: ApplicationInfo): CharSequence {
         val asw = getAppSwitch()
         val si = AppSwitch.StateInfo()
-        val userId = ctx.userId
+        val userId = appInfo.userId
         val isOn = asw.get(ctx, userId, appInfo, GosPackageState.get(appInfo.packageName, userId), si)
         return if (si.isUsingDefaultValue) {
             getDefaultTitle(ctx, isOn)

--- a/src/com/android/settings/applications/AswAdapter.kt
+++ b/src/com/android/settings/applications/AswAdapter.kt
@@ -12,7 +12,6 @@ import com.android.settings.applications.appinfo.AppInfoDashboardFragment
 import com.android.settings.spa.SpaActivity.Companion.startSpaActivity
 import com.android.settings.spa.app.appinfo.AppInfoSettingsProvider
 import com.android.settings.spa.app.appinfo.AswAppListPageProvider
-import com.android.settingslib.spaprivileged.model.app.userId
 import kotlin.reflect.KClass
 
 abstract class AswAdapter<T : AppSwitch> {
@@ -27,7 +26,7 @@ abstract class AswAdapter<T : AppSwitch> {
     fun getPreferenceSummary(ctx: Context, appInfo: ApplicationInfo): CharSequence {
         val asw = getAppSwitch()
         val si = AppSwitch.StateInfo()
-        val userId = appInfo.userId
+        val userId = ctx.userId
         val isOn = asw.get(ctx, userId, appInfo, GosPackageState.get(appInfo.packageName, userId), si)
         return if (si.isUsingDefaultValue) {
             getDefaultTitle(ctx, isOn)

--- a/src/com/android/settings/spa/app/appinfo/AppExploitProtectionCompatModeSwitchPreference.kt
+++ b/src/com/android/settings/spa/app/appinfo/AppExploitProtectionCompatModeSwitchPreference.kt
@@ -10,6 +10,7 @@ import com.android.settings.applications.AswExploitProtectionFragment
 import com.android.settingslib.spa.widget.preference.SwitchPreference
 import com.android.settingslib.spa.widget.preference.SwitchPreferenceModel
 import com.android.settingslib.spaprivileged.model.app.installed
+import com.android.settingslib.spaprivileged.model.app.userId
 
 @Composable
 fun AppExploitProtectionCompatModeSwitchPreference(app: ApplicationInfo,
@@ -20,6 +21,7 @@ fun AppExploitProtectionCompatModeSwitchPreference(app: ApplicationInfo,
 
     val context = LocalContext.current
     val pkgName = app.packageName
+    val userId = app.userId
     val psFlag = GosPackageState.FLAG_ENABLE_EXPLOIT_PROTECTION_COMPAT_MODE
 
     SwitchPreference(object : SwitchPreferenceModel {
@@ -29,12 +31,12 @@ fun AppExploitProtectionCompatModeSwitchPreference(app: ApplicationInfo,
         }
 
         override val checked = {
-            GosPackageState.get(pkgName)?.hasFlag(psFlag) == true
+            GosPackageState.get(pkgName, userId)?.hasFlag(psFlag) == true
         }
 
         override val onCheckedChange = { newChecked: Boolean ->
             val action = Runnable {
-                GosPackageState.edit(pkgName).run {
+                GosPackageState.edit(pkgName, userId).run {
                     setFlagsState(psFlag, newChecked)
                     killUidAfterApply()
                     if (apply()) {


### PR DESCRIPTION
Previous and current bugfix are committed with fixup on original changes for rebasing convenience.