### PR TITLE
opt-out dev options app picker activity from edge-to-edge

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -3159,6 +3159,7 @@
         </activity>
 
         <activity android:name=".development.AppPicker"
+                  android:theme="@style/Theme.DeviceDefault.DayNight.NoEdgeToEdge"
                   android:label="@string/select_application" />
 
         <activity android:name=".development.AdbQrCodeActivity" />


### PR DESCRIPTION
"None" app picker option was invisible because this activity wasn't updated to support edge-to-edge.