### PR TITLE
[temporary] don't show battery usage info in App info item summary

### DIFF
--- a/src/com/android/settings/spa/app/appinfo/AppBatteryPreference.kt
+++ b/src/com/android/settings/spa/app/appinfo/AppBatteryPreference.kt
@@ -57,7 +57,6 @@ fun AppBatteryPreference(app: ApplicationInfo) {
     Preference(object : PreferenceModel {
         override val title = stringResource(R.string.battery_details_title)
         override val summary = presenter.summary
-        override val enabled = presenter.enabled
         override val onClick = presenter::startActivity
     })
 
@@ -96,8 +95,6 @@ private class AppBatteryPresenter(private val context: Context, private val app:
             .getAppOptimizationMode(false);
         Pair(batteryDiffEntry.await(), optimizationMode)
     }
-
-    val enabled = { batteryDiffEntryState is LoadingState.Done }
 
     val summary = {
         if (app.installed) {


### PR DESCRIPTION
It takes more than 5 seconds to load in many cases due to an upstream regression.
