### PR TITLE
Add high EMF (PWM) mode setting for Pixel 10 series

### DIFF
--- a/res/drawable/ic_high_emission_frequency.xml
+++ b/res/drawable/ic_high_emission_frequency.xml
@@ -1,0 +1,35 @@
+<!--
+     Copyright (C) 2022 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <com.android.settingslib.widget.AdaptiveIconShapeDrawable
+            android:width="@dimen/accessibility_icon_size"
+            android:height="@dimen/accessibility_icon_size"
+            android:color="@color/accessibility_feature_background"/>
+    </item>
+    <item android:gravity="center">
+        <vector
+            android:width="@dimen/accessibility_icon_foreground_size"
+            android:height="@dimen/accessibility_icon_foreground_size"
+            android:viewportWidth="960"
+            android:viewportHeight="960">
+            <path
+                android:fillColor="#ffffff"
+                android:pathData="M480,640Q555,640 607.5,587.5Q660,535 660,460Q660,385 607.5,332.5Q555,280 480,280Q405,280 352.5,332.5Q300,385 300,460Q300,535 352.5,587.5Q405,640 480,640ZM480,568Q435,568 403.5,536.5Q372,505 372,460Q372,415 403.5,383.5Q435,352 480,352Q525,352 556.5,383.5Q588,415 588,460Q588,505 556.5,536.5Q525,568 480,568ZM480,760Q334,760 214,678.5Q94,597 40,460Q94,323 214,241.5Q334,160 480,160Q626,160 746,241.5Q866,323 920,460Q866,597 746,678.5Q626,760 480,760ZM480,460Q480,460 480,460Q480,460 480,460Q480,460 480,460Q480,460 480,460Q480,460 480,460Q480,460 480,460Q480,460 480,460Q480,460 480,460ZM480,680Q593,680 687.5,620.5Q782,561 832,460Q782,359 687.5,299.5Q593,240 480,240Q367,240 272.5,299.5Q178,359 128,460Q178,561 272.5,620.5Q367,680 480,680Z"/>
+        </vector>
+    </item>
+</layer-list>

--- a/res/values/strings_google.xml
+++ b/res/values/strings_google.xml
@@ -12,6 +12,8 @@
     <string name="help_url_battery_replacement"/>
     <string name="battery_tip_replacement_title"/>
     <string name="battery_tip_replacement_summary"/>
+    <string name="emission_frequency_summary"/>
+    <string name="emission_frequency_title"/>
     <string name="enable_glanceable_hub_toggle_summary"/>
 
     <!-- SettingsIntelligenceGoogle -->

--- a/res/xml/accessibility_settings.xml
+++ b/res/xml/accessibility_settings.xml
@@ -72,6 +72,14 @@
             settings:keywords="@string/keywords_magnification"
             settings:controller="com.android.settings.accessibility.MagnificationPreferenceController"/>
 
+        <SwitchPreferenceCompat
+            android:key="high_emission_frequency"
+            android:icon="@drawable/ic_high_emission_frequency"
+            android:persistent="false"
+            android:title="@string/emission_frequency_title"
+            android:summary="@string/emission_frequency_summary"
+            settings:controller="com.google.android.settings.display.HighEmissionFrequencyController"/>
+
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/src/com/google/android/settings/display/HighEmissionFrequencyController.kt
+++ b/src/com/google/android/settings/display/HighEmissionFrequencyController.kt
@@ -1,0 +1,44 @@
+package com.google.android.settings.display
+
+import android.content.Context
+import android.os.UserHandle
+import android.provider.Settings
+import com.android.settings.R
+import com.android.settings.core.TogglePreferenceController
+
+class HighEmissionFrequencyController(context: Context, prefKey: String) :
+    TogglePreferenceController(context, prefKey) {
+    override fun getAvailabilityStatus(): Int {
+        // SettingsGoogle and PixelDisplayService both seem to assume that the array might not exist
+        // and perform a dynamic lookup. However, this array actually exists in AOSP and there's no
+        // reason we can't just use the static identifier.
+        val options = mContext.resources.getIntArray(com.android.internal.R.array.config_availableEMValueOptions)
+
+        // This differs slightly from SettingsGoogle, which checks if the array is exactly [0, 1].
+        return if (1 in options) {
+            AVAILABLE
+        } else {
+            UNSUPPORTED_ON_DEVICE
+        }
+    }
+
+    override fun isChecked(): Boolean {
+        return Settings.Secure.getIntForUser(
+            mContext.contentResolver,
+            Settings.Secure.EM_VALUE,
+            0,
+            UserHandle.USER_CURRENT,
+        ) == 1
+    }
+
+    override fun setChecked(isChecked: Boolean): Boolean {
+        return Settings.Secure.putIntForUser(
+            mContext.contentResolver,
+            Settings.Secure.EM_VALUE,
+            (if (isChecked) 1 else 0),
+            UserHandle.USER_CURRENT,
+        )
+    }
+
+    override fun getSliceHighlightMenuRes(): Int = R.string.menu_key_display
+}

--- a/src/com/google/android/settings/display/HighEmissionFrequencyController.kt
+++ b/src/com/google/android/settings/display/HighEmissionFrequencyController.kt
@@ -1,6 +1,7 @@
 package com.google.android.settings.display
 
 import android.content.Context
+import android.os.Build
 import android.os.UserHandle
 import android.provider.Settings
 import com.android.settings.R
@@ -16,7 +17,7 @@ class HighEmissionFrequencyController(context: Context, prefKey: String) :
 
         // This matches PixelDisplayService's check. Note that SettingsGoogle has a different
         // conditional, which checks if the array is exactly [0, 1].
-        return if (options.size >= 2) {
+        return if ("Google".equals(Build.MANUFACTURER) && options.size >= 2) {
             AVAILABLE
         } else {
             UNSUPPORTED_ON_DEVICE

--- a/src/com/google/android/settings/display/HighEmissionFrequencyController.kt
+++ b/src/com/google/android/settings/display/HighEmissionFrequencyController.kt
@@ -14,8 +14,9 @@ class HighEmissionFrequencyController(context: Context, prefKey: String) :
         // reason we can't just use the static identifier.
         val options = mContext.resources.getIntArray(com.android.internal.R.array.config_availableEMValueOptions)
 
-        // This differs slightly from SettingsGoogle, which checks if the array is exactly [0, 1].
-        return if (1 in options) {
+        // This matches PixelDisplayService's check. Note that SettingsGoogle has a different
+        // conditional, which checks if the array is exactly [0, 1].
+        return if (options.size >= 2) {
             AVAILABLE
         } else {
             UNSUPPORTED_ON_DEVICE


### PR DESCRIPTION
Depends on: https://github.com/GrapheneOS/adevtool/pull/273

---

This adds a setting for enabling the high emission frequency (480 Hz PWM) mode available on blazer, mustang, and rango. GrapheneOS already includes the PixelDisplayService implementation. The only missing component is the setting.

In the stock OS' SettingsGoogle and PixelDisplayService, the array resource lookup for `config_availableEMValueOptions` is done dynamically. However, this resource actually exists in AOSP (https://github.com/GrapheneOS/platform_frameworks_base/commit/644b6491408f2ab5a1c9558d1c452cb747c4469b), so we can just refer to it statically like all other resources.

The two strings for this option are pulled in via adevtool, but the icon is added directly in this commit because it contains references to other resources. The icon is an exact recreation of the stock OS icon. It turns out Google just used the `visibility` icon from the Apache 2.0 licensed Material Symbols project verbatim.

https://github.com/google/material-design-icons/blob/bb04090f930e272697f2a1f0d7b352d92dfeee43/symbols/android/visibility/materialsymbolsoutlined/visibility_24px.xml

---

I primarily tested this on a Pixel Tablet. With the default build, the option is hidden as expected. If I add an overlay to specify:

```xml
<array name="config_availableEMValueOptions">
    <item>0</item>
    <item>1</item>
</array>
```

then the setting shows up and changing the setting is reflected in:

```bash
adb shell settings get secure em_value
```

Unfortunately, I won't be able to test this on my Pixel 10 Pro XL until January due to an upcoming vacation.

In case anyone wants to test this on a Pixel 10, note that PixelDisplayService does not log the `check EM_VALUE setting <value>` message to logcat when changing the setting unless you're running an eng or userdebug build.