### PR TITLE
Revert "don't show "More options" button in App info uninstall dialog"

### DIFF
--- a/src/com/android/settings/spa/app/AppUtil.kt
+++ b/src/com/android/settings/spa/app/AppUtil.kt
@@ -37,7 +37,6 @@ fun Context.startUninstallActivity(
 
     val intent = Intent(Intent.ACTION_UNINSTALL_PACKAGE, packageUri).apply {
         putExtra(Intent.EXTRA_UNINSTALL_ALL_USERS, forAllUsers)
-        putExtra(Intent.EXTRA_UNINSTALL_SHOW_MORE_OPTIONS_BUTTON, false)
     }
     startActivityAsUser(intent, userHandle)
 }


### PR DESCRIPTION
The "More options" button is never shown now.