### PR TITLE
fixup! Factor out common code for reading/writing UserManager restrictions

### DIFF
--- a/src/com/android/settings/users/UserRestrictions.java
+++ b/src/com/android/settings/users/UserRestrictions.java
@@ -1,23 +1,51 @@
 package com.android.settings.users;
 
+import android.content.Context;
 import android.content.pm.UserInfo;
 import android.os.Bundle;
-import android.os.UserHandle;
 import android.os.UserManager;
 
-import java.util.List;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
-final class UserRestrictions {
+public final class UserRestrictions {
 
-    final UserManager userManager;
-    final UserInfo userInfo;
+    @NonNull
+    private final UserManager userManager;
+    @NonNull
+    public final UserInfo userInfo;
 
-    UserRestrictions(UserManager userManager, UserInfo userInfo) {
+    @Nullable
+    public static UserRestrictions createInstance(@NonNull Context ctx, int userId) {
+        UserManager userManager = ctx.getSystemService(UserManager.class);
+        if (userManager == null) {
+            return null;
+        }
+
+        return createInstance(userManager, userId);
+    }
+
+    @Nullable
+    public static UserRestrictions createInstance(@NonNull UserManager userManager, int userId) {
+        UserInfo userInfo = userManager.getUserInfo(userId);
+        if (userInfo == null) {
+            return null;
+        }
+
+        return new UserRestrictions(userManager, userInfo);
+    }
+
+    @NonNull
+    public static UserRestrictions createInstance(@NonNull UserManager userManager, @NonNull UserInfo userInfo) {
+        return new UserRestrictions(userManager, userInfo);
+    }
+
+    UserRestrictions(@NonNull UserManager userManager, @NonNull UserInfo userInfo) {
         this.userManager = userManager;
         this.userInfo = userInfo;
     }
 
-    boolean isSet(String restrictionKey) {
+    public boolean isSet(String restrictionKey) {
         final boolean isSetFromUser = userManager.hasUserRestriction(restrictionKey, userInfo.getUserHandle());
         if (userInfo.isGuest()) {
             return isSetFromUser || userManager.getDefaultGuestRestrictions().getBoolean(restrictionKey);
@@ -26,7 +54,7 @@ final class UserRestrictions {
         return isSetFromUser;
     }
 
-    void set(String restrictionKey, boolean enableRestriction) {
+    public void set(String restrictionKey, boolean enableRestriction) {
         if (userInfo.isGuest()) {
             Bundle defaultGuestRestrictions = userManager.getDefaultGuestRestrictions();
             defaultGuestRestrictions.putBoolean(restrictionKey, enableRestriction);


### PR DESCRIPTION
This is needed for the check at https://github.com/GrapheneOS/platform_packages_apps_Settings/commit/f92862a1d6198f6e658cd314d025bd4135c0d995#diff-d3deaa7756856bb77cb48caca427ddc2c01249395a1a476112a78713234de2edR49-R65 to work as intended, similar to downstream checks in UI based on upstream's install checks.