### PR TITLE
Revert "remove a large blank rectangle from "Quickly open camera" screen"

### DIFF
--- a/res/xml/double_tap_power_settings.xml
+++ b/res/xml/double_tap_power_settings.xml
@@ -19,6 +19,11 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:settings="http://schemas.android.com/apk/res-auto"
     android:title="@string/double_tap_power_title">
+    <com.android.settingslib.widget.IllustrationPreference
+        android:key="gesture_double_tap_power_video"
+        settings:searchable="false"
+        settings:lottie_rawRes="@drawable/quickly_open_camera"
+        settings:controller="com.android.settings.gestures.DoubleTapPowerIllustrationPreferenceController"/>
 
     <com.android.settingslib.widget.MainSwitchPreference
         android:key="gesture_double_tap_power_enabled_main_switch"

--- a/res/xml/double_tap_power_to_open_camera_settings.xml
+++ b/res/xml/double_tap_power_to_open_camera_settings.xml
@@ -20,6 +20,11 @@
     xmlns:settings="http://schemas.android.com/apk/res-auto"
     android:title="@string/double_tap_power_for_camera_title">
 
+    <com.android.settingslib.widget.IllustrationPreference
+        android:key="gesture_double_tap_power_video"
+        settings:searchable="false"
+        settings:lottie_rawRes="@drawable/quickly_open_camera"/>
+
     <SwitchPreferenceCompat
         android:key="gesture_double_tap_power"
         android:title="@string/double_tap_power_for_camera_title"

--- a/res/xml/firmware_version.xml
+++ b/res/xml/firmware_version.xml
@@ -37,14 +37,6 @@
         settings:enableCopying="true"
         settings:controller="com.android.settings.deviceinfo.firmwareversion.SecurityPatchLevelPreferenceController"/>
 
-    <!-- Mainline module version -->
-    <Preference
-        android:key="module_version"
-        android:title="@string/module_version"
-        android:summary="@string/summary_placeholder"
-        settings:enableCopying="true"
-        settings:controller="com.android.settings.deviceinfo.firmwareversion.MainlineModuleVersionPreferenceController"/>
-
     <!-- Baseband -->
     <Preference
         android:key="base_band"


### PR DESCRIPTION
The missing resource is now imported by adevtool.

Depends on https://github.com/GrapheneOS/adevtool/pull/270