### PR TITLE
fix discharge time estimates not being shown when charging optimization on

### DIFF
--- a/src/com/google/android/settings/fuelgauge/BatterySettingsFeatureProviderGoogleImpl.java
+++ b/src/com/google/android/settings/fuelgauge/BatterySettingsFeatureProviderGoogleImpl.java
@@ -15,10 +15,7 @@ public class BatterySettingsFeatureProviderGoogleImpl extends BatterySettingsFea
 
     @Override
     public boolean isChargingOptimizationMode(@NonNull Context context, boolean isLongLife) {
-        // TODO: Revisit. In current SettingsGoogle app, isLongLife is used like this:
-        //  isLongLife && BatteryChargeLimit.isChargeLimitEnabled(context)
-        //  Long life is tied to BatteryManager.CHARGING_POLICY_ADAPTIVE_LONGLIFE
-        return BatteryChargeLimit.isChargeLimitEnabled(context);
+        return isLongLife && BatteryChargeLimit.isChargeLimitEnabled(context);
     }
 
     @Nullable


### PR DESCRIPTION
The upstream commit ab6b7758c101fa4fa5f69d1dfc170329346504b8 in Android 16 moves the responsibility of the longLife condition check into the implementation of `isChargingOptimizationMode`, but we didn't observe the condition  during the port and left it as a TODO. This resulted in a regression of the display of the battery  discharge time estimate when charging optimization is set to on. It would only display strings like "Not charging" instead of strings like "Until 5:00 PM" in the top-level battery preference and in the battery screen.

For example, `com.android.settings.fuelgauge.BatteryInfo#isPluggedIn` has the following diff in the upstream commit which clearly shows this check was intended to be moved into implementations of `isChargingOptimizationMode`:

```diff
    private static boolean isPluggedIn(Context context, boolean isCharging, int chargingPolicy) {
        return isCharging
-               || (chargingPolicy == BatteryManager.CHARGING_POLICY_ADAPTIVE_LONGLIFE
-                       && FeatureFactory.getFeatureFactory()
-                              .getBatterySettingsFeatureProvider()
-                              .isChargingOptimizationMode(context));
+               || FeatureFactory.getFeatureFactory()
+                      .getBatterySettingsFeatureProvider()
+                      .isChargingOptimizationMode(
+                              context,
+                              chargingPolicy == BatteryManager.CHARGING_POLICY_ADAPTIVE_LONGLIFE);
    }
```

`com.android.settings.fuelgauge.TopLevelBatteryPreferenceController#generateLabel` would use `info.chargeLabel`, because `info.chargeLabel != null` and `isChargingOptimizationMode(mContext, info.isLongLife)` was returning true with charging optimization on even if the device isn't plugged in.

`com.android.settings.fuelgauge.BatteryHeaderTextPreferenceController#generateLabel` would return `info.statusLabel` due to `info.remainingLabel` being null. This is because `com.android.settings.fuelgauge.BatteryInfo#isPluggedIn` was returning true with charging optimization on even if the device isn't plugged in. `isPluggedIn` returning true meant that `updateBatteryInfoCharging` gets called in `BatteryInfo#getBatteryInfo`; `updateBatteryInfoCharging` sets `info.remainingLabel` to null in the last block of the function.

Fix this by following up on the TODO.