### PR TITLE
add CarrierConfig override UI

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -151,6 +151,7 @@
     <uses-permission android:name="android.permission.READ_SYSTEM_GRAMMATICAL_GENDER" />
     <uses-permission android:name="android.permission.MANAGE_COMPANION_DEVICES" />
     <uses-permission android:name="app.grapheneos.logviewer.SHOW_LOGCAT" />
+    <uses-permission android:name="app.grapheneos.carrierconfig2.FORCE_UPDATE_CONFIG" />
 
     <application
             android:name=".SettingsApplication"

--- a/res/values/strings_ext.xml
+++ b/res/values/strings_ext.xml
@@ -284,6 +284,9 @@ May cause unreliable service. Use at your own risk.
     <string name="carrier_settings_override_no_override_selected_message">No overrides are active. All settings are at their defaults.</string>
     <string name="carrier_settings_override_main_switch_title">Enable overrides</string>
     <string name="carrier_settings_override_active_title">Overrides active</string>
+    <string name="carrier_settings_override_unrecognized_category_title">Unknown overrides</string>
+    <string name="carrier_settings_override_unrecognized_warning_title">Warning</string>
+    <string name="carrier_settings_override_unrecognized_warning_summary">These carrier config overrides are not set from this screen.</string>
     <string name="carrier_settings_override_active_summary">Disable overrides to make changes</string>
     <string name="carrier_settings_override_apply_button">Apply carrier config override</string>
     <string name="carrier_settings_override_clear_button">Clear all carrier config overrides</string>

--- a/res/values/strings_ext.xml
+++ b/res/values/strings_ext.xml
@@ -268,4 +268,40 @@ This method can be particularly useful when GNSS is unavailable or unreliable, s
     <string name="geocoder_enabled_nominatim_server">Nominatim server</string>
     <string name="geocoder_disabled">Off</string>
 
+    <string name="carrier_settings_override_gos_title">Carrier settings overrides</string>
+    <string name="carrier_settings_override_intro_text">
+Override device carrier settings for this SIM. Choose your overrides first before enabling.
+    </string>
+    <string name="carrier_settings_override_footer">
+These local overrides may reveal hidden IMS options for your SIM, but functionality depends on carrier support and provisioning.
+May cause unreliable service. Use at your own risk.
+    </string>
+    <string name="carrier_settings_override_intro_text_expand">Expand</string>
+    <string name="carrier_settings_override_intro_text_collapse">Collapse</string>
+    <string name="carrier_settings_override_error_title">Error</string>
+    <string name="carrier_settings_override_error_unable_to_connect_to_config__s">Unable to connect to subscription service (%1$s)</string>
+    <string name="carrier_settings_override_no_override_selected_title">Cannot enable overrides</string>
+    <string name="carrier_settings_override_no_override_selected_message">No overrides are active. All settings are at their defaults.</string>
+    <string name="carrier_settings_override_main_switch_title">Enable overrides</string>
+    <string name="carrier_settings_override_active_title">Overrides active</string>
+    <string name="carrier_settings_override_active_summary">Disable overrides to make changes</string>
+    <string name="carrier_settings_override_apply_button">Apply carrier config override</string>
+    <string name="carrier_settings_override_clear_button">Clear all carrier config overrides</string>
+    <string name="carrier_settings_default_bool_true">Enabled</string>
+    <string name="carrier_settings_default_bool_false">Disabled</string>
+    <string name="carrier_settings_default_unknown">Unknown</string>
+    <string name="carrier_settings_override_bool_true">Force enabled</string>
+    <string name="carrier_settings_override_bool_false">Force disabled</string>
+    <string name="carrier_settings_override_default__s">Default (%1$s)</string>
+    <string name="carrier_settings_override_volte_availability">VoLTE</string>
+    <string name="carrier_settings_override_vonr_enable">VoNR</string>
+    <string name="carrier_settings_override_5g_title">5G capabilities</string>
+    <string name="carrier_settings_override_5g_enabled_all_modes">Force NSA and SA</string>
+    <string name="carrier_settings_override_5g_default_all_modes">NSA and SA</string>
+    <string name="carrier_settings_override_5g_enabled_nsa">Force NSA</string>
+    <string name="carrier_settings_override_5g_default_nsa">NSA</string>
+    <string name="carrier_settings_override_5g_enabled_sa">Force NSA</string>
+    <string name="carrier_settings_override_5g_default_sa">SA</string>
+    <string name="carrier_settings_override_5g_disabled">Force disabled</string>
+    <string name="carrier_settings_default_5g_disabled">Disabled</string>
 </resources>

--- a/res/xml/mobile_network_settings.xml
+++ b/res/xml/mobile_network_settings.xml
@@ -184,6 +184,13 @@
             settings:controller="com.android.settings.network.telephony.CarrierSettingsVersionPreferenceController"
             settings:enableCopying="true"/>
 
+        <!-- Settings search is handled by CarrierSettingsOverridesSearchItem. -->
+        <Preference
+            android:key="carrier_settings_override_gos"
+            android:title="@string/carrier_settings_override_gos_title"
+            settings:searchable="false"
+            settings:controller="com.android.settings.network.telephony.CarrierSettingsOverridesPreferenceController"/>
+
         <!-- IMEI -->
         <Preference
             android:key="network_mode_imei_info"

--- a/src/com/android/settings/network/telephony/CarrierConfigRepository.kt
+++ b/src/com/android/settings/network/telephony/CarrierConfigRepository.kt
@@ -33,7 +33,7 @@ class CarrierConfigRepository(private val context: Context) {
     private val carrierConfigManager: CarrierConfigManager? =
         context.getSystemService(CarrierConfigManager::class.java)
 
-    private enum class KeyType {
+    enum class KeyType {
         BOOLEAN,
         INT,
         INT_ARRAY,

--- a/src/com/android/settings/network/telephony/CarrierSettingsOverridesPreferenceController.kt
+++ b/src/com/android/settings/network/telephony/CarrierSettingsOverridesPreferenceController.kt
@@ -1,0 +1,56 @@
+package com.android.settings.network.telephony
+
+import android.content.Context
+import android.telephony.SubscriptionManager
+import androidx.lifecycle.LifecycleOwner
+import androidx.preference.Preference
+import androidx.preference.PreferenceScreen
+import com.android.settings.R
+import com.android.settings.core.BasePreferenceController
+import com.android.settings.network.telephony.MobileNetworkSettingsSearchIndex.MobileNetworkSettingsSearchItem
+import com.android.settings.network.telephony.MobileNetworkSettingsSearchIndex.MobileNetworkSettingsSearchResult
+import com.android.settings.spa.SpaActivity.Companion.startSpaActivity
+import com.android.settings.network.telephony.carriersettingsoverride.CarrierSettingsOverridesProvider
+
+/** Preference controller for "Carrier settings overrides" */
+class CarrierSettingsOverridesPreferenceController(context: Context, key: String) :
+    BasePreferenceController(context, key) {
+
+    private var subId = SubscriptionManager.INVALID_SUBSCRIPTION_ID
+    private lateinit var preference: Preference
+
+    fun init(subId: Int) {
+        this.subId = subId
+    }
+
+    override fun getAvailabilityStatus() = AVAILABLE
+
+    override fun displayPreference(screen: PreferenceScreen) {
+        super.displayPreference(screen)
+        preference = screen.findPreference(preferenceKey)!!
+    }
+
+    override fun onViewCreated(viewLifecycleOwner: LifecycleOwner) {
+        // preference.summary = mContext.getPlaceholder()
+    }
+
+    override fun handlePreferenceTreeClick(preference: Preference): Boolean {
+        if (preference.key != preferenceKey) return false
+        val route = CarrierSettingsOverridesProvider.getRoute(subId)
+        mContext.startSpaActivity(route)
+        return true
+    }
+
+    companion object {
+        class CarrierSettingsOverridesSearchItem(
+            private val context: Context
+        ) : MobileNetworkSettingsSearchItem {
+            override fun getSearchResult(subId: Int): MobileNetworkSettingsSearchResult {
+                return MobileNetworkSettingsSearchResult(
+                    key = "carrier_settings_override_gos",
+                    title = context.getString(R.string.carrier_settings_override_gos_title),
+                )
+            }
+        }
+    }
+}

--- a/src/com/android/settings/network/telephony/MobileNetworkSettings.java
+++ b/src/com/android/settings/network/telephony/MobileNetworkSettings.java
@@ -293,6 +293,7 @@ public class MobileNetworkSettings extends AbstractMobileNetworkSettings impleme
 
         use(ApnPreferenceController.class).init(mSubId);
         use(CarrierPreferenceController.class).init(mSubId);
+        use(CarrierSettingsOverridesPreferenceController.class).init(mSubId);
         use(DataUsagePreferenceController.class).init(mSubId);
         use(PreferredNetworkModePreferenceController.class).init(mSubId);
         use(EnabledNetworkModePreferenceController.class).init(mSubId, getParentFragmentManager());

--- a/src/com/android/settings/network/telephony/MobileNetworkSettingsSearchIndex.kt
+++ b/src/com/android/settings/network/telephony/MobileNetworkSettingsSearchIndex.kt
@@ -21,6 +21,7 @@ import android.provider.Settings
 import android.telephony.SubscriptionInfo
 import com.android.settings.R
 import com.android.settings.datausage.BillingCyclePreferenceController.Companion.BillingCycleSearchItem
+import com.android.settings.network.telephony.CarrierSettingsOverridesPreferenceController.Companion.CarrierSettingsOverridesSearchItem
 import com.android.settings.network.telephony.CarrierSettingsVersionPreferenceController.Companion.CarrierSettingsVersionSearchItem
 import com.android.settings.network.telephony.DataUsagePreferenceController.Companion.DataUsageSearchItem
 import com.android.settings.network.telephony.MmsMessagePreferenceController.Companion.MmsMessageSearchItem
@@ -35,7 +36,6 @@ import com.android.settings.spa.search.SpaSearchRepository.Companion.createSearc
 import com.android.settings.spa.search.SpaSearchRepository.Companion.searchIndexProviderOf
 import com.android.settingslib.search.SearchIndexableData
 import com.android.settingslib.search.SearchIndexableRaw
-import com.android.settingslib.spaprivileged.settingsprovider.settingsGlobalBoolean
 
 class MobileNetworkSettingsSearchIndex(
     private val searchItemsFactory: (context: Context) -> List<MobileNetworkSettingsSearchItem> =
@@ -113,6 +113,7 @@ class MobileNetworkSettingsSearchIndex(
         fun createSearchItems(context: Context): List<MobileNetworkSettingsSearchItem> =
             listOf(
                 BillingCycleSearchItem(context),
+                CarrierSettingsOverridesSearchItem(context),
                 CarrierSettingsVersionSearchItem(context),
                 DataUsageSearchItem(context),
                 MmsMessageSearchItem(context),

--- a/src/com/android/settings/network/telephony/carriersettingsoverride/CarrierConfigOverrideOptions.kt
+++ b/src/com/android/settings/network/telephony/carriersettingsoverride/CarrierConfigOverrideOptions.kt
@@ -1,0 +1,197 @@
+package com.android.settings.network.telephony.carriersettingsoverride
+
+import android.telephony.CarrierConfigManager
+import com.android.settings.R
+import com.android.settings.network.telephony.CarrierConfigRepository.KeyType
+
+/**
+ * This file contains all the possible carrier config override options that will appear in the UI
+ * To add a new option:
+ *
+ * 1. Create a new object subclassing [ChangeableCarrierConfigOption].
+ *    keysWithImportance specifies the keys that will be changed by the option.
+ *    allPossibleConfigStates should enumerate all possible expected states for those keys. The "use
+ *    default" option is added automatically elsewhere. You can mark user-selectable states that
+ *    will be shown to the user; everything is selectable by default. You should also give human-
+ *    readable strings for the options and the option title.
+ *
+ * 2. Add the new class to the allowedUserChangeableCarrierConfigFlags list below. This will allow
+ *    the UI to detect the option and render it.
+ *
+ * 3. Consider bumping the value of OverrideConfigConstants.MAX_OVERRIDES in
+ *    packages/apps/CarrierConfig2/overrideslibSrc if needed
+ */
+
+private val simpleUniformBoolStates: List<ConfigState> = listOf(
+    ConfigState.Simple(
+        CarrierConfigTypedValue.Bool(true),
+        R.string.carrier_settings_override_bool_true,
+        R.string.carrier_settings_default_bool_true,
+    ),
+    ConfigState.Simple(
+        CarrierConfigTypedValue.Bool(false),
+        R.string.carrier_settings_override_bool_false,
+        R.string.carrier_settings_default_bool_false,
+        isUserSelectable = false,
+    ),
+)
+
+// Add new options here so that the UI can display it
+val allowedUserChangeableCarrierConfigOptions: List<ChangeableCarrierConfigOption> by lazy {
+    listOf(
+
+        VoLTEAvailable,
+        VoNREnabled,
+        Enable5G,
+
+    ).also { list ->
+       list.onEach { flag ->
+            flag.possibleConfigStates.forEach { state ->
+                if (state is ConfigState.Complex) {
+                    val left = state.stateValues.size
+                    val right = flag.keys.size
+                    require(left == right) {
+                        "key size for ${flag.javaClass.simpleName} mismatch ($left != $right)"
+                    }
+                }
+            }
+        }
+        val numTotalKeys = list.sumOf { it.keys.size }
+        val max = 25
+        require(numTotalKeys <= max) {
+            "numTotalKeys $numTotalKeys exceeds max number of overrides $max"
+        }
+    }
+}
+
+data object VoLTEAvailable : ChangeableCarrierConfigOption(
+    // The keys that will be edited in this option
+    keysWithType = listOf(
+        CarrierConfigManager.KEY_CARRIER_VOLTE_AVAILABLE_BOOL to KeyType.BOOLEAN,
+        CarrierConfigManager.KEY_HIDE_ENHANCED_4G_LTE_BOOL to KeyType.BOOLEAN,
+    ),
+    // All possible values for the keys. Each of these can be an option that the user can select
+    allPossibleConfigStates = listOf(
+        // Enabled
+        ConfigState.Complex(
+            listOf(
+                CarrierConfigTypedValue.Bool(true), // KEY_CARRIER_VOLTE_AVAILABLE_BOOL
+                CarrierConfigTypedValue.Bool(false), // KEY_HIDE_ENHANCED_4G_LTE_BOOL
+            ),
+            R.string.carrier_settings_override_bool_true,
+            R.string.carrier_settings_default_bool_true,
+        ),
+        // Disabled
+        ConfigState.Complex(
+            listOf(
+                CarrierConfigTypedValue.Bool(false),
+                CarrierConfigTypedValue.Bool(true),
+            ),
+            R.string.carrier_settings_override_bool_false,
+            R.string.carrier_settings_default_bool_false,
+            isUserSelectable = false,
+        ),
+
+        // Other states not exposed for user selection just so that we have a description for them
+        // Disabled
+        ConfigState.Complex(
+            listOf(
+                CarrierConfigTypedValue.Bool(false),
+                CarrierConfigTypedValue.Bool(false),
+            ),
+            R.string.carrier_settings_override_bool_false,
+            R.string.carrier_settings_default_bool_false,
+            isUserSelectable = false,
+        ),
+        // Disabled
+        ConfigState.Complex(
+            listOf(
+                CarrierConfigTypedValue.Bool(true),
+                CarrierConfigTypedValue.Bool(true),
+            ),
+            R.string.carrier_settings_override_bool_false,
+            R.string.carrier_settings_default_bool_false,
+            isUserSelectable = false,
+        ),
+    )
+) {
+    override val titleStringRes = R.string.carrier_settings_override_volte_availability
+}
+
+data object VoNREnabled : ChangeableCarrierConfigOption(
+    keysWithType = listOf(
+        CarrierConfigManager.KEY_VONR_ENABLED_BOOL to KeyType.BOOLEAN,
+        CarrierConfigManager.KEY_VONR_SETTING_VISIBILITY_BOOL to KeyType.BOOLEAN,
+    ),
+    // Use uniform booleans (true true, false false), then cover other states not exposed for user
+    // selection just so that we have a description for them
+    allPossibleConfigStates = simpleUniformBoolStates + listOf(
+        // Not exposed for user
+        ConfigState.Complex(
+            listOf(
+                CarrierConfigTypedValue.Bool(true),
+                CarrierConfigTypedValue.Bool(false),
+            ),
+            R.string.carrier_settings_override_bool_false,
+            R.string.carrier_settings_default_bool_false,
+            isUserSelectable = false,
+        ),
+        ConfigState.Complex(
+            listOf(
+                CarrierConfigTypedValue.Bool(false),
+                CarrierConfigTypedValue.Bool(true),
+            ),
+            R.string.carrier_settings_override_bool_false,
+            R.string.carrier_settings_default_bool_false,
+            isUserSelectable = false,
+        ),
+    )
+) {
+    override val titleStringRes = R.string.carrier_settings_override_vonr_enable
+}
+
+data object Enable5G : ChangeableCarrierConfigOption(
+    keysWithType = listOf(
+        CarrierConfigManager.KEY_CARRIER_NR_AVAILABILITIES_INT_ARRAY to KeyType.INT_ARRAY,
+    ),
+    allPossibleConfigStates = listOf(
+        // Enabled (i.e. all the 5G NR capabilities)
+        ConfigState.Simple(
+            CarrierConfigTypedValue.IntegerArray(
+                listOf(
+                    CarrierConfigManager.CARRIER_NR_AVAILABILITY_NSA,
+                    CarrierConfigManager.CARRIER_NR_AVAILABILITY_SA,
+                )
+            ),
+            R.string.carrier_settings_override_5g_enabled_all_modes,
+            R.string.carrier_settings_override_5g_default_all_modes,
+        ),
+        // Only NSA
+        ConfigState.Simple(
+            CarrierConfigTypedValue.IntegerArray(
+                listOf(CarrierConfigManager.CARRIER_NR_AVAILABILITY_NSA)
+            ),
+            R.string.carrier_settings_override_5g_enabled_nsa,
+            R.string.carrier_settings_override_5g_default_nsa,
+            isUserSelectable = false,
+        ),
+        // Only SA
+        ConfigState.Simple(
+            CarrierConfigTypedValue.IntegerArray(
+                listOf(CarrierConfigManager.CARRIER_NR_AVAILABILITY_SA)
+            ),
+            R.string.carrier_settings_override_5g_enabled_sa,
+            R.string.carrier_settings_override_5g_default_sa,
+            isUserSelectable = false,
+        ),
+        // Disabled (i.e. no 5G NR capabilities)
+        ConfigState.Simple(
+            CarrierConfigTypedValue.IntegerArray(emptyList()),
+            R.string.carrier_settings_override_5g_disabled,
+            R.string.carrier_settings_default_5g_disabled,
+            isUserSelectable = false,
+        ),
+    )
+) {
+    override val titleStringRes = R.string.carrier_settings_override_5g_title
+}

--- a/src/com/android/settings/network/telephony/carriersettingsoverride/CarrierSettingsOverridesProvider.kt
+++ b/src/com/android/settings/network/telephony/carriersettingsoverride/CarrierSettingsOverridesProvider.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material.icons.outlined.Warning
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
@@ -45,7 +46,6 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavType
 import androidx.navigation.navArgument
 import com.android.settings.R
-import com.android.settings.network.telephony.carriersettingsoverride.CarrierSettingsOverridesViewModel.MessageType
 import com.android.settings.spa.network.CollectAirplaneModeAndFinishIfOn
 import com.android.settingslib.spa.framework.common.SettingsPageProvider
 import com.android.settingslib.spa.framework.theme.SettingsDimension
@@ -64,6 +64,7 @@ import com.android.settingslib.spa.widget.ui.SettingsIcon
 import com.android.settingslib.spaprivileged.model.enterprise.Restrictions
 import com.android.settingslib.spaprivileged.template.preference.RestrictedMainSwitchPreference
 import com.android.settingslib.spaprivileged.template.preference.RestrictedPreference
+import com.android.settings.network.telephony.carriersettingsoverride.CarrierSettingsOverridesViewModel.MessageType
 
 private const val SUB_ID_FOR_OVERRIDE = "subId"
 
@@ -168,6 +169,50 @@ object CarrierSettingsOverridesProvider : SettingsPageProvider {
                         isOverrideInProgress,
                         isOverrideActive
                     )
+                }
+            }
+
+            val unrecognizedOverrides by viewModel.unrecognizedOverrides
+                .collectAsStateWithLifecycle()
+            if (!unrecognizedOverrides.isNullOrEmpty()) {
+                Category(stringResource(R.string.carrier_settings_override_unrecognized_category_title)) {
+                    CompositionLocalProvider(
+                        LocalContentColor provides MaterialTheme.colorScheme.error
+                    ) {
+                        Preference(
+                            model = object : PreferenceModel {
+                                override val title = stringResource(
+                                    R.string.carrier_settings_override_unrecognized_warning_title
+                                )
+                                override val summary: () -> String = {
+                                    context.getString(
+                                        R.string.carrier_settings_override_unrecognized_warning_summary
+                                    )
+                                }
+                                override val icon = @Composable {
+                                    SettingsIcon(imageVector = Icons.Outlined.Warning)
+                                }
+                            }
+                        )
+                    }
+
+                    unrecognizedOverrides?.forEachInline { key, value ->
+                        Preference(
+                            model = object : PreferenceModel {
+                                override val title = key
+                                override val summary: () -> String = {
+                                    if (value is Array<*>) {
+                                        value.asList().toString()
+                                    } else {
+                                        value.toString()
+                                    }
+                                }
+                                override val icon = @Composable {
+                                    SettingsIcon(imageVector = Icons.Outlined.Warning)
+                                }
+                            }
+                        )
+                    }
                 }
             }
 

--- a/src/com/android/settings/network/telephony/carriersettingsoverride/CarrierSettingsOverridesProvider.kt
+++ b/src/com/android/settings/network/telephony/carriersettingsoverride/CarrierSettingsOverridesProvider.kt
@@ -1,0 +1,312 @@
+package com.android.settings.network.telephony.carriersettingsoverride
+
+import android.app.settings.SettingsEnums
+import android.content.Context
+import android.os.Bundle
+import android.os.UserManager
+import android.util.ArrayMap
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavType
+import androidx.navigation.navArgument
+import com.android.settings.R
+import com.android.settings.network.telephony.carriersettingsoverride.CarrierSettingsOverridesViewModel.MessageType
+import com.android.settings.spa.network.CollectAirplaneModeAndFinishIfOn
+import com.android.settingslib.spa.framework.common.SettingsPageProvider
+import com.android.settingslib.spa.framework.theme.SettingsDimension
+import com.android.settingslib.spa.widget.dialog.SettingsDialog
+import com.android.settingslib.spa.widget.preference.Preference
+import com.android.settingslib.spa.widget.preference.PreferenceModel
+import com.android.settingslib.spa.widget.preference.SwitchPreferenceModel
+import com.android.settingslib.spa.widget.preference.TopIntroPreference
+import com.android.settingslib.spa.widget.preference.TopIntroPreferenceModel
+import com.android.settingslib.spa.widget.scaffold.RegularScaffold
+import com.android.settingslib.spa.widget.ui.Category
+import com.android.settingslib.spa.widget.ui.Footer
+import com.android.settingslib.spa.widget.ui.SettingsBody
+import com.android.settingslib.spa.widget.ui.SettingsDialogItem
+import com.android.settingslib.spa.widget.ui.SettingsIcon
+import com.android.settingslib.spaprivileged.model.enterprise.Restrictions
+import com.android.settingslib.spaprivileged.template.preference.RestrictedMainSwitchPreference
+import com.android.settingslib.spaprivileged.template.preference.RestrictedPreference
+
+private const val SUB_ID_FOR_OVERRIDE = "subId"
+
+object CarrierSettingsOverridesProvider : SettingsPageProvider {
+    override val name = "CarrierSettingsOverridesProvider"
+    override val metricsCategory = SettingsEnums.MOBILE_NETWORK
+
+    override val parameter = listOf(
+        navArgument(SUB_ID_FOR_OVERRIDE) { type = NavType.IntType },
+    )
+
+    @Composable
+    override fun Page(arguments: Bundle?) {
+        val subId = arguments!!.getInt(com.android.settings.network.apn.SUB_ID)
+        val context = LocalContext.current
+        val viewModel = viewModel<CarrierSettingsOverridesViewModel>()
+        LaunchedEffect(subId) {
+            viewModel.init(subId)
+        }
+
+        val isOverrideInProgress by viewModel.isOverrideInProgress.collectAsStateWithLifecycle()
+        val isOverrideActive by viewModel.isAnOverrideActive.collectAsStateWithLifecycle()
+
+        CollectAirplaneModeAndFinishIfOn()
+
+        RegularScaffold(title = stringResource(R.string.carrier_settings_override_gos_title)) {
+            TopIntroPreference(model = object : TopIntroPreferenceModel {
+                override val text = stringResource(R.string.carrier_settings_override_intro_text)
+                override val expandText = stringResource(R.string.carrier_settings_override_intro_text_expand)
+                override val collapseText = stringResource(R.string.carrier_settings_override_intro_text_collapse)
+                override val alwaysExpand = true
+                override val labelText: Int? = null
+            })
+
+            RestrictedMainSwitchPreference(
+                model = object : SwitchPreferenceModel {
+                    override val title = stringResource(R.string.carrier_settings_override_main_switch_title)
+                    override val changeable = { !isOverrideInProgress }
+                    override val checked = { isOverrideActive }
+                    override val onCheckedChange: (Boolean) -> Unit = { _ ->
+                        viewModel.submitOverrides(clearOverrides = isOverrideActive)
+                    }
+                },
+                restrictions = Restrictions(keys = listOf(UserManager.DISALLOW_CONFIG_MOBILE_NETWORKS))
+            )
+
+            Category {
+                val message by viewModel.message.collectAsStateWithLifecycle(null)
+                AnimatedContent(
+                    targetState = message,
+                    transitionSpec = {
+                        // Make it fade / slide in from top and vice versa
+                        (fadeIn(tween(200)) + expandVertically()) togetherWith
+                                (fadeOut(tween(150)) + shrinkVertically())
+                    },
+                    label = "errorPref"
+                ) { msg ->
+                    when (msg) {
+                        is MessageType.ErrorMessage -> {
+                            CompositionLocalProvider(
+                                LocalContentColor provides MaterialTheme.colorScheme.error
+                            ) {
+                                Preference(
+                                    model = object : PreferenceModel {
+                                        override val title = msg.title
+                                            ?: stringResource(
+                                                R.string.carrier_settings_override_error_title
+                                            )
+                                        override val summary: () -> String = { msg.msg }
+                                        override val icon = @Composable {
+                                            SettingsIcon(imageVector = Icons.Outlined.Info)
+                                        }
+                                    }
+                                )
+                            }
+                        }
+                        MessageType.TurnOffToEdit -> {
+                            Preference(
+                                model = object : PreferenceModel {
+                                    override val title = stringResource(
+                                        R.string.carrier_settings_override_active_title
+                                    )
+                                    override val summary: () -> String = {
+                                        context.getString(
+                                            R.string.carrier_settings_override_active_summary
+                                        )
+                                    }
+                                    override val icon = @Composable {
+                                        SettingsIcon(imageVector = Icons.Outlined.Info)
+                                    }
+                                }
+                            )
+                        }
+                        null -> {}
+                    }
+                }
+
+                viewModel.overrideStates.forEach { flagState: CarrierConfigState ->
+                    CarrierSettingOverrideOptionPreference(
+                        flagState,
+                        context,
+                        isOverrideInProgress,
+                        isOverrideActive
+                    )
+                }
+            }
+
+            Footer(stringResource(R.string.carrier_settings_override_footer))
+        }
+    }
+
+    fun getRoute(subId: Int): String = "${name}/$subId"
+}
+
+private inline fun <K, V> ArrayMap<K, V>.forEachInline(action: (K, V) -> Unit) {
+    for (index in 0 until size) {
+        action(keyAt(index), valueAt(index))
+    }
+}
+
+@Composable
+private fun CarrierSettingOverrideOptionPreference(
+    flagState: CarrierConfigState,
+    context: Context,
+    isOverrideInProgress: Boolean,
+    isOverrideActive: Boolean
+) {
+    val selectedIndexForThisFlag by flagState.stateIndex
+    val currentState: ConfigState? = remember(selectedIndexForThisFlag) {
+        selectedIndexForThisFlag?.let { flagState.key.possibleConfigStates[it] }
+    }
+
+    var dialogOpened by rememberSaveable { mutableStateOf(false) }
+    if (dialogOpened) {
+        SettingsDialog(
+            title = stringResource(flagState.key.titleStringRes),
+            onDismissRequest = { dialogOpened = false },
+        ) {
+            Column(
+                modifier = Modifier.selectableGroup().verticalScroll(
+                    rememberScrollState()
+                )
+            ) {
+                val allStates = flagState.key.possibleConfigStates
+                allStates.forEachIndexed { index, possibleState ->
+                    if (!possibleState.isUserSelectable) return@forEachIndexed
+                    Radio(
+                        text = getSelectionText(context, flagState, possibleState),
+                        selected = index == selectedIndexForThisFlag,
+                        enabled = !isOverrideInProgress && !isOverrideActive,
+                        onSelected = {
+                            flagState.stateIndex.value = index
+                            dialogOpened = false
+                        }
+                    )
+                }
+            }
+        }
+    }
+
+    RestrictedPreference(
+        model = object : PreferenceModel {
+            override val title = context.getString(flagState.key.titleStringRes)
+            override val summary = {
+                getSelectionText(context, flagState, currentState)
+            }
+            override val icon = null
+            override val enabled = { !isOverrideInProgress && !isOverrideActive }
+            override val onClick = {
+                if (enabled()) dialogOpened = true
+            }
+        },
+        restrictions = Restrictions(keys = listOf(UserManager.DISALLOW_CONFIG_MOBILE_NETWORKS)),
+    )
+}
+
+private fun getSelectionText(
+    context: Context,
+    flagState: CarrierConfigState,
+    stateToDisplay: ConfigState?,
+): String {
+    return when (stateToDisplay) {
+        is ConfigState.ActiveState -> {
+            context.getString(stateToDisplay.selectionStringRes)
+        }
+        ConfigState.Inactive, null -> {
+            val active = flagState.getConfigStateFromIndex(useIndexOfCurrentConfigValue = true)
+                as? ConfigState.ActiveState
+            if (flagState.isOverriddenBefore.value) {
+                // Show as an overridden summary if the current state is from overridden config
+                // e.g. it will show "Force enabled"
+                active
+                    ?.selectionStringRes
+                    ?.let(context::getString)
+                    ?: context.getString(R.string.carrier_settings_default_unknown)
+            } else {
+                // Show as a default-value summary if the current state is not from overridden config
+                // e.g. it will show "Default (Enabled)"
+                val existingValString = active
+                    ?.existingValueStringRes
+                    ?.let(context::getString)
+                    ?: context.getString(R.string.carrier_settings_default_unknown)
+
+                context.getString(R.string.carrier_settings_override_default__s, existingValString)
+            }
+        }
+    }
+}
+
+/**
+ * Adapted from com.android.settingslib.spa.widget.preference.ListPreference
+ */
+@Composable
+private fun Radio(
+    text: String,
+    summary: String? = null,
+    selected: Boolean,
+    enabled: Boolean,
+    modifier: Modifier = Modifier,
+    onSelected: () -> Unit,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .selectable(
+                selected = selected,
+                enabled = enabled,
+                onClick = { onSelected() },
+                role = Role.RadioButton,
+            )
+            .padding(SettingsDimension.dialogItemPadding),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        RadioButton(selected = selected, onClick = null, enabled = enabled)
+        Spacer(modifier = Modifier.width(SettingsDimension.itemPaddingEnd))
+        Column {
+            SettingsDialogItem(text = text, enabled = enabled)
+            if (summary?.isNotEmpty() == true) {
+                SettingsBody(
+                    body = summary,
+                    maxLines = 2
+                )
+            }
+        }
+    }
+}

--- a/src/com/android/settings/network/telephony/carriersettingsoverride/CarrierSettingsOverridesState.kt
+++ b/src/com/android/settings/network/telephony/carriersettingsoverride/CarrierSettingsOverridesState.kt
@@ -1,0 +1,329 @@
+package com.android.settings.network.telephony.carriersettingsoverride
+
+import android.annotation.StringRes
+import android.os.PersistableBundle
+import android.util.Log
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.mutableStateOf
+import com.android.settings.network.telephony.CarrierConfigRepository
+import com.android.settings.network.telephony.CarrierConfigRepository.KeyType
+
+private const val TAG = "CarrierSetOverrideState"
+
+// See CarrierConfigOverrideOptions to add more options
+
+/**
+ * A class that represents a specific state for a carrier config override option. The state may
+ * be selectable or not by the user.
+ *
+ * e.g. for boolean flags, you would have [ConfigState] instance for "Enabled" which specifies
+ * the carrier config flag values for "Enabled", and another [ConfigState] for "Disabled" with its
+ * own flag values.
+ */
+@Immutable
+sealed class ConfigState {
+    /**
+     * Indicates the state where the override is not active.
+     */
+    data object Inactive : ConfigState() {
+        override val isUserSelectable: Boolean get() = true
+        override fun get(index: Int): CarrierConfigTypedValue? = null
+        override fun insertIntoBundle(keys: List<String>, bundle: PersistableBundle) {}
+        override fun testMatching(
+            key: String,
+            keyIndex: Int,
+            config: PersistableBundle,
+            overrideConfig: PersistableBundle
+        ): Boolean {
+            return !overrideConfig.containsKey(key)
+        }
+    }
+
+    /**
+     * Indicates a state where the override is active.
+     */
+    sealed class ActiveState : ConfigState() {
+        @get:StringRes abstract val selectionStringRes: Int
+        @get:StringRes abstract val existingValueStringRes: Int
+    }
+
+    /**
+     * Whether this state can be selected by the user in the UI or just something we display if
+     * the default values are set to this state.
+     */
+    abstract val isUserSelectable: Boolean
+
+    data class Simple(
+        val valueForAllKeys: CarrierConfigTypedValue,
+        @get:StringRes override val selectionStringRes: Int,
+        @get:StringRes override val existingValueStringRes: Int,
+        override val isUserSelectable: Boolean = true
+    ) : ActiveState() {
+        override fun get(index: Int): CarrierConfigTypedValue = valueForAllKeys
+        override fun insertIntoBundle(keys: List<String>, bundle: PersistableBundle) {
+            keys.forEach{ key ->
+                doInsertion(valueForAllKeys, bundle, key)
+            }
+        }
+
+        override fun testMatching(
+            key: String,
+            keyIndex: Int,
+            config: PersistableBundle,
+            overrideConfig: PersistableBundle
+        ): Boolean {
+            return valueForAllKeys.matchesValue(key, config)
+        }
+    }
+
+    /**
+     *  For when a set of flags have different values per setting. size of [stateValues] is
+     *  expected to be the same as the size of the keys list.
+     */
+    data class Complex(
+        val stateValues: List<CarrierConfigTypedValue>,
+        @get:StringRes override val selectionStringRes: Int,
+        @get:StringRes override val existingValueStringRes: Int,
+        override val isUserSelectable: Boolean = true
+    ) : ActiveState() {
+        override fun get(index: Int): CarrierConfigTypedValue = stateValues[index]
+        override fun insertIntoBundle(keys: List<String>, bundle: PersistableBundle) {
+            keys.forEachIndexed { index, key -> doInsertion(stateValues[index], bundle, key) }
+        }
+
+        override fun testMatching(
+            key: String,
+            keyIndex: Int,
+            config: PersistableBundle,
+            overrideConfig: PersistableBundle
+        ): Boolean {
+            val typedValue = stateValues[keyIndex]
+            return typedValue.matchesValue(key, config)
+        }
+
+    }
+
+    abstract operator fun get(index: Int): CarrierConfigTypedValue?
+
+    abstract fun insertIntoBundle(keys: List<String>, bundle: PersistableBundle)
+
+    protected abstract fun testMatching(
+        key: String,
+        keyIndex: Int,
+        config: PersistableBundle,
+        overrideConfig: PersistableBundle
+    ): Boolean
+
+    /**
+     * Determines whether the values in [config] and [overrideConfig] match with this particular
+     * config state.
+     */
+    fun isMatchingConfig(
+        keys: List<String>,
+        subsetKeyIndices: List<Int>,
+        config: PersistableBundle,
+        overrideConfig: PersistableBundle
+    ): Boolean {
+        subsetKeyIndices.forEach { index ->
+            val key = keys[index]
+            if (!testMatching(key, index, config, overrideConfig)) {
+                return false
+            }
+        }
+        return true
+    }
+
+    fun doInsertion(
+        stateVal: CarrierConfigTypedValue,
+        bundle: PersistableBundle,
+        key: String,
+    ) {
+        when (stateVal) {
+            is CarrierConfigTypedValue.Bool ->
+                stateVal.currentValue?.let { bundle.putBoolean(key, it) }
+            is CarrierConfigTypedValue.Integer ->
+                stateVal.currentValue?.let { bundle.putInt(key, it) }
+            is CarrierConfigTypedValue.IntegerArray ->
+                stateVal.currentValue?.let { bundle.putIntArray(key, it.toIntArray()) }
+            is CarrierConfigTypedValue.Str ->
+                stateVal.currentValue?.let { bundle.putString(key, it) }
+        }
+    }
+}
+
+/**
+ * Specifies a user-facing option for a set of carrier config flags
+ *
+ * @param keysWithType specifies the keys for the config flags that will be edited by this u
+ * @param allPossibleConfigStates specifies all the possible values for this option.
+ * For example, for 5G, you would need to do FLAG_ENABLED and FLAG_UI_ENABLED. So the possible
+ * options would be:
+ *  - FLAG_ENABLED and FLAG_UI_ENABLED: "Enabled"
+ *  - !FLAG_ENABLED and !FLAG_UI_ENABLED: "Disabled"
+ * And we can consider all other options as disabled.
+ */
+@Stable
+sealed class ChangeableCarrierConfigOption(
+    keysWithType: List<Pair<String, KeyType>>,
+    allPossibleConfigStates: List<ConfigState>,
+) {
+    @get:StringRes
+    abstract val titleStringRes: Int
+
+    /**
+     * List of all possible config states including disabled.
+     */
+    val possibleConfigStates: List<ConfigState> = allPossibleConfigStates + listOf(ConfigState.Inactive)
+
+    val keys: List<String> = keysWithType.map { it.first }
+    val types: List<KeyType> = keysWithType.map { it.second }
+
+    fun findMatchingConfigStateIndex(
+        currentConfig: PersistableBundle,
+        activeOverrides: PersistableBundle
+    ): Int? {
+        Log.d(TAG, "findMatchingConfigStateIndex for ${this.javaClass.simpleName}")
+        require(possibleConfigStates.last() is ConfigState.Inactive)
+        require(possibleConfigStates.isNotEmpty())
+
+        // Note that the current config values already include the active overrides
+        val indicesOfKeysInConfig: List<Int> = keys.asSequence()
+            .withIndex()
+            .filter { currentConfig.containsKey(it.value) }
+            .map { it.index }
+            .toList()
+
+        Log.d(TAG, "indicesOfKeysInConfig: $indicesOfKeysInConfig")
+        if (indicesOfKeysInConfig.isEmpty()) {
+            // Match to the disabled option
+            return possibleConfigStates.indices.last
+        }
+
+        return possibleConfigStates.asSequence()
+            .withIndex()
+            .filter {
+                it.value.isMatchingConfig(
+                    keys, indicesOfKeysInConfig, currentConfig, activeOverrides
+                )
+            }
+            .map { it.index }
+            .firstOrNull()
+    }
+}
+
+@Immutable
+sealed class CarrierConfigTypedValue {
+    abstract val currentValue: Any?
+    fun matchesValue(key: String, bundle: PersistableBundle): Boolean {
+        if (!bundle.containsKey(key)) {
+            return currentValue == null
+        }
+        return matchesValueInner(key, bundle)
+    }
+    protected abstract fun matchesValueInner(key: String, bundle: PersistableBundle): Boolean
+    data class Bool(
+        override val currentValue: Boolean?,
+    ) : CarrierConfigTypedValue() {
+        override fun matchesValueInner(key: String, bundle: PersistableBundle) =
+            bundle.getBoolean(key) == currentValue
+    }
+    data class Str(
+        override val currentValue: String?,
+    ) : CarrierConfigTypedValue() {
+        override fun matchesValueInner(key: String, bundle: PersistableBundle) =
+            bundle.getString(key) == currentValue
+    }
+    data class Integer(
+        override val currentValue: Int?,
+    ) : CarrierConfigTypedValue() {
+        override fun matchesValueInner(key: String, bundle: PersistableBundle) =
+            bundle.getInt(key) == currentValue
+    }
+    data class IntegerArray(
+        // represent as a List (zero-copy representation of array in Kotlin) for hashcode/equals
+        override val currentValue: List<Int>?,
+    ) : CarrierConfigTypedValue() {
+        override fun matchesValueInner(key: String, bundle: PersistableBundle) =
+            bundle.getIntArray(key)?.asList() == currentValue
+    }
+}
+
+/**
+ * UI-facing state for a specific carrier config override option. e.g., we would have an instance
+ * of this to store state for VoLTE overrides, and another instance for VoNR state.
+ *
+ * Stores info such as which state is selected and whether this state value is from an overridden
+ * value.
+ */
+@Stable
+data class CarrierConfigState(
+    /**
+     * The specific option. This stores all possible states for the option, along with some string
+     * resources to display in the UI, etc.
+     */
+    val key: ChangeableCarrierConfigOption,
+    /**
+     * An index to the state prior to entering the carrier config overrides screen, i.e. the
+     * existing state
+     */
+    val indexOfValueBefore: Int?,
+    /**
+     * An index to the current selection for this carrier config override option
+     */
+    val stateIndex: MutableState<Int?> = mutableStateOf(null),
+    /**
+     * Whether this carrier config option is from an active override. If this is true, we expect
+     * that this state can't be changed until all overrides are removed.
+     */
+    val isOverriddenBefore: MutableState<Boolean> = mutableStateOf(false),
+) {
+    fun getConfigStateFromIndex(useIndexOfCurrentConfigValue: Boolean = false): ConfigState? {
+        val index = if (useIndexOfCurrentConfigValue) {
+            indexOfValueBefore
+        } else {
+            stateIndex.value
+        }
+        return index?.let { key.possibleConfigStates[index] }
+    }
+
+    companion object {
+        fun createState(
+            subId: Int,
+            repo: CarrierConfigRepository,
+            flag: ChangeableCarrierConfigOption,
+            activeOverride: PersistableBundle
+        ): CarrierConfigState {
+            val currentAsBundle: PersistableBundle = repo.transformConfig(subId) {
+                val bundle = PersistableBundle()
+                flag.keys.forEachIndexed { index, key ->
+                    val type = flag.types[index]
+                    when (type) {
+                        KeyType.BOOLEAN -> bundle.putBoolean(key, getBoolean(key))
+                        KeyType.INT -> bundle.putInt(key, getInt(key))
+                        KeyType.INT_ARRAY -> bundle.putIntArray(key, getIntArray(key))
+                        KeyType.STRING -> bundle.putString(key, getString(key))
+                    }
+                }
+                bundle
+            }
+
+            Log.d(TAG, "currentAsBundle: $currentAsBundle")
+
+            val indexOfClosestMatch = flag.findMatchingConfigStateIndex(currentAsBundle, activeOverride)
+
+            val isOverridden = !activeOverride.isEmpty &&
+                    flag.keys.any { key -> activeOverride.containsKey(key) }
+            // Set this so that when entering back into the screen with an override active, the
+            // corresponding options gets selected
+            val index: Int? = if (isOverridden) indexOfClosestMatch else null
+            return CarrierConfigState(
+                key = flag,
+                indexOfValueBefore = indexOfClosestMatch,
+                stateIndex = mutableStateOf(index),
+                isOverriddenBefore = mutableStateOf(isOverridden)
+            )
+        }
+    }
+}

--- a/src/com/android/settings/network/telephony/carriersettingsoverride/CarrierSettingsOverridesViewModel.kt
+++ b/src/com/android/settings/network/telephony/carriersettingsoverride/CarrierSettingsOverridesViewModel.kt
@@ -1,0 +1,303 @@
+package com.android.settings.network.telephony.carriersettingsoverride
+
+import android.app.Application
+import android.net.Uri
+import android.os.Bundle
+import android.os.PersistableBundle
+import android.os.RemoteException
+import android.telephony.CarrierConfigManager
+import android.telephony.SubscriptionManager
+import android.telephony.TelephonyFrameworkInitializer
+import android.util.Log
+import androidx.compose.runtime.mutableStateListOf
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.application
+import androidx.lifecycle.viewModelScope
+import com.android.internal.telephony.ISub
+import com.android.settings.R
+import com.android.settings.network.telephony.CarrierConfigRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.asExecutor
+import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.conflate
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.shareIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+
+private const val TAG = "CarriSettOverridVM"
+
+class CarrierSettingsOverridesViewModel(application: Application) : AndroidViewModel(application) {
+
+    private val subscriptionService = ISub.Stub.asInterface(
+        TelephonyFrameworkInitializer
+            .getTelephonyServiceManager()
+            .subscriptionServiceRegisterer
+            .get()
+    )
+
+    private val carrierConfigRepo = CarrierConfigRepository(application)
+    private val carrierConfigManager: CarrierConfigManager? =
+        application.getSystemService(CarrierConfigManager::class.java)
+
+    private val authority = Uri.parse(
+        "content://app.grapheneos.carrierconfig2.UpdateConfigProvider"
+    )
+
+    private fun carrierConfigChanges(subId: Int): Flow<Unit> = callbackFlow {
+        val manager = carrierConfigManager
+        if (manager == null) {
+            close()
+            return@callbackFlow
+        }
+
+        val executor = Dispatchers.Default.asExecutor()
+        val listener = CarrierConfigManager.CarrierConfigChangeListener { _, subscriptionId, _, _ ->
+            if (subscriptionId == subId) {
+                trySend(Unit)
+            }
+        }
+
+        Log.d(TAG, "registering config listener")
+        manager.registerCarrierConfigChangeListener(executor, listener)
+        awaitClose {
+            Log.d(TAG, "unregistering config listener")
+            manager.unregisterCarrierConfigChangeListener(listener)
+        }
+    }.conflate()
+
+    private val subId = MutableStateFlow(SubscriptionManager.INVALID_SUBSCRIPTION_ID)
+
+    private val carrierConfigUpdatePing: SharedFlow<Unit> =
+        subId
+            .filter { it != SubscriptionManager.INVALID_SUBSCRIPTION_ID }
+            .flatMapLatest { sid -> carrierConfigChanges(sid) }
+            .shareIn(
+                scope = viewModelScope,
+                started = SharingStarted.Lazily,
+                replay = 0
+            )
+
+    private val _overrideStates = mutableStateListOf<CarrierConfigState>()
+    val overrideStates: List<CarrierConfigState>
+        get() = _overrideStates
+
+    /**
+     * Whether the SIM is currently using an active override
+     */
+    private val _isAnOverrideActive = MutableStateFlow(false)
+    val isAnOverrideActive: StateFlow<Boolean> = _isAnOverrideActive
+
+    private var isInitialized = false
+
+    fun init(subId: Int) {
+        if (isInitialized) return
+
+        this.subId.update { oldSubId ->
+            if (oldSubId == SubscriptionManager.INVALID_SUBSCRIPTION_ID) {
+                subId
+            } else {
+                return
+            }
+        }
+        viewModelScope.launch(Dispatchers.Default) {
+            reloadFromCarrierConfig()
+
+            isInitialized = true
+        }
+    }
+
+    private suspend fun setOverrideConfig(newOverrides: PersistableBundle?): Boolean {
+        if (!subscriptionService.setExtOverrideConfigs(subId.value, newOverrides)) {
+            return false
+        }
+
+        val extras = Bundle().apply { putInt("subId", subId.value) }
+        application.contentResolver.call(authority, "updateConfig", null, extras)
+        return true
+    }
+
+    private suspend fun getOverrideConfigForSubId(): PersistableBundle? {
+        return subscriptionService.getExtOverrideConfigs(subId.value)
+    }
+
+    private suspend fun reloadFromCarrierConfig() {
+
+        val activeOverrides = try {
+            getOverrideConfigForSubId()
+        } catch (e: RemoteException) {
+            Log.e(TAG, "error getting activeOverrides", e)
+            _message.update {
+                MessageType.ErrorMessage(
+                    application.getString(
+                        R.string.carrier_settings_override_error_unable_to_connect_to_config__s,
+                        e.message
+                    )
+                )
+            }
+            null
+        }
+        Log.d(TAG, "activeOverrides: $activeOverrides")
+        _isAnOverrideActive.update { activeOverrides?.isEmpty == false }
+
+        // Construct states
+        val configList = allowedUserChangeableCarrierConfigOptions.map { flagKey ->
+            val state = CarrierConfigState.createState(
+                subId.value,
+                carrierConfigRepo,
+                flagKey,
+                activeOverrides ?: PersistableBundle()
+            )
+            if (state.isOverriddenBefore.value && !_isAnOverrideActive.value) {
+                _isAnOverrideActive.update { true }
+            }
+            state
+        }
+
+        Log.d(TAG, "new configList is $configList")
+        withContext(Dispatchers.Main) {
+            if (_overrideStates.isEmpty()) {
+                _overrideStates.addAll(configList)
+            } else {
+                // preserve the selections if just trying to reload with latest state
+                _overrideStates.indices.forEach { index ->
+                    val newState = configList[index]
+                    _overrideStates[index] = _overrideStates[index].copy(
+                        indexOfValueBefore = newState.indexOfValueBefore,
+                        isOverriddenBefore = newState.isOverriddenBefore
+                    )
+                }
+            }
+        }
+    }
+
+    private val _isOverriding = MutableStateFlow(false)
+    val isOverrideInProgress: StateFlow<Boolean> = _isOverriding
+
+    sealed class MessageType {
+        data class ErrorMessage(val msg: String, val title: String? = null) : MessageType()
+        data object TurnOffToEdit : MessageType()
+    }
+
+    private val _message = MutableStateFlow<MessageType?>(null)
+    val message: Flow<MessageType?> =
+        combine(_message, _isAnOverrideActive) { errorMsg, active ->
+            errorMsg
+                ?: if (active) {
+                    MessageType.TurnOffToEdit
+                } else {
+                    null
+                }
+        }.distinctUntilChanged()
+
+    private val gate = Mutex()
+    fun submitOverrides(clearOverrides: Boolean): Unit = viewModelScope.launch {
+        if (!isInitialized) return@launch
+        if (!gate.tryLock()) return@launch
+        _isOverriding.update { true }
+        try {
+            val overrides: PersistableBundle? = if (clearOverrides) {
+                null
+            } else {
+                val bundle = PersistableBundle()
+                for (state in _overrideStates) {
+                    // null index means disabled. But the disabled option at the end could be
+                    // selected as well resulting in non-null configState.
+                    val configState = state.getConfigStateFromIndex() ?: continue
+                    configState.insertIntoBundle(state.key.keys, bundle)
+                }
+
+                if (bundle.isEmpty) {
+                    Log.d(TAG, "attempting to submit no overrides but not disabling")
+                    _message.update {
+                        MessageType.ErrorMessage(
+                            application.getString(
+                                R.string.carrier_settings_override_no_override_selected_message
+                            ),
+                            title = application.getString(
+                                R.string.carrier_settings_override_no_override_selected_title
+                            ),
+                        )
+                    }
+                    return@launch
+                }
+
+                bundle
+            }
+            Log.d(TAG, "submitting overrides $overrides")
+
+
+            try {
+                runThenAwaitCarrierConfigUpdateIfTrue {
+                    if (setOverrideConfig(overrides)) {
+                        _message.update { null }
+                        true
+                    } else {
+                        _message.update {
+                            MessageType.ErrorMessage(
+                                application.getString(
+                                    R.string.carrier_settings_override_error_unable_to_connect_to_config__s,
+                                    "setExtOverrideConfigs false"
+                                )
+                            )
+                        }
+                        false
+                    }
+                }
+            } catch (e: RemoteException) {
+                Log.e(TAG, "error while overriding config", e)
+                _message.update { MessageType.ErrorMessage("RemoteException: ${e.message}") }
+            }
+            reloadFromCarrierConfig()
+            // delay so user can't spam quickly
+            delay(250L)
+        } finally {
+            gate.unlock()
+            _isOverriding.update { false }
+        }
+    }.let { }
+
+    private suspend inline fun runThenAwaitCarrierConfigUpdateIfTrue(
+        timeoutMillis: Long = 2000L,
+        crossinline block: suspend () -> Boolean
+    ) {
+        coroutineScope {
+            // setOverrideConfig, etc. do the updates asynchronously, so the config is not
+            // guaranteed to update immediately after RPC Binder calls. Wait until an update is
+            // broadcast after making the override call.
+            //
+            // Start waiting here to avoid missing very a fast update.
+            val waiter = async { carrierConfigUpdatePing.first() }
+            try {
+                if (block()) {
+                    withTimeoutOrNull(timeoutMillis) {
+                        waiter.await()
+                    }
+                }
+            } finally {
+                waiter.cancel()
+            }
+        }
+    }
+}
+
+private suspend fun <T> Flow<T>.firstWithTimeoutOrNull(timeMillis: Long = 1000): T? =
+    withTimeoutOrNull(timeMillis) {
+        filter { it != null }.first()
+    }

--- a/src/com/android/settings/network/telephony/carriersettingsoverride/CarrierSettingsOverridesViewModel.kt
+++ b/src/com/android/settings/network/telephony/carriersettingsoverride/CarrierSettingsOverridesViewModel.kt
@@ -8,12 +8,14 @@ import android.os.RemoteException
 import android.telephony.CarrierConfigManager
 import android.telephony.SubscriptionManager
 import android.telephony.TelephonyFrameworkInitializer
+import android.util.ArrayMap
 import android.util.Log
 import androidx.compose.runtime.mutableStateListOf
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.application
 import androidx.lifecycle.viewModelScope
 import com.android.internal.telephony.ISub
+import com.android.internal.telephony.ICarrierConfigLoader
 import com.android.settings.R
 import com.android.settings.network.telephony.CarrierConfigRepository
 import kotlinx.coroutines.Dispatchers
@@ -49,6 +51,12 @@ class CarrierSettingsOverridesViewModel(application: Application) : AndroidViewM
         TelephonyFrameworkInitializer
             .getTelephonyServiceManager()
             .subscriptionServiceRegisterer
+            .get()
+    )
+
+    private val carrierConfigLoader = ICarrierConfigLoader.Stub.asInterface(
+        TelephonyFrameworkInitializer.getTelephonyServiceManager()
+            .carrierConfigServiceRegisterer
             .get()
     )
 
@@ -123,6 +131,9 @@ class CarrierSettingsOverridesViewModel(application: Application) : AndroidViewM
         }
     }
 
+    private val _unrecognizedOverrides = MutableStateFlow<ArrayMap<String, Any?>?>(null)
+    val unrecognizedOverrides: StateFlow<ArrayMap<String, Any?>?> = _unrecognizedOverrides
+
     private suspend fun setOverrideConfig(newOverrides: PersistableBundle?): Boolean {
         if (!subscriptionService.setExtOverrideConfigs(subId.value, newOverrides)) {
             return false
@@ -155,6 +166,28 @@ class CarrierSettingsOverridesViewModel(application: Application) : AndroidViewM
         }
         Log.d(TAG, "activeOverrides: $activeOverrides")
         _isAnOverrideActive.update { activeOverrides?.isEmpty == false }
+
+        // Display any overrides from AOSP. We expect these to not be set, because
+        // CarrierConfigLoader's overrideConfig is normally just a test API.
+        val overridesFromAosp: PersistableBundle = carrierConfigLoader
+            .getOverrideConfigForSubIdWithFeature(
+                subId.value,
+                application.opPackageName,
+                application.attributionTag
+            )
+        if (overridesFromAosp.isEmpty) {
+            _unrecognizedOverrides.update { null }
+        } else {
+            // every override from AOSP is unrecognized
+            val newUnrecognizedOverrides = ArrayMap<String, Any?>()
+            overridesFromAosp.keySet().forEach { key ->
+                newUnrecognizedOverrides[key] = overridesFromAosp.get(key)
+            }
+            Log.d(TAG, "found newUnrecognizedOverrides: $newUnrecognizedOverrides")
+            _unrecognizedOverrides.update {
+                newUnrecognizedOverrides.ifEmpty { null }
+            }
+        }
 
         // Construct states
         val configList = allowedUserChangeableCarrierConfigOptions.map { flagKey ->
@@ -258,6 +291,14 @@ class CarrierSettingsOverridesViewModel(application: Application) : AndroidViewM
                             )
                         }
                         false
+                    }
+                }
+
+                if (clearOverrides && !_unrecognizedOverrides.value.isNullOrEmpty()) {
+                    Log.d(TAG, "clearing all AOSP overrides")
+                    runThenAwaitCarrierConfigUpdateIfTrue {
+                        carrierConfigLoader.overrideConfig(subId.value, null, true)
+                        true
                     }
                 }
             } catch (e: RemoteException) {

--- a/src/com/android/settings/spa/SettingsSpaEnvironment.kt
+++ b/src/com/android/settings/spa/SettingsSpaEnvironment.kt
@@ -48,6 +48,7 @@ import com.android.settings.spa.core.instrumentation.SpaLogMetricsProvider
 import com.android.settings.spa.development.UsageStatsPageProvider
 import com.android.settings.spa.development.compat.PlatformCompatAppListPageProvider
 import com.android.settings.spa.home.HomePageProvider
+import com.android.settings.network.telephony.carriersettingsoverride.CarrierSettingsOverridesProvider
 import com.android.settings.spa.network.NetworkAndInternetPageProvider
 import com.android.settings.spa.network.NetworkCellularGroupProvider
 import com.android.settings.spa.network.SimOnboardingPageProvider
@@ -135,6 +136,7 @@ open class SettingsSpaEnvironment(context: Context) : SpaEnvironment(context) {
         NetworkCellularGroupProvider(),
         WifiPrivacyPageProvider,
         PrintSettingsPageProvider,
+        CarrierSettingsOverridesProvider,
     )
 
     override val logger = if (FeatureFlagUtils.isEnabled(


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/os-issue-tracker/issues/956

Requires changes in
- frameworks/base to fix some issues with UI components, expose a method to return config overrides in the CarrierConfigLoader, and infrastructure for extended SIM state: https://github.com/GrapheneOS/platform_frameworks_base/pull/256
- frameworks/opt/telephony: https://github.com/GrapheneOS/platform_frameworks_opt_telephony/pull/11
- platform/packages/TelephonyProvider for infrastructure for extended SIM state (https://github.com/GrapheneOS/platform_packages_providers_TelephonyProvider/pull/3)
- https://github.com/GrapheneOS/platform_packages_apps_CarrierConfig2/pull/4
- packages/app/Settings (here)
- packages/services/Telephony for implementing the method in CarrierConfigLoader to return config overrides: https://github.com/GrapheneOS/platform_packages_services_Telephony/pull/18

To add more options, see CarrierConfigOverrideOptions.kt.

<img src="https://github.com/user-attachments/assets/e3e1cc8a-c803-48e1-978a-897572470421" width=35% />