### PR TITLE
add cross SIM calling to carrier config overrides

### DIFF
--- a/res/values/strings_ext.xml
+++ b/res/values/strings_ext.xml
@@ -318,4 +318,6 @@ May cause unreliable service. Use at your own risk.
     <string name="carrier_settings_override_wfc_availability_on_summary">Includes Wi-Fi calling while roaming</string>
     <string name="carrier_settings_override_wfc_availability_enabled_not_editable">Available but state uneditable</string>
     <string name="carrier_settings_override_wfc_availability_enabled_roaming_not_editable">Available but roaming not editable</string>
+    <string name="carrier_settings_override_cross_sim">Cross SIM calling / backup calling availability</string>
+    <string name="carrier_settings_override_cross_sim_description">Only for dual SIM setups. If enabled, then when the SIM is roaming or out of service and Wi‑Fi isn\’t available, calls can be made over another SIM’s data connection. Wi-Fi calling should be set to available to use this.</string>
 </resources>

--- a/src/com/android/settings/network/telephony/carriersettingsoverride/CarrierConfigOverrideOptions.kt
+++ b/src/com/android/settings/network/telephony/carriersettingsoverride/CarrierConfigOverrideOptions.kt
@@ -44,6 +44,7 @@ val allowedUserChangeableCarrierConfigOptions: List<ChangeableCarrierConfigOptio
         VoNREnabled,
         Enable5G,
         WiFiCallingAvailable,
+        CrossSIMAvailable
 
     ).also { list ->
        list.onEach { flag ->
@@ -287,4 +288,38 @@ data object WiFiCallingAvailable : ChangeableCarrierConfigOption(
     override val titleStringRes = R.string.carrier_settings_override_wfc_availability
     override val dialogDescriptionStringRes =
         R.string.carrier_settings_override_wfc_availability_description
+}
+
+data object CrossSIMAvailable : ChangeableCarrierConfigOption(
+    keysWithType = listOf(
+        CarrierConfigManager.KEY_CARRIER_CROSS_SIM_IMS_AVAILABLE_BOOL to KeyType.BOOLEAN,
+        CarrierConfigManager.KEY_ENABLE_CROSS_SIM_CALLING_ON_OPPORTUNISTIC_DATA_BOOL to KeyType.BOOLEAN,
+    ),
+    // Use uniform booleans (true true, false false), then cover other states not exposed for user
+    // selection just so that we have a description for them
+    allPossibleConfigStates = simpleUniformBoolStates + listOf(
+        // Not exposed for user
+        ConfigState.NonUniform(
+            listOf(
+                CarrierConfigTypedValue.Bool(false),
+                CarrierConfigTypedValue.AnyMatcher,
+            ),
+            R.string.carrier_settings_override_bool_false,
+            R.string.carrier_settings_default_bool_false,
+            isUserSelectable = false,
+        ),
+        ConfigState.NonUniform(
+            listOf(
+                CarrierConfigTypedValue.Bool(true),
+                CarrierConfigTypedValue.AnyMatcher,
+            ),
+            R.string.carrier_settings_override_bool_true,
+            R.string.carrier_settings_default_bool_true,
+            isUserSelectable = false,
+        ),
+    )
+) {
+    override val titleStringRes = R.string.carrier_settings_override_cross_sim
+    override val dialogDescriptionStringRes: Int
+        get() = R.string.carrier_settings_override_cross_sim_description
 }


### PR DESCRIPTION
See https://github.com/GrapheneOS/os-issue-tracker/issues/4027

Requires https://github.com/GrapheneOS/adevtool/pull/286

Adapted from https://github.com/GrapheneOS/platform_packages_apps_Settings/pull/406, added extra state catcher so that it displays Enabled if carrier config already has KEY_CARRIER_CROSS_SIM_IMS_AVAILABLE_BOOL enabled but doesn't set KEY_ENABLE_CROSS_SIM_CALLING_ON_OPPORTUNISTIC_DATA_BOOL. According to https://cs.android.com/search?q=KEY_ENABLE_CROSS_SIM_CALLING_ON_OPPORTUNISTIC_DATA_BOOL&ss=android, it doesn't seem like that key is read anywhere? But they're definitely reading https://cs.android.com/android/platform/superproject/+/android-16.0.0_r4:frameworks/opt/net/ims/src/java/com/android/ims/ImsManager.java;l=1618?q=KEY_CARRIER_CROSS_SIM_IMS_AVAILABLE_BOOL&ss=android and using it (along with Wi-Fi calling) to gate cross SIM calling