### PR TITLE
add App info > Storage > Manage storage button for apps that support it

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -4219,6 +4219,7 @@
     <string name="enable_text">Enable</string>
     <!-- Manage applications, individual application info screen, button label under Storage heading. Button to clear all data associated with tis app (for example, remove all cached emails for an Email app) -->
     <string name="clear_user_data_text">Clear storage</string>
+    <string name="manage_storage_text">Manage storage</string>
     <!-- Manage applications, restore updated system application to factory version -->
     <string name="app_factory_reset">Uninstall updates</string>
     <!-- [CHAR LIMIT=50] Manage applications, unlock restricted setting from lock screen title -->

--- a/src/com/android/settings/applications/AppStorageSettings.java
+++ b/src/com/android/settings/applications/AppStorageSettings.java
@@ -207,10 +207,14 @@ public class AppStorageSettings extends AppInfoWithHeader
 
     @VisibleForTesting
     void handleClearDataClick() {
+        handleClearDataClick(false);
+    }
+
+    private void handleClearDataClick(boolean ignoreAppActivity) {
         if (mAppsControlDisallowedAdmin != null && !mAppsControlDisallowedBySystem) {
             RestrictedLockUtils.sendShowAdminSupportDetailsIntent(
                     getActivity(), mAppsControlDisallowedAdmin);
-        } else if (mAppEntry.info.manageSpaceActivityName != null) {
+        } else if (!ignoreAppActivity && mAppEntry.info.manageSpaceActivityName != null) {
             if (!Utils.isMonkeyRunning()) {
                 Intent intent = new Intent(Intent.ACTION_DEFAULT);
                 intent.setClassName(mAppEntry.info.packageName,
@@ -296,15 +300,7 @@ public class AppStorageSettings extends AppInfoWithHeader
                 (mAppEntry.info.flags & (FLAG_SYSTEM | FLAG_ALLOW_CLEAR_USER_DATA)) == FLAG_SYSTEM;
         final boolean appRestrictsClearingData = isNonClearableSystemApp || appHasActiveAdmins;
 
-        final Intent intent = new Intent(Intent.ACTION_DEFAULT);
-        if (appHasSpaceManagementUI) {
-            intent.setClassName(mAppEntry.info.packageName, mAppEntry.info.manageSpaceActivityName);
-        }
-        final boolean isManageSpaceActivityAvailable =
-                getPackageManager().resolveActivity(intent, 0) != null;
-
-        if ((!appHasSpaceManagementUI && appRestrictsClearingData)
-                || !isManageSpaceActivityAvailable) {
+        if (appRestrictsClearingData) {
             mButtonsPref
                     .setButton1Text(R.string.clear_user_data_text)
                     .setButton1Icon(R.drawable.ic_settings_delete)
@@ -313,11 +309,25 @@ public class AppStorageSettings extends AppInfoWithHeader
         } else {
             mButtonsPref.setButton1Text(R.string.clear_user_data_text);
             mButtonsPref.setButton1Icon(R.drawable.ic_settings_delete)
-                    .setButton1OnClickListener(v -> handleClearDataClick());
+                    .setButton1OnClickListener(v -> handleClearDataClick(true));
+        }
+
+        if (appHasSpaceManagementUI) {
+            final Intent intent = new Intent(Intent.ACTION_DEFAULT);
+            intent.setClassName(mAppEntry.info.packageName, mAppEntry.info.manageSpaceActivityName);
+            final boolean isManageSpaceActivityAvailable = getPackageManager().resolveActivity(intent, 0) != null;
+
+            if (isManageSpaceActivityAvailable) {
+                ActionButtonsPreference bp = mButtonsPref;
+                bp.setButton3Text(R.string.manage_storage_text);
+                bp.setButton3Icon(R.drawable.ic_settings_open);
+                bp.setButton3OnClickListener(v -> handleClearDataClick(false));
+            }
         }
 
         if (mAppsControlDisallowedBySystem || AppUtils.isMainlineModule(mPm, mPackageName)) {
             mButtonsPref.setButton1Enabled(false);
+            mButtonsPref.setButton3Enabled(false);
         }
     }
 
@@ -574,7 +584,7 @@ public class AppStorageSettings extends AppInfoWithHeader
                 mButtonsPref.setButton1Enabled(false);
             } else {
                 mButtonsPref.setButton1Enabled(true)
-                        .setButton1OnClickListener(v -> handleClearDataClick());
+                        .setButton1OnClickListener(v -> handleClearDataClick(true));
             }
             if (cacheSize <= 0 || mCacheCleared) {
                 mButtonsPref.setButton2Enabled(false);

--- a/src/com/android/settings/security/DuressPasswordMainActivity.java
+++ b/src/com/android/settings/security/DuressPasswordMainActivity.java
@@ -19,12 +19,18 @@ import com.google.android.setupdesign.items.Item;
 import com.google.android.setupdesign.items.ItemGroup;
 import com.google.android.setupdesign.items.RecyclerItemAdapter;
 
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
 public class DuressPasswordMainActivity extends DuressPasswordActivity implements RecyclerItemAdapter.OnItemSelectedListener {
     private static final String TAG = DuressPasswordMainActivity.class.getSimpleName();
     private static final String KEY_USER_CREDENTIAL = "user_credential";
+    private static final String KEY_HAS_ASKED_FOR_USER_CREDENTIALS = "asked_for_user_credentials";
 
     private GlifRecyclerLayout layout;
     private LockscreenCredential userCredential;
+    private boolean askedForUserCredentials;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -41,6 +47,7 @@ public class DuressPasswordMainActivity extends DuressPasswordActivity implement
 
         if (savedInstanceState != null) {
             userCredential = savedInstanceState.getParcelable(KEY_USER_CREDENTIAL, LockscreenCredential.class);
+            askedForUserCredentials = requireNonNull(savedInstanceState.getBoolean2(KEY_HAS_ASKED_FOR_USER_CREDENTIALS));
         }
     }
 
@@ -53,6 +60,7 @@ public class DuressPasswordMainActivity extends DuressPasswordActivity implement
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putParcelable(KEY_USER_CREDENTIAL, userCredential);
+        outState.putBoolean(KEY_HAS_ASKED_FOR_USER_CREDENTIALS, askedForUserCredentials);
     }
 
     @Override
@@ -62,12 +70,13 @@ public class DuressPasswordMainActivity extends DuressPasswordActivity implement
         if (userCredential == null) {
             if (!getLockPatternUtils().isSecure(getUserId())) {
                 userCredential = LockscreenCredential.createNone();
-            } else {
+            } else if (!askedForUserCredentials) {
                 var b = new ChooseLockSettingsHelper.Builder(this);
                 b.setRequestCode(REQ_CODE_OBTAIN_USER_CREDENTIALS);
                 b.setReturnCredentials(true);
                 b.setForegroundOnly(true);
                 b.show();
+                askedForUserCredentials = true;
             }
         }
 


### PR DESCRIPTION
There's a "Clear storage" button in App info > Storage & cache. When app implements a "manage
storage space" activity, that button opens it instead of actually clearing the storage.

"Manage space" activity might not provide an option to clear app storage or it might not work at
all.

This change adds a separate button to launch that activity and makes the "Clear storage" button
ignore its presence.

Closes https://github.com/GrapheneOS/os-issue-tracker/issues/3802