### PR TITLE
set distinct UI name for override_desktop_mode_features toggle

### DIFF
--- a/res/xml/development_settings.xml
+++ b/res/xml/development_settings.xml
@@ -750,7 +750,7 @@
 
         <SwitchPreferenceCompat
             android:key="override_desktop_mode_features"
-            android:title="@string/enable_desktop_mode" />
+            android:title="Enable desktop mode support" />
 
         <SwitchPreferenceCompat
             android:key="enable_freeform_support"


### PR DESCRIPTION
Both override_desktop_mode_features and enable_freeform_support toggle had the same name UI name: "Enable freeform windows".