### PR TITLE
16-qpr1 bluejay battery

### DIFF
--- a/TODO-16-qpr1
+++ b/TODO-16-qpr1
@@ -1,7 +1,4 @@
 Skipped commits:
-[temporary] bluejay-battery: handle both 16QPR1 and pre-16QPR1 UI
-bluejay-battery: switch battery tips to BannerMessagePreference for 16QPR1
-bluejay-battery: add battery replacement tip from stock OS
 "set distinct UI name for override_desktop_mode_features toggle": not clear if needed
 
 Potential issues:

--- a/res/drawable/ic_battery_charging_full_google.xml
+++ b/res/drawable/ic_battery_charging_full_google.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:tint="?attr/colorControlNormal"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <path
+        android:fillColor="@color/settingslib_materialColorOnSurface"
+        android:pathData="M660,880L660,760L560,760L700,560L700,680L800,680L660,880ZM360,800L360,800L360,800L360,800Q360,800 360,800Q360,800 360,800Q360,800 360,800Q360,800 360,800ZM320,880Q303,880 291.5,868.5Q280,857 280,840L280,200Q280,183 291.5,171.5Q303,160 320,160L400,160L400,80L560,80L560,160L640,160Q657,160 668.5,171.5Q680,183 680,200L680,480Q659,480 639,483.5Q619,487 600,494L600,240L360,240L360,800L454,800Q462,823 473.5,843Q485,863 501,880L320,880Z"/>
+</vector>

--- a/res/values/strings_google.xml
+++ b/res/values/strings_google.xml
@@ -8,6 +8,10 @@
     <string name="touch_sensitivity_title"/>
     <string name="touch_sensitivity_summary"/>
     <string name="charge_cycle_count"/>
+    <string name="battery_tip_early_replacement_summary"/>
+    <string name="help_url_battery_replacement"/>
+    <string name="battery_tip_replacement_title"/>
+    <string name="battery_tip_replacement_summary"/>
 
     <!-- SettingsIntelligenceGoogle -->
     <string name="charge_limit_indexing_keywords"/>

--- a/res/xml/power_usage_summary.xml
+++ b/res/xml/power_usage_summary.xml
@@ -45,7 +45,8 @@
         settings:controller="com.android.settings.fuelgauge.batterytip.BatteryTipPreferenceController" />
 
     <!-- Removed tag from stock OS:  android:featureFlag="com.google.android.systemui.enable_whiskey"-->
-    <com.android.settings.widget.TipCardPreference
+    <com.android.settingslib.widget.BannerMessagePreference
+        android:icon="@drawable/ic_battery_charging_full_google"
         android:title="@string/charge_cycle_count"
         android:key="cycle_count_tip"
         settings:controller="com.google.android.settings.fuelgauge.batterytip.CycleCountTipPreferenceController"

--- a/src/com/google/android/settings/fuelgauge/BatterySettingsFeatureProviderGoogleImpl.java
+++ b/src/com/google/android/settings/fuelgauge/BatterySettingsFeatureProviderGoogleImpl.java
@@ -7,8 +7,15 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.android.settings.R;
+import com.android.settings.fuelgauge.BatteryInfo;
 import com.android.settings.fuelgauge.BatterySettingsFeatureProviderImpl;
+import com.android.settings.fuelgauge.batterytip.BatteryTipPolicy;
+import com.android.settings.fuelgauge.batterytip.tips.BatteryTip;
 import com.android.settingslib.utils.PowerUtil;
+
+import com.google.android.settings.fuelgauge.batterytip.BatteryReplacementDetector;
+
+import java.util.List;
 
 // based on code from SettingsGoogle app
 public class BatterySettingsFeatureProviderGoogleImpl extends BatterySettingsFeatureProviderImpl {
@@ -57,5 +64,14 @@ public class BatterySettingsFeatureProviderGoogleImpl extends BatterySettingsFea
                     batteryPercentageString, targetTime);
         }
         return null;
+    }
+
+    @Override
+    public void addBatteryTipDetector(Context context, List<BatteryTip> batteryTips,
+            BatteryInfo batteryInfo, BatteryTipPolicy batteryTipPolicy) {
+        super.addBatteryTipDetector(context, batteryTips, batteryInfo, batteryTipPolicy);
+        if (Utils.isBarrelRequiredDevice(context)) {
+            batteryTips.addFirst(new BatteryReplacementDetector(context).detect());
+        }
     }
 }

--- a/src/com/google/android/settings/fuelgauge/batterytip/BatteryReplacementDetector.java
+++ b/src/com/google/android/settings/fuelgauge/batterytip/BatteryReplacementDetector.java
@@ -1,0 +1,43 @@
+package com.google.android.settings.fuelgauge.batterytip;
+
+import static com.google.android.settings.fuelgauge.batterytip.CycleCountTipPreferenceController.BATTERY_HEALTH_FAIR;
+import static com.google.android.settings.fuelgauge.batterytip.CycleCountTipPreferenceController.CYCLE_COUNT_THRESHOLD;
+import static com.google.android.settings.fuelgauge.batterytip.CycleCountTipPreferenceController.CYCLE_COUNT_UNAVAILABLE;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.BatteryManager;
+import android.util.Log;
+import com.android.settings.fuelgauge.BatteryUtils;
+import com.android.settings.fuelgauge.batterytip.tips.BatteryTip;
+
+public class BatteryReplacementDetector {
+    private final Context mContext;
+    private final static String TAG = BatteryReplacementDetector.class.getSimpleName();
+
+    public BatteryReplacementDetector(Context context) {
+        this.mContext = context;
+    }
+
+    public BatteryTip detect() {
+        final Intent batteryIntent = BatteryUtils.getBatteryIntent(mContext);
+        if (batteryIntent == null) {
+            return new BatteryReplacementTip(BatteryTip.StateType.INVISIBLE,
+                    BatteryManager.BATTERY_HEALTH_UNKNOWN);
+        }
+        int health = batteryIntent.getIntExtra(BatteryManager.EXTRA_HEALTH,
+                BatteryManager.BATTERY_HEALTH_UNKNOWN);
+        int cycleCount = batteryIntent.getIntExtra(BatteryManager.EXTRA_CYCLE_COUNT,
+                CYCLE_COUNT_UNAVAILABLE);
+        Log.d(TAG, "detect() - battery health: " + health + ", cycle count: " + cycleCount);
+
+        final @BatteryTip.StateType int state;
+        if (health == BatteryManager.BATTERY_HEALTH_DEAD ||
+                (health == BATTERY_HEALTH_FAIR && cycleCount >= CYCLE_COUNT_THRESHOLD)) {
+            state = BatteryTip.StateType.NEW;
+        } else {
+            state = BatteryTip.StateType.INVISIBLE;
+        }
+        return new BatteryReplacementTip(state, health);
+    }
+}

--- a/src/com/google/android/settings/fuelgauge/batterytip/BatteryReplacementTip.kt
+++ b/src/com/google/android/settings/fuelgauge/batterytip/BatteryReplacementTip.kt
@@ -1,0 +1,96 @@
+package com.google.android.settings.fuelgauge.batterytip
+
+import android.app.settings.SettingsEnums
+import android.content.Context
+import android.os.BatteryManager
+import android.os.Parcel
+import android.os.Parcelable
+import android.text.Html
+import android.util.Log
+import androidx.preference.Preference
+import com.android.settings.R
+import com.android.settings.fuelgauge.batterytip.tips.BatteryTip
+import com.android.settingslib.HelpUtils
+import com.android.settingslib.core.instrumentation.MetricsFeatureProvider
+import com.android.settingslib.widget.BannerMessagePreference
+
+private const val TAG = "BatteryReplacementTip"
+
+class BatteryReplacementTip : BatteryTip {
+    private var mBatteryHealth = 0
+
+    constructor(@StateType state: Int, batteryHealth: Int) : super(
+        TipType.BATTERY_HEALTH,
+        state,
+        false
+    ) {
+        mBatteryHealth = batteryHealth
+    }
+
+    constructor(parcel: Parcel) : super(parcel) {
+        mBatteryHealth = parcel.readInt()
+    }
+
+    override fun writeToParcel(dest: Parcel, flags: Int) {
+        super.writeToParcel(dest, flags)
+        dest.writeInt(mBatteryHealth)
+    }
+
+    override fun getTitle(context: Context): CharSequence {
+        return context.getString(R.string.battery_tip_replacement_title)
+    }
+
+    override fun getSummary(context: Context): CharSequence {
+        val stringRes = if (mBatteryHealth == BatteryManager.BATTERY_HEALTH_DEAD) {
+            R.string.battery_tip_replacement_summary
+        } else {
+            R.string.battery_tip_early_replacement_summary
+        }
+        return Html.fromHtml(context.getString(stringRes), 0);
+    }
+
+    override fun getIconId(): Int = R.drawable.ic_battery_alert_24dp
+
+    override fun updateState(tip: BatteryTip) {
+        mState = tip.state
+    }
+
+    override fun log(context: Context?, metricsFeatureProvider: MetricsFeatureProvider?) {
+        metricsFeatureProvider?.action(
+            context,
+            SettingsEnums.ACTION_BATTERY_HEALTH_TIP,
+            mState
+        )
+    }
+
+    override fun updatePreference(preference: Preference) {
+        super.updatePreference(preference)
+        val tipCardPref = preference as? BannerMessagePreference ?: return
+        tipCardPref.isSelectable = true
+        tipCardPref.onPreferenceClickListener = Preference.OnPreferenceClickListener onClick@ { _ ->
+            val context: Context = tipCardPref.context
+            val helpIntent = HelpUtils.getHelpIntent(
+                context,
+                context.getString(R.string.help_url_battery_replacement),
+                ""
+            ) ?: return@onClick true
+
+            try {
+                context.startActivity(helpIntent)
+            } catch (e: Exception) {
+                Log.e(TAG, "can't start action $helpIntent", e)
+            }
+            true
+        }
+    }
+
+    companion object CREATOR : Parcelable.Creator<BatteryReplacementTip> {
+        override fun createFromParcel(parcel: Parcel): BatteryReplacementTip {
+            return BatteryReplacementTip(parcel)
+        }
+
+        override fun newArray(size: Int): Array<BatteryReplacementTip?> {
+            return arrayOfNulls(size)
+        }
+    }
+}

--- a/src/com/google/android/settings/fuelgauge/batterytip/CycleCountTipPreferenceController.kt
+++ b/src/com/google/android/settings/fuelgauge/batterytip/CycleCountTipPreferenceController.kt
@@ -12,7 +12,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.preference.PreferenceScreen
 import com.android.settings.R
 import com.android.settings.core.BasePreferenceController
-import com.android.settings.widget.TipCardPreference
+import com.android.settingslib.widget.BannerMessagePreference
 import com.google.android.settings.fuelgauge.Utils
 
 class CycleCountTipPreferenceController(
@@ -34,7 +34,7 @@ class CycleCountTipPreferenceController(
     }
 
     private var batteryBroadcastReceiver: BroadcastReceiver? = null
-    private var cycleCountPreference: TipCardPreference? = null
+    private var cycleCountPreference: BannerMessagePreference? = null
 
     override fun getAvailabilityStatus(): Int {
         return if (Utils.isBarrelRequiredDevice(mContext)) {
@@ -46,9 +46,9 @@ class CycleCountTipPreferenceController(
 
     override fun displayPreference(screen: PreferenceScreen) {
         super.displayPreference(screen)
-        val preference = screen.findPreference<TipCardPreference>(preferenceKey) ?: return
-        preference.iconResId = R.drawable.ic_battery_charging_full
+        val preference = screen.findPreference<BannerMessagePreference>(preferenceKey) ?: return
         cycleCountPreference = preference
+        preference.setAttentionLevel(BannerMessagePreference.AttentionLevel.NORMAL)
         // set later in updatePreference
         preference.isVisible = false
     }
@@ -116,6 +116,8 @@ class CycleCountTipPreferenceController(
                 summary = convertCycleCountToString(cycleCount)
                 isVisible = true
             }
+        } else {
+            cycleCountPreference?.isVisible = false
         }
     }
 }


### PR DESCRIPTION
Requires https://github.com/GrapheneOS/adevtool/pull/266

In 16-qpr1, 84c8e3d73774819d04b25c05e7b40f1554301e61 removed some string entries for battery tips
from AOSP such as `help_url_battery_replacement`, `battery_tip_replacement_title`, and
`battery_tip_replacement_summary`. Requires adevtool change to retrieve the title string from SettingsGoogle; the other strings are already in the synthetic overlays

In 16-qpr1, b49d170117c6918efe56a883add4816c279fd2a9 added `TipType.BATTERY_HEALTH`. `BatteryReplacementTip` now uses this which addresses [the TODO from the `16` branch](https://github.com/GrapheneOS/platform_packages_apps_Settings/commit/542900c120c1b70c061e6cd3e746bf1005054d42#diff-e14107e80c553c1ec723fb69d6f59441321567c597e0469cd93da0309649fe4dR23-R25)

`ic_battery_charging_full` exists in AOSP but looks outdated with Expressive (e.g. coloring issues); added the Google version as a separate drawable for compatibility

<img src="https://github.com/user-attachments/assets/267b4811-46ff-4c35-8075-a777081835a8" width=30%/>
