### PR TITLE
bluejay battery replacement UI

### DIFF
--- a/res/values/strings_google.xml
+++ b/res/values/strings_google.xml
@@ -8,6 +8,8 @@
     <string name="touch_sensitivity_title"/>
     <string name="touch_sensitivity_summary"/>
     <string name="charge_cycle_count"/>
+    <string name="battery_tip_early_replacement_summary"/>
+    <!-- battery_tip_replacement_summary already exists in AOSP -->
 
     <!-- SettingsIntelligenceGoogle -->
     <string name="charge_limit_indexing_keywords"/>

--- a/res/values/strings_google.xml
+++ b/res/values/strings_google.xml
@@ -7,6 +7,7 @@
     <string name="charging_optimization_remaining_time_label"/>
     <string name="touch_sensitivity_title"/>
     <string name="touch_sensitivity_summary"/>
+    <string name="charge_cycle_count"/>
 
     <!-- SettingsIntelligenceGoogle -->
     <string name="charge_limit_indexing_keywords"/>

--- a/res/xml/power_usage_summary.xml
+++ b/res/xml/power_usage_summary.xml
@@ -44,6 +44,13 @@
         android:title="@string/summary_placeholder"
         settings:controller="com.android.settings.fuelgauge.batterytip.BatteryTipPreferenceController" />
 
+    <!-- Removed tag from stock OS:  android:featureFlag="com.google.android.systemui.enable_whiskey"-->
+    <com.android.settings.widget.TipCardPreference
+        android:title="@string/charge_cycle_count"
+        android:key="cycle_count_tip"
+        settings:controller="com.google.android.settings.fuelgauge.batterytip.CycleCountTipPreferenceController"
+        settings:isPreferenceVisible="false" />
+
     <PreferenceCategory
         android:key="power_usage_summary_category"
         android:layout="@layout/settingslib_preference_category_no_title">

--- a/res/xml/power_usage_summary.xml
+++ b/res/xml/power_usage_summary.xml
@@ -45,7 +45,8 @@
         settings:controller="com.android.settings.fuelgauge.batterytip.BatteryTipPreferenceController" />
 
     <!-- Removed tag from stock OS:  android:featureFlag="com.google.android.systemui.enable_whiskey"-->
-    <com.android.settings.widget.TipCardPreference
+    <com.android.settingslib.widget.BannerMessagePreference
+        android:icon="@drawable/ic_battery_charging_full"
         android:title="@string/charge_cycle_count"
         android:key="cycle_count_tip"
         settings:controller="com.google.android.settings.fuelgauge.batterytip.CycleCountTipPreferenceController"

--- a/res/xml/power_usage_summary.xml
+++ b/res/xml/power_usage_summary.xml
@@ -45,8 +45,7 @@
         settings:controller="com.android.settings.fuelgauge.batterytip.BatteryTipPreferenceController" />
 
     <!-- Removed tag from stock OS:  android:featureFlag="com.google.android.systemui.enable_whiskey"-->
-    <com.android.settingslib.widget.BannerMessagePreference
-        android:icon="@drawable/ic_battery_charging_full"
+    <com.android.settings.widget.TipCardPreference
         android:title="@string/charge_cycle_count"
         android:key="cycle_count_tip"
         settings:controller="com.google.android.settings.fuelgauge.batterytip.CycleCountTipPreferenceController"

--- a/src/com/google/android/settings/fuelgauge/BatterySettingsFeatureProviderGoogleImpl.java
+++ b/src/com/google/android/settings/fuelgauge/BatterySettingsFeatureProviderGoogleImpl.java
@@ -7,8 +7,15 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.android.settings.R;
+import com.android.settings.fuelgauge.BatteryInfo;
 import com.android.settings.fuelgauge.BatterySettingsFeatureProviderImpl;
+import com.android.settings.fuelgauge.batterytip.BatteryTipPolicy;
+import com.android.settings.fuelgauge.batterytip.tips.BatteryTip;
 import com.android.settingslib.utils.PowerUtil;
+
+import com.google.android.settings.fuelgauge.batterytip.BatteryReplacementDetector;
+
+import java.util.List;
 
 // based on code from SettingsGoogle app
 public class BatterySettingsFeatureProviderGoogleImpl extends BatterySettingsFeatureProviderImpl {
@@ -57,5 +64,14 @@ public class BatterySettingsFeatureProviderGoogleImpl extends BatterySettingsFea
                     batteryPercentageString, targetTime);
         }
         return null;
+    }
+
+    @Override
+    public void addBatteryTipDetector(Context context, List<BatteryTip> batteryTips,
+            BatteryInfo batteryInfo, BatteryTipPolicy batteryTipPolicy) {
+        super.addBatteryTipDetector(context, batteryTips, batteryInfo, batteryTipPolicy);
+        if (Utils.isBarrelRequiredDevice(context)) {
+            batteryTips.addFirst(new BatteryReplacementDetector(context).detect());
+        }
     }
 }

--- a/src/com/google/android/settings/fuelgauge/Utils.java
+++ b/src/com/google/android/settings/fuelgauge/Utils.java
@@ -1,0 +1,12 @@
+package com.google.android.settings.fuelgauge;
+
+import android.content.Context;
+import android.os.Build;
+import android.text.TextUtils;
+
+public class Utils {
+    public static boolean isBarrelRequiredDevice(Context context) {
+        // Removed a check for Settings.Secure.getInt(context.getContentResolver(), "barrel_forcibly_disabled", 0) == 1;
+        return TextUtils.equals("bluejay", Build.DEVICE); // && !isBarrelForciblyDisabled;
+    }
+}

--- a/src/com/google/android/settings/fuelgauge/batterytip/BatteryReplacementDetector.java
+++ b/src/com/google/android/settings/fuelgauge/batterytip/BatteryReplacementDetector.java
@@ -1,0 +1,43 @@
+package com.google.android.settings.fuelgauge.batterytip;
+
+import static com.google.android.settings.fuelgauge.batterytip.CycleCountTipPreferenceController.BATTERY_HEALTH_FAIR;
+import static com.google.android.settings.fuelgauge.batterytip.CycleCountTipPreferenceController.CYCLE_COUNT_THRESHOLD;
+import static com.google.android.settings.fuelgauge.batterytip.CycleCountTipPreferenceController.CYCLE_COUNT_UNAVAILABLE;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.BatteryManager;
+import android.util.Log;
+import com.android.settings.fuelgauge.BatteryUtils;
+import com.android.settings.fuelgauge.batterytip.tips.BatteryTip;
+
+public class BatteryReplacementDetector {
+    private final Context mContext;
+    private final static String TAG = BatteryReplacementDetector.class.getSimpleName();
+
+    public BatteryReplacementDetector(Context context) {
+        this.mContext = context;
+    }
+
+    public BatteryTip detect() {
+        final Intent batteryIntent = BatteryUtils.getBatteryIntent(mContext);
+        if (batteryIntent == null) {
+            return new BatteryReplacementTip(BatteryTip.StateType.INVISIBLE,
+                    BatteryManager.BATTERY_HEALTH_UNKNOWN);
+        }
+        int health = batteryIntent.getIntExtra(BatteryManager.EXTRA_HEALTH,
+                BatteryManager.BATTERY_HEALTH_UNKNOWN);
+        int cycleCount = batteryIntent.getIntExtra(BatteryManager.EXTRA_CYCLE_COUNT,
+                CYCLE_COUNT_UNAVAILABLE);
+        Log.d(TAG, "detect() - battery health: " + health + ", cycle count: " + cycleCount);
+
+        final @BatteryTip.StateType int state;
+        if (health == BatteryManager.BATTERY_HEALTH_DEAD ||
+                (health == BATTERY_HEALTH_FAIR && cycleCount >= CYCLE_COUNT_THRESHOLD)) {
+            state = BatteryTip.StateType.NEW;
+        } else {
+            state = BatteryTip.StateType.INVISIBLE;
+        }
+        return new BatteryReplacementTip(state, health);
+    }
+}

--- a/src/com/google/android/settings/fuelgauge/batterytip/BatteryReplacementTip.kt
+++ b/src/com/google/android/settings/fuelgauge/batterytip/BatteryReplacementTip.kt
@@ -10,6 +10,7 @@ import android.util.Log
 import androidx.preference.Preference
 import com.android.settings.R
 import com.android.settings.fuelgauge.batterytip.tips.BatteryTip
+import com.android.settings.widget.TipCardPreference
 import com.android.settingslib.HelpUtils
 import com.android.settingslib.core.instrumentation.MetricsFeatureProvider
 import com.android.settingslib.widget.BannerMessagePreference
@@ -68,22 +69,32 @@ class BatteryReplacementTip : BatteryTip {
 
     override fun updatePreference(preference: Preference) {
         super.updatePreference(preference)
-        val tipCardPref = preference as? BannerMessagePreference ?: return
-        tipCardPref.isSelectable = true
-        tipCardPref.onPreferenceClickListener = Preference.OnPreferenceClickListener onClick@ { _ ->
-            val context: Context = tipCardPref.context
-            val helpIntent = HelpUtils.getHelpIntent(
-                context,
-                context.getString(R.string.help_url_battery_replacement),
-                ""
-            ) ?: return@onClick true
-
-            try {
-                context.startActivity(helpIntent)
-            } catch (e: Exception) {
-                Log.e(TAG, "can't start action $helpIntent", e)
+        // TODO: Remove the TipCardPreference branch if 16QPR1 replaces TipCardPreference with
+        //  BannerMessagePreference. Do this by reverting the commit.
+        if (preference is BannerMessagePreference) {
+            preference.isSelectable = true
+            preference.onPreferenceClickListener = Preference.OnPreferenceClickListener { _ ->
+                handlePreferenceClick(preference.context)
+                true
             }
-            true
+        } else if (preference is TipCardPreference) {
+            preference.iconResId = iconId
+            preference.onClick = { handlePreferenceClick(preference.context) }
+            preference.buildContent()
+        }
+    }
+
+    private fun handlePreferenceClick(context: Context) {
+        val helpIntent = HelpUtils.getHelpIntent(
+            context,
+            context.getString(R.string.help_url_battery_replacement),
+            ""
+        ) ?: return
+
+        try {
+            context.startActivity(helpIntent)
+        } catch (e: Exception) {
+            Log.e(TAG, "can't start action $helpIntent", e)
         }
     }
 

--- a/src/com/google/android/settings/fuelgauge/batterytip/BatteryReplacementTip.kt
+++ b/src/com/google/android/settings/fuelgauge/batterytip/BatteryReplacementTip.kt
@@ -10,9 +10,9 @@ import android.util.Log
 import androidx.preference.Preference
 import com.android.settings.R
 import com.android.settings.fuelgauge.batterytip.tips.BatteryTip
-import com.android.settings.widget.TipCardPreference
 import com.android.settingslib.HelpUtils
 import com.android.settingslib.core.instrumentation.MetricsFeatureProvider
+import com.android.settingslib.widget.BannerMessagePreference
 
 private const val TAG = "BatteryReplacementTip"
 
@@ -68,23 +68,23 @@ class BatteryReplacementTip : BatteryTip {
 
     override fun updatePreference(preference: Preference) {
         super.updatePreference(preference)
-        val tipCardPref = preference as? TipCardPreference ?: return
-        tipCardPref.iconResId = iconId
-        tipCardPref.onClick = onClick@ {
+        val tipCardPref = preference as? BannerMessagePreference ?: return
+        tipCardPref.isSelectable = true
+        tipCardPref.onPreferenceClickListener = Preference.OnPreferenceClickListener onClick@ { _ ->
             val context: Context = tipCardPref.context
             val helpIntent = HelpUtils.getHelpIntent(
                 context,
                 context.getString(R.string.help_url_battery_replacement),
                 ""
-            ) ?: return@onClick
+            ) ?: return@onClick true
 
             try {
                 context.startActivity(helpIntent)
             } catch (e: Exception) {
                 Log.e(TAG, "can't start action $helpIntent", e)
             }
+            true
         }
-        tipCardPref.buildContent()
     }
 
     companion object CREATOR : Parcelable.Creator<BatteryReplacementTip> {

--- a/src/com/google/android/settings/fuelgauge/batterytip/BatteryReplacementTip.kt
+++ b/src/com/google/android/settings/fuelgauge/batterytip/BatteryReplacementTip.kt
@@ -1,0 +1,99 @@
+package com.google.android.settings.fuelgauge.batterytip
+
+import android.app.settings.SettingsEnums
+import android.content.Context
+import android.os.BatteryManager
+import android.os.Parcel
+import android.os.Parcelable
+import android.text.Html
+import android.util.Log
+import androidx.preference.Preference
+import com.android.settings.R
+import com.android.settings.fuelgauge.batterytip.tips.BatteryTip
+import com.android.settings.widget.TipCardPreference
+import com.android.settingslib.HelpUtils
+import com.android.settingslib.core.instrumentation.MetricsFeatureProvider
+
+private const val TAG = "BatteryReplacementTip"
+
+class BatteryReplacementTip : BatteryTip {
+    private var mBatteryHealth = 0
+
+    constructor(@StateType state: Int, batteryHealth: Int) : super(
+        // TODO: 12 is used as the tipType param in stock OS, but TipType currently goes up to
+        //  11 (BATTERY_WARNING) in AOSP (no July tags). Stock OS also has changes in TipType and
+        //  adds 12 to the top of the order
+        TipType.BATTERY_WARNING,
+        state,
+        false
+    ) {
+        mBatteryHealth = batteryHealth
+    }
+
+    constructor(parcel: Parcel) : super(parcel) {
+        mBatteryHealth = parcel.readInt()
+    }
+
+    override fun writeToParcel(dest: Parcel, flags: Int) {
+        super.writeToParcel(dest, flags)
+        dest.writeInt(mBatteryHealth)
+    }
+
+    override fun getTitle(context: Context): CharSequence {
+        return context.getString(R.string.battery_tip_replacement_title)
+    }
+
+    override fun getSummary(context: Context): CharSequence {
+        val stringRes = if (mBatteryHealth == BatteryManager.BATTERY_HEALTH_DEAD) {
+            R.string.battery_tip_replacement_summary
+        } else {
+            R.string.battery_tip_early_replacement_summary
+        }
+        return Html.fromHtml(context.getString(stringRes), 0);
+    }
+
+    override fun getIconId(): Int = R.drawable.ic_battery_alert_24dp
+
+    override fun updateState(tip: BatteryTip) {
+        mState = tip.state
+    }
+
+    override fun log(context: Context?, metricsFeatureProvider: MetricsFeatureProvider?) {
+        metricsFeatureProvider?.action(
+            context,
+            SettingsEnums.ACTION_BATTERY_HEALTH_TIP,
+            mState
+        )
+    }
+
+    override fun updatePreference(preference: Preference) {
+        super.updatePreference(preference)
+        val tipCardPref = preference as? TipCardPreference ?: return
+        tipCardPref.iconResId = iconId
+        tipCardPref.onClick = onClick@ {
+            val context: Context = tipCardPref.context
+            val helpIntent = HelpUtils.getHelpIntent(
+                context,
+                context.getString(R.string.help_url_battery_replacement),
+                ""
+            ) ?: return@onClick
+
+            try {
+                context.startActivity(helpIntent)
+            } catch (e: Exception) {
+                Log.e(TAG, "can't start action $helpIntent", e)
+            }
+        }
+        tipCardPref.buildContent()
+    }
+
+    companion object CREATOR : Parcelable.Creator<BatteryReplacementTip> {
+        override fun createFromParcel(parcel: Parcel): BatteryReplacementTip {
+            return BatteryReplacementTip(parcel)
+        }
+
+        override fun newArray(size: Int): Array<BatteryReplacementTip?> {
+            return arrayOfNulls(size)
+        }
+    }
+}

--- a/src/com/google/android/settings/fuelgauge/batterytip/CycleCountTipPreferenceController.kt
+++ b/src/com/google/android/settings/fuelgauge/batterytip/CycleCountTipPreferenceController.kt
@@ -1,0 +1,121 @@
+package com.google.android.settings.fuelgauge.batterytip
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.BatteryManager
+import android.util.Log
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.preference.PreferenceScreen
+import com.android.settings.R
+import com.android.settings.core.BasePreferenceController
+import com.android.settings.widget.TipCardPreference
+import com.google.android.settings.fuelgauge.Utils
+
+class CycleCountTipPreferenceController(
+    context: Context,
+    key: String,
+) : BasePreferenceController(context, key), LifecycleEventObserver {
+    companion object {
+        /**
+         * An undocumented constant value for {@link BatteryManager#EXTRA_HEALTH}.
+         * It's defined in
+         * frameworks/native/services/batteryservice/include/batteryservice/BatteryServiceConstants.h
+         * but not exposed in frameworks {@link android.os.BatteryManager}
+         */
+        const val BATTERY_HEALTH_FAIR = 8
+        const val CYCLE_COUNT_THRESHOLD = 375
+        const val CYCLE_COUNT_UNAVAILABLE = -1
+        const val REQUIRED_DEVICE = "bluejay"
+        private const val TAG = "CycleCountTipPreferenceController"
+    }
+
+    private var batteryBroadcastReceiver: BroadcastReceiver? = null
+    private var cycleCountPreference: TipCardPreference? = null
+
+    override fun getAvailabilityStatus(): Int {
+        return if (Utils.isBarrelRequiredDevice(mContext)) {
+            AVAILABLE_UNSEARCHABLE
+        } else {
+            CONDITIONALLY_UNAVAILABLE
+        }
+    }
+
+    override fun displayPreference(screen: PreferenceScreen) {
+        super.displayPreference(screen)
+        val preference = screen.findPreference<TipCardPreference>(preferenceKey) ?: return
+        preference.iconResId = R.drawable.ic_battery_charging_full
+        cycleCountPreference = preference
+        // set later in updatePreference
+        preference.isVisible = false
+    }
+
+    override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
+        if (Utils.isBarrelRequiredDevice(mContext)) {
+            when (event) {
+                Lifecycle.Event.ON_CREATE -> {
+                    batteryBroadcastReceiver = object : BroadcastReceiver() {
+                        override fun onReceive(context: Context?, intent: Intent) {
+                            updatePreference(intent)
+                        }
+                    }
+                }
+                Lifecycle.Event.ON_START -> {
+                    batteryBroadcastReceiver?.let {
+                        mContext.registerReceiver(it, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+                    }
+                }
+                Lifecycle.Event.ON_STOP -> {
+                    batteryBroadcastReceiver?.let { mContext.unregisterReceiver(it) }
+                }
+                else -> return
+            }
+        }
+    }
+
+    private fun getCycleCount(intent: Intent): Int {
+        val cycleCount = intent.getIntExtra(
+            BatteryManager.EXTRA_CYCLE_COUNT,
+            CYCLE_COUNT_UNAVAILABLE
+        )
+        Log.d(TAG, "cycleCount: $cycleCount")
+        return cycleCount
+    }
+
+    private fun shouldShowCycleCountTip(intent: Intent, cycleCount: Int): Boolean {
+        if (cycleCount < CYCLE_COUNT_THRESHOLD) {
+            return false
+        }
+
+        val health = intent.getIntExtra(
+            BatteryManager.EXTRA_HEALTH,
+            BatteryManager.BATTERY_HEALTH_UNKNOWN
+        )
+        Log.d(TAG, "healthStatus: $health")
+
+        return health == BATTERY_HEALTH_FAIR || health == BatteryManager.BATTERY_HEALTH_DEAD
+    }
+
+    private fun convertCycleCountToString(cycleCount: Int): CharSequence {
+        return if (cycleCount == CYCLE_COUNT_UNAVAILABLE) {
+            return mContext.getText(R.string.battery_cycle_count_not_available)
+        } else {
+            cycleCount.toString()
+        }
+    }
+
+    private fun updatePreference(intent: Intent) {
+        val cycleCount = getCycleCount(intent)
+        val shouldShowCycleCountTip = shouldShowCycleCountTip(intent, cycleCount)
+        Log.d(TAG, "shouldShowCycleCountTip: $shouldShowCycleCountTip")
+        if (shouldShowCycleCountTip) {
+            cycleCountPreference?.apply {
+                summary = convertCycleCountToString(cycleCount)
+                isVisible = true
+            }
+        }
+    }
+}

--- a/src/com/google/android/settings/fuelgauge/batterytip/CycleCountTipPreferenceController.kt
+++ b/src/com/google/android/settings/fuelgauge/batterytip/CycleCountTipPreferenceController.kt
@@ -12,7 +12,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.preference.PreferenceScreen
 import com.android.settings.R
 import com.android.settings.core.BasePreferenceController
-import com.android.settings.widget.TipCardPreference
+import com.android.settingslib.widget.BannerMessagePreference
 import com.google.android.settings.fuelgauge.Utils
 
 class CycleCountTipPreferenceController(
@@ -34,7 +34,7 @@ class CycleCountTipPreferenceController(
     }
 
     private var batteryBroadcastReceiver: BroadcastReceiver? = null
-    private var cycleCountPreference: TipCardPreference? = null
+    private var cycleCountPreference: BannerMessagePreference? = null
 
     override fun getAvailabilityStatus(): Int {
         return if (Utils.isBarrelRequiredDevice(mContext)) {
@@ -46,9 +46,9 @@ class CycleCountTipPreferenceController(
 
     override fun displayPreference(screen: PreferenceScreen) {
         super.displayPreference(screen)
-        val preference = screen.findPreference<TipCardPreference>(preferenceKey) ?: return
-        preference.iconResId = R.drawable.ic_battery_charging_full
+        val preference = screen.findPreference<BannerMessagePreference>(preferenceKey) ?: return
         cycleCountPreference = preference
+        preference.setAttentionLevel(BannerMessagePreference.AttentionLevel.NORMAL)
         // set later in updatePreference
         preference.isVisible = false
     }
@@ -116,6 +116,8 @@ class CycleCountTipPreferenceController(
                 summary = convertCycleCountToString(cycleCount)
                 isVisible = true
             }
+        } else {
+            cycleCountPreference?.isVisible = false
         }
     }
 }

--- a/src/com/google/android/settings/fuelgauge/batterytip/CycleCountTipPreferenceController.kt
+++ b/src/com/google/android/settings/fuelgauge/batterytip/CycleCountTipPreferenceController.kt
@@ -9,9 +9,11 @@ import android.util.Log
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
+import androidx.preference.Preference
 import androidx.preference.PreferenceScreen
 import com.android.settings.R
 import com.android.settings.core.BasePreferenceController
+import com.android.settings.widget.TipCardPreference
 import com.android.settingslib.widget.BannerMessagePreference
 import com.google.android.settings.fuelgauge.Utils
 
@@ -34,7 +36,7 @@ class CycleCountTipPreferenceController(
     }
 
     private var batteryBroadcastReceiver: BroadcastReceiver? = null
-    private var cycleCountPreference: BannerMessagePreference? = null
+    private var cycleCountPreference: Preference? = null
 
     override fun getAvailabilityStatus(): Int {
         return if (Utils.isBarrelRequiredDevice(mContext)) {
@@ -46,9 +48,20 @@ class CycleCountTipPreferenceController(
 
     override fun displayPreference(screen: PreferenceScreen) {
         super.displayPreference(screen)
-        val preference = screen.findPreference<BannerMessagePreference>(preferenceKey) ?: return
+        // TODO: Remove the TipCardPreference branch (and change type parameter to
+        //  BannerMessagePreference) if 16QPR1 replaces TipCardPreference with
+        //  BannerMessagePreference. Do this by reverting the commit.
+        val preference = screen.findPreference<Preference>(preferenceKey) ?: return
+        when (preference) {
+            is BannerMessagePreference -> {
+                preference.setAttentionLevel(BannerMessagePreference.AttentionLevel.NORMAL)
+            }
+            is TipCardPreference -> {
+                preference.iconResId = R.drawable.ic_battery_charging_full
+            }
+            else -> return
+        }
         cycleCountPreference = preference
-        preference.setAttentionLevel(BannerMessagePreference.AttentionLevel.NORMAL)
         // set later in updatePreference
         preference.isVisible = false
     }


### PR DESCRIPTION
Review with:
- https://github.com/GrapheneOS/adevtool/pull/253
- https://github.com/GrapheneOS/platform_frameworks_base/pull/254

Shows battery replacement UI for bluejay in the battery screen if the kernel code detects that the device has an affected battery. This doesn't add a setting to opt out; it just reflects the battery health state reported by the kernel.

This is based on the stock OS logic. An early warning is shown if the battery health is reported as "fair" and charge cycles is >= 375. If the battery health is reported as "dead", it will tell the user that the battery capacity and charging performance are reduced (see picture below for "dead" state message).

Almost all of this code in the stock OS are in Google-specific classes, so we don't expect any of this to show up in 16QPR1 AOSP code.

<img src="https://github.com/user-attachments/assets/0d4b6d41-cf52-460b-a381-02f15b48556e" width=30%/>

