### PR TITLE
fix Linux terminal for secondary users when there are profiles

### DIFF
--- a/src/com/android/settings/dashboard/profileselector/ProfileSelectLinuxTerminalFragment.java
+++ b/src/com/android/settings/dashboard/profileselector/ProfileSelectLinuxTerminalFragment.java
@@ -23,8 +23,7 @@ import com.android.settings.development.DeveloperOptionAwareMixin;
 import com.android.settings.development.linuxterminal.LinuxTerminalDashboardFragment;
 
 /** Linux terminal preferences at developers option for personal/managed profile. */
-public class ProfileSelectLinuxTerminalFragment extends ProfileSelectFragment
-        implements DeveloperOptionAwareMixin {
+public class ProfileSelectLinuxTerminalFragment extends ProfileSelectFragment {
 
     private static final String TAG = "ProfileSelLinuxTerminalFrag";
 


### PR DESCRIPTION
Linux terminal access was added for secondary users in https://github.com/GrapheneOS/platform_packages_apps_Settings/commit/d4f643c946e21907882de941a13ec2bbd82f92db, but ProfileSelectLinuxTerminalFragment implements the DeveloperOptionAwareMixin interface, which prevents its use by secondary users.

fixes https://github.com/GrapheneOS/os-issue-tracker/issues/6925