### PR TITLE
add Terminal app preference to System category when dev options are on

### DIFF
--- a/res/xml/system_dashboard_fragment.xml
+++ b/res/xml/system_dashboard_fragment.xml
@@ -112,6 +112,12 @@
         settings:controller="com.android.settings.system.DeviceDiagnosticsPreferenceController"/>
 
     <Preference
+        android:key="linux_terminal"
+        android:title="@string/enable_linux_terminal_title"
+        android:summary="@string/enable_linux_terminal_summary"
+        android:fragment="com.android.settings.development.linuxterminal.LinuxTerminalDashboardFragment" />
+
+    <Preference
         android:key="reset_dashboard"
         android:title="@string/reset_dashboard_title"
         android:icon="@drawable/ic_restore"

--- a/src/com/android/settings/development/linuxterminal/LinuxTerminalPreferenceController.java
+++ b/src/com/android/settings/development/linuxterminal/LinuxTerminalPreferenceController.java
@@ -16,10 +16,12 @@
 
 package com.android.settings.development.linuxterminal;
 
+import android.content.ContentResolver;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.os.Process;
 import android.os.storage.StorageManager;
+import android.provider.Settings;
 import android.text.TextUtils;
 import android.util.DataUnit;
 
@@ -63,13 +65,23 @@ public class LinuxTerminalPreferenceController extends DeveloperOptionsPreferenc
                         && storageManager.getPrimaryStorageSize() >= STORAGE_MIN_BYTES;
     }
 
+    public boolean mIsInSystemSettings;
+
     // Avoid lazy initialization because this may be called before displayPreference().
     @Override
     public boolean isAvailable() {
         // Check build flag RELEASE_AVF_SUPPORT_CUSTOM_VM_WITH_PARAVIRTUALIZED_DEVICES indirectly
         // by checking whether the terminal app is installed.
         // TODO(b/343795511): Add explicitly check for the flag when it's accessible from Java code.
-        return mTerminalPackageName != null && mIsDeviceCapable;
+        boolean res = mTerminalPackageName != null && mIsDeviceCapable;
+
+        if (res && mIsInSystemSettings) {
+            ContentResolver cr = mContext.getContentResolver();
+            String key = Settings.Global.DEVELOPMENT_SETTINGS_ENABLED;
+            res = Settings.Global.getInt(cr, key, 0) == 1;
+        }
+
+        return res;
     }
 
     @Override

--- a/src/com/android/settings/system/SystemDashboardFragment.java
+++ b/src/com/android/settings/system/SystemDashboardFragment.java
@@ -16,6 +16,7 @@
 package com.android.settings.system;
 
 import android.app.settings.SettingsEnums;
+import android.content.Context;
 import android.os.Bundle;
 
 import androidx.preference.Preference;
@@ -24,8 +25,13 @@ import androidx.preference.PreferenceScreen;
 
 import com.android.settings.R;
 import com.android.settings.dashboard.DashboardFragment;
+import com.android.settings.development.linuxterminal.LinuxTerminalPreferenceController;
 import com.android.settings.search.BaseSearchIndexProvider;
+import com.android.settingslib.core.AbstractPreferenceController;
 import com.android.settingslib.search.SearchIndexable;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @SearchIndexable
 public class SystemDashboardFragment extends DashboardFragment {
@@ -41,6 +47,18 @@ public class SystemDashboardFragment extends DashboardFragment {
         if (getVisiblePreferenceCount(screen) == screen.getInitialExpandedChildrenCount() + 1) {
             screen.setInitialExpandedChildrenCount(Integer.MAX_VALUE);
         }
+    }
+
+    @Override
+    protected List<AbstractPreferenceController> createPreferenceControllers(Context context) {
+        List<AbstractPreferenceController> result = super.createPreferenceControllers(context);
+        if (result == null) {
+            result = new ArrayList<>();
+        }
+        var linuxTerminal = new LinuxTerminalPreferenceController(context);
+        linuxTerminal.mIsInSystemSettings = true;
+        result.add(linuxTerminal);
+        return result;
     }
 
     @Override


### PR DESCRIPTION
It's already present in Developer options, but they are not available in secondary users.