### PR TITLE
Add "VoLTE while roaming" and "Backup calling"

### DIFF
--- a/res/values/strings_ext.xml
+++ b/res/values/strings_ext.xml
@@ -297,6 +297,7 @@ May cause unreliable service. Use at your own risk.
     <string name="carrier_settings_override_bool_false">Force disabled</string>
     <string name="carrier_settings_override_default__s">Default (%1$s)</string>
     <string name="carrier_settings_override_volte_availability">VoLTE</string>
+    <string name="carrier_settings_override_volte_roaming">VoLTE (when roaming)</string>
     <string name="carrier_settings_override_vonr_enable">VoNR</string>
     <string name="carrier_settings_override_5g_title">5G capabilities</string>
     <string name="carrier_settings_override_5g_enabled_all_modes">Force NSA and SA</string>
@@ -307,4 +308,5 @@ May cause unreliable service. Use at your own risk.
     <string name="carrier_settings_override_5g_default_sa">SA</string>
     <string name="carrier_settings_override_5g_disabled">Force disabled</string>
     <string name="carrier_settings_default_5g_disabled">Disabled</string>
+    <string name="carrier_settings_override_backup_calling">Backup calling</string>
 </resources>

--- a/src/com/android/settings/network/telephony/carriersettingsoverride/CarrierConfigOverrideOptions.kt
+++ b/src/com/android/settings/network/telephony/carriersettingsoverride/CarrierConfigOverrideOptions.kt
@@ -41,8 +41,10 @@ val allowedUserChangeableCarrierConfigOptions: List<ChangeableCarrierConfigOptio
     listOf(
 
         VoLTEAvailable,
+        VoLTEWhileRoaming,
         VoNREnabled,
         Enable5G,
+        BackupCalling,
 
     ).also { list ->
        list.onEach { flag ->
@@ -116,6 +118,17 @@ data object VoLTEAvailable : ChangeableCarrierConfigOption(
     )
 ) {
     override val titleStringRes = R.string.carrier_settings_override_volte_availability
+}
+
+data object VoLTEWhileRoaming : ChangeableCarrierConfigOption(
+    // The keys that will be edited in this option
+    keysWithType = listOf(
+        CarrierConfigManager.KEY_CARRIER_DEFAULT_WFC_IMS_ROAMING_ENABLED_BOOL to KeyType.BOOLEAN,
+    ),
+    // All possible values for the keys. Each of these can be an option that the user can select
+    allPossibleConfigStates = simpleUniformBoolStates,
+) {
+    override val titleStringRes = R.string.carrier_settings_override_volte_roaming
 }
 
 data object VoNREnabled : ChangeableCarrierConfigOption(
@@ -194,4 +207,36 @@ data object Enable5G : ChangeableCarrierConfigOption(
     )
 ) {
     override val titleStringRes = R.string.carrier_settings_override_5g_title
+}
+
+data object BackupCalling : ChangeableCarrierConfigOption(
+    keysWithType = listOf(
+        CarrierConfigManager.KEY_CARRIER_CROSS_SIM_IMS_AVAILABLE_BOOL to KeyType.BOOLEAN,
+        CarrierConfigManager.KEY_ENABLE_CROSS_SIM_CALLING_ON_OPPORTUNISTIC_DATA_BOOL to KeyType.BOOLEAN,
+    ),
+    // Use uniform booleans (true true, false false), then cover other states not exposed for user
+    // selection just so that we have a description for them
+    allPossibleConfigStates = simpleUniformBoolStates + listOf(
+        // Not exposed for user
+        ConfigState.Complex(
+            listOf(
+                CarrierConfigTypedValue.Bool(true),
+                CarrierConfigTypedValue.Bool(false),
+            ),
+            R.string.carrier_settings_override_bool_false,
+            R.string.carrier_settings_default_bool_false,
+            isUserSelectable = false,
+        ),
+        ConfigState.Complex(
+            listOf(
+                CarrierConfigTypedValue.Bool(false),
+                CarrierConfigTypedValue.Bool(true),
+            ),
+            R.string.carrier_settings_override_bool_false,
+            R.string.carrier_settings_default_bool_false,
+            isUserSelectable = false,
+        ),
+    )
+) {
+    override val titleStringRes = R.string.carrier_settings_override_backup_calling
 }


### PR DESCRIPTION
This is a **draft** submission. I'm not able to compile GOS right now and I'm not quite sure if there's additional work needed in other modules. This is my first PR to GOS and I'm not used to the codebase, so forgive any lack of quality.

Please treat it as an issue with a suggested starting implementation.

---

Adds two additional settings:
- VoLTE while roaming
- Backup calling

See: https://github.com/GrapheneOS/os-issue-tracker/issues/4027

