### PR TITLE
add cross SIM calling to carrier config overrides

### DIFF
--- a/res/values/strings_ext.xml
+++ b/res/values/strings_ext.xml
@@ -316,4 +316,6 @@ May cause unreliable service. Use at your own risk.
     <string name="carrier_settings_override_wfc_availability_on_summary">Includes Wi-Fi calling while roaming</string>
     <string name="carrier_settings_override_wfc_availability_enabled_not_editable">Available but state uneditable</string>
     <string name="carrier_settings_override_wfc_availability_enabled_roaming_not_editable">Available but roaming not editable</string>
+    <string name="carrier_settings_override_cross_sim">Cross SIM calling / backup calling availability</string>
+    <string name="carrier_settings_override_cross_sim_description">Only for dual SIM setups. If enabled, then when the SIM is roaming or out of service and Wi‑Fi isn\’t available, calls can be made over another SIM’s data connection. Wi-Fi calling should be set to available to use this.</string>
 </resources>

--- a/src/com/android/settings/network/telephony/carriersettingsoverride/CarrierConfigOverrideOptions.kt
+++ b/src/com/android/settings/network/telephony/carriersettingsoverride/CarrierConfigOverrideOptions.kt
@@ -299,7 +299,7 @@ data object CrossSIMAvailable : ChangeableCarrierConfigOption(
     // selection just so that we have a description for them
     allPossibleConfigStates = simpleUniformBoolStates + listOf(
         // Not exposed for user
-        ConfigState.Complex(
+        ConfigState.NonUniform(
             listOf(
                 CarrierConfigTypedValue.Bool(false),
                 CarrierConfigTypedValue.AnyMatcher,

--- a/src/com/android/settings/network/telephony/carriersettingsoverride/CarrierConfigOverrideOptions.kt
+++ b/src/com/android/settings/network/telephony/carriersettingsoverride/CarrierConfigOverrideOptions.kt
@@ -44,6 +44,7 @@ val allowedUserChangeableCarrierConfigOptions: List<ChangeableCarrierConfigOptio
         VoNREnabled,
         Enable5G,
         WiFiCallingAvailable,
+        CrossSIMAvailable
 
     ).also { list ->
        list.onEach { flag ->
@@ -287,4 +288,29 @@ data object WiFiCallingAvailable : ChangeableCarrierConfigOption(
     override val titleStringRes = R.string.carrier_settings_override_wfc_availability
     override val dialogDescriptionStringRes =
         R.string.carrier_settings_override_wfc_availability_description
+}
+
+data object CrossSIMAvailable : ChangeableCarrierConfigOption(
+    keysWithType = listOf(
+        CarrierConfigManager.KEY_CARRIER_CROSS_SIM_IMS_AVAILABLE_BOOL to KeyType.BOOLEAN,
+        CarrierConfigManager.KEY_ENABLE_CROSS_SIM_CALLING_ON_OPPORTUNISTIC_DATA_BOOL to KeyType.BOOLEAN,
+    ),
+    // Use uniform booleans (true true, false false), then cover other states not exposed for user
+    // selection just so that we have a description for them
+    allPossibleConfigStates = simpleUniformBoolStates + listOf(
+        // Not exposed for user
+        ConfigState.Complex(
+            listOf(
+                CarrierConfigTypedValue.Bool(false),
+                CarrierConfigTypedValue.AnyMatcher,
+            ),
+            R.string.carrier_settings_override_bool_false,
+            R.string.carrier_settings_default_bool_false,
+            isUserSelectable = false,
+        ),
+    )
+) {
+    override val titleStringRes = R.string.carrier_settings_override_cross_sim
+    override val dialogDescriptionStringRes: Int
+        get() = R.string.carrier_settings_override_cross_sim_description
 }


### PR DESCRIPTION
Copied from : https://github.com/GrapheneOS/platform_packages_apps_Settings/commit/c864b83befbf5594aa32147605985cacb5933739 with a very minor fix (Complex to NonUniform).

Still needs something to enable isCrossSimCallingEnabledByUser().
A possible option is: https://github.com/steve-cs/platform_frameworks_opt_net_ims/pull/1/changes