### PR TITLE
fixup! add battery charge limit setting

### DIFF
--- a/res/xml/power_usage_summary.xml
+++ b/res/xml/power_usage_summary.xml
@@ -80,13 +80,6 @@
         settings:keywords="@string/charge_limit_indexing_keywords"
         settings:controller="com.android.settings.fuelgauge.BatteryChargingOptimizationPrefController" />
 
-    <Preference
-        android:fragment="com.android.settings.fuelgauge.SmartBatterySettings"
-        android:key="smart_battery_manager"
-        android:title="@string/smart_battery_manager_title"
-        settings:controller="com.android.settings.fuelgauge.batterytip.BatteryManagerPreferenceController"
-        settings:keywords="@string/keywords_battery_adaptive_preferences" />
-
     <SwitchPreferenceCompat
         android:key="status_bar_show_battery_percent"
         android:title="@string/battery_percentage"


### PR DESCRIPTION
Remove duplicate Battery Manager entry, which was added by https://github.com/GrapheneOS/platform_packages_apps_Settings/pull/362