### PR TITLE
add per-user setting for end session button on lockscreen

### DIFF
--- a/res/values/strings_ext.xml
+++ b/res/values/strings_ext.xml
@@ -315,4 +315,6 @@ May cause unreliable service. Use at your own risk.
     <string name="carrier_settings_override_wfc_availability_on_summary">Includes Wi-Fi calling while roaming</string>
     <string name="carrier_settings_override_wfc_availability_enabled_not_editable">Available but state uneditable</string>
     <string name="carrier_settings_override_wfc_availability_enabled_roaming_not_editable">Available but roaming not editable</string>
+
+    <string name="user_settings_show_end_session_on_lock_screen">Show end session button on lock screen</string>
 </resources>

--- a/res/xml/user_settings.xml
+++ b/res/xml/user_settings.xml
@@ -123,4 +123,9 @@
             android:summary="@string/user_settings_send_censored_notifications_to_current_summary"
             android:order="108"/>
 
+    <SwitchPreferenceCompat
+        android:key="user_settings_show_end_session_on_lock_screen"
+        android:title="@string/user_settings_show_end_session_on_lock_screen"
+        android:order="109"/>
+
 </PreferenceScreen>

--- a/res/xml/user_settings.xml
+++ b/res/xml/user_settings.xml
@@ -112,10 +112,15 @@
         android:fragment="com.android.settings.users.TimeoutToDockUserSettings"
         settings:controller="com.android.settings.users.TimeoutToDockUserPreferenceController"/>
 
+    <PreferenceCategory
+        android:key="lockscreen_settings_u_category"
+        android:title="@string/lockscreen_settings_title"
+        android:order="107"/>
+
     <SwitchPreferenceCompat
             android:key="user_settings_send_censored_notifications_to_current"
             android:title="@string/user_settings_send_censored_notifications_to_current"
             android:summary="@string/user_settings_send_censored_notifications_to_current_summary"
-            android:order="106"/>
+            android:order="108"/>
 
 </PreferenceScreen>

--- a/src/com/android/settings/users/ShowEndSessionButtonOnLockScreenPreferenceController.java
+++ b/src/com/android/settings/users/ShowEndSessionButtonOnLockScreenPreferenceController.java
@@ -1,0 +1,60 @@
+package com.android.settings.users;
+
+import static android.os.UserManager.LOGOUTABILITY_STATUS_OK;
+
+import android.app.admin.DevicePolicyManager;
+import android.content.Context;
+import android.ext.settings.ExtSettings;
+import android.os.UserHandle;
+import android.os.UserManager;
+
+import com.android.settings.R;
+import com.android.settings.ext.BoolSettingPrefController;
+
+public class ShowEndSessionButtonOnLockScreenPreferenceController
+        extends BoolSettingPrefController {
+
+    private final UserManager mUserManager;
+    private final DevicePolicyManager mDPM;
+
+    static final String PREF_KEY = "user_settings_show_end_session_on_lock_screen";
+
+    public ShowEndSessionButtonOnLockScreenPreferenceController(Context context) {
+        super(context, PREF_KEY, ExtSettings.SHOW_END_SESSION_BUTTON_LOCK_SCREEN);
+        mUserManager = context.getSystemService(UserManager.class);
+        mDPM = context.getSystemService(DevicePolicyManager.class);
+    }
+
+    @Override
+    public int getAvailabilityStatus() {
+        // In SystemUI, the lockscreen logout button visibility from SystemUI follows this logic
+        // (note the boolean OR):
+        //
+        // val isLogoutEnabled: StateFlow<Boolean> =
+        //        combine(
+        //                userRepository.isPolicyManagerLogoutEnabled,
+        //                userRepository.isUserManagerLogoutEnabled,
+        //                Boolean::or,
+        //            )
+        //
+        // Both of these conditions are replicated here. For isUserManagerLogoutEnabled, skipped a
+        // check for com.android.internal.R.bool.config_userSwitchingMustGoThroughLoginScreen for
+        // simplicity.
+
+        // For the system user, getLogoutUser should be null due to a GrapheneOS change in fw/base
+        // ("fix DevicePolicyManager#logoutUser to succeed without device admin").
+        final boolean isPolicyManagerLogoutEnabled =
+                mDPM.isLogoutEnabled() && mDPM.getLogoutUser() != null;
+        // For the system user, this will be LOGOUTABILITY_STATUS_CANNOT_LOGOUT_SYSTEM_USER.
+        final boolean isUserManagerLogoutEnabled =
+                mUserManager.getUserLogoutability(UserHandle.myUserId()) == LOGOUTABILITY_STATUS_OK;
+
+        return isPolicyManagerLogoutEnabled || isUserManagerLogoutEnabled
+                ? AVAILABLE : DISABLED_FOR_USER;
+    }
+
+    @Override
+    public int getSliceHighlightMenuRes() {
+        return R.string.menu_key_system;
+    }
+}

--- a/src/com/android/settings/users/UserSettings.java
+++ b/src/com/android/settings/users/UserSettings.java
@@ -252,6 +252,7 @@ public class UserSettings extends SettingsPreferenceFragment
     private GuestTelephonyPreferenceController mGuestTelephonyPreferenceController;
     private RemoveGuestOnExitPreferenceController mRemoveGuestOnExitPreferenceController;
     private SendCensoredNotificationsToCurrentUserPreferenceController mSendCensoredNotificationsToCurrentUserPreferenceController;
+    private ShowEndSessionButtonOnLockScreenPreferenceController mShowEndSessionButtonOnLockScreenPreferenceController;
     private MultiUserTopIntroPreferenceController mMultiUserTopIntroPreferenceController;
     private TimeoutToDockUserPreferenceController mTimeoutToDockUserPreferenceController;
     private UserCreatingDialog mUserCreatingDialog;
@@ -348,6 +349,9 @@ public class UserSettings extends SettingsPreferenceFragment
                 new SendCensoredNotificationsToCurrentUserPreferenceController(activity,
                         KEY_SEND_CENSORED_NOTIFICATIONS);
 
+        mShowEndSessionButtonOnLockScreenPreferenceController =
+                new ShowEndSessionButtonOnLockScreenPreferenceController(activity);
+
         mMultiUserTopIntroPreferenceController = new MultiUserTopIntroPreferenceController(activity,
                 KEY_MULTIUSER_TOP_INTRO);
 
@@ -363,6 +367,7 @@ public class UserSettings extends SettingsPreferenceFragment
         mGuestTelephonyPreferenceController.displayPreference(screen);
         mRemoveGuestOnExitPreferenceController.displayPreference(screen);
         mSendCensoredNotificationsToCurrentUserPreferenceController.displayPreference(screen);
+        mShowEndSessionButtonOnLockScreenPreferenceController.displayPreference(screen);
         mMultiUserTopIntroPreferenceController.displayPreference(screen);
         mTimeoutToDockUserPreferenceController.displayPreference(screen);
         mMainSwitchController.displayPreference(screen);
@@ -372,6 +377,8 @@ public class UserSettings extends SettingsPreferenceFragment
                 .setOnPreferenceChangeListener(mAddUserWhenLockedPreferenceController);
         screen.findPreference(mSendCensoredNotificationsToCurrentUserPreferenceController.getPreferenceKey())
                 .setOnPreferenceChangeListener(mSendCensoredNotificationsToCurrentUserPreferenceController);
+        screen.findPreference(mShowEndSessionButtonOnLockScreenPreferenceController.getPreferenceKey())
+                .setOnPreferenceChangeListener(mShowEndSessionButtonOnLockScreenPreferenceController);
 
         screen.findPreference(mAddUserFromSignInPreferenceController.getPreferenceKey())
                 .setOnPreferenceChangeListener(mAddUserFromSignInPreferenceController);
@@ -465,6 +472,8 @@ public class UserSettings extends SettingsPreferenceFragment
         mMainSwitchController.updateState();
         mSendCensoredNotificationsToCurrentUserPreferenceController.updateState(screen.findPreference(
                 mSendCensoredNotificationsToCurrentUserPreferenceController.getPreferenceKey()));
+        mShowEndSessionButtonOnLockScreenPreferenceController.updateState(screen.findPreference(
+                mShowEndSessionButtonOnLockScreenPreferenceController.getPreferenceKey()));
 
         if (mShouldUpdateUserList) {
             updateUI();
@@ -1442,6 +1451,10 @@ public class UserSettings extends SettingsPreferenceFragment
                 mSendCensoredNotificationsToCurrentUserPreferenceController.getPreferenceKey());
         mSendCensoredNotificationsToCurrentUserPreferenceController.updateState(sendCensoredNotifs);
 
+        final Preference showEndSessionLockScreen = getPreferenceScreen().findPreference(
+                mShowEndSessionButtonOnLockScreenPreferenceController.getPreferenceKey());
+        mShowEndSessionButtonOnLockScreenPreferenceController.updateState(showEndSessionLockScreen);
+
         final Preference multiUserTopIntroPreference = getPreferenceScreen().findPreference(
                 mMultiUserTopIntroPreferenceController.getPreferenceKey());
         mMultiUserTopIntroPreferenceController.updateState(multiUserTopIntroPreference);
@@ -2014,6 +2027,8 @@ public class UserSettings extends SettingsPreferenceFragment
                     controller.updateNonIndexableKeys(niks);
                     new SendCensoredNotificationsToCurrentUserPreferenceController(context,
                             KEY_SEND_CENSORED_NOTIFICATIONS).updateNonIndexableKeys(niks);
+                    new ShowEndSessionButtonOnLockScreenPreferenceController(context)
+                            .updateNonIndexableKeys(niks);
                     new AutoSyncDataPreferenceController(context, null /* parent */)
                             .updateNonIndexableKeys(niks);
                     new AutoSyncPersonalDataPreferenceController(context, null /* parent */)


### PR DESCRIPTION
Also adds category for lock screen user settings so that they're not grouped with Guest settings for device owner user

| Before | After |
| -- | -- |
| <img src="https://github.com/user-attachments/assets/7096ce02-ee4d-41cc-9e58-a6dfbefe4db7 " width=60% /> | <img src="https://github.com/user-attachments/assets/578d13ca-4ee0-4721-ba90-fb401912f525" width=60% /> |
