### PR TITLE
fix port of the "add base class for ListPreference controllers" commit

### DIFF
--- a/src/com/android/settings/widget/RadioButtonPickerFragment.java
+++ b/src/com/android/settings/widget/RadioButtonPickerFragment.java
@@ -203,9 +203,6 @@ public abstract class RadioButtonPickerFragment extends SettingsPreferenceFragme
             addIllustration(screen);
         }
         addPrefsBeforeList(screen);
-        if (!mAppendStaticPreferences) {
-            addStaticPreferences(screen);
-        }
         PreferenceGroup radioButtonsGroup = screen;
         if (mCategoryTitleId != 0) {
             Context context = getPrefContext();


### PR DESCRIPTION
addStaticPreferences() call is an unintended duplicate. This bug broke the display color mode selection screen.