### PR TITLE
AppsScope: Integrate Apps Scope configuration in Settings

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -5753,6 +5753,16 @@
         <activity android:name=".spa.SpaAppBridgeActivity" android:exported="false"/>
 
         <activity
+            android:name=".spa.app.appinfo.AppsScopeActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.settings.APPS_SCOPE_DETAILS" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="package" />
+            </intent-filter>
+        </activity>
+
+        <activity
             android:name=".spa.search.SettingsSpaSearchLandingActivity"
             android:exported="true">
             <intent-filter android:priority="1">

--- a/res/values/strings_ext.xml
+++ b/res/values/strings_ext.xml
@@ -93,6 +93,44 @@ No query or data is sent to the server. These files contain orbits and statuses 
 
     <string name="storage_scopes">Storage Scopes</string>
 
+    <string name="apps_scope">Apps Scope</string>
+    <string name="apps_scopes_add_package">Manage visibility</string>
+    <string name="apps_scopes_allowed_packages_title">Allowed apps</string>
+    <string name="apps_scopes_allowed_shared_cert_apps">Allowed shared certificate apps</string>
+    <string name="apps_scopes_allowed_system_apps">Allowed system apps</string>
+    <string name="apps_scopes_allowed_user_apps">Allowed user apps</string>
+    <string name="apps_scopes_deselect_visible">Deselect visible</string>
+    <string name="apps_scopes_filter_all">Show all</string>
+    <string name="apps_scopes_filter_disabled">Show disabled</string>
+    <string name="apps_scopes_filter_enabled">Show enabled</string>
+    <string name="apps_scopes_main_switch">Enable Apps Scope</string>
+    <string name="apps_scopes_restore">Restore to default</string>
+    <string name="apps_scopes_restore_summary">Delete configuration and disable Apps Scope</string>
+    <string name="apps_scopes_restrict_all">Restrict all visible</string>
+    <string name="apps_scopes_restrict_all_dialog_title">Select apps to restrict</string>
+    <string name="apps_scopes_restrict_all_option_all">All apps</string>
+    <string name="apps_scopes_restrict_all_option_system">System apps</string>
+    <string name="apps_scopes_restrict_all_option_user">User apps</string>
+    <string name="apps_scopes_restrict_all_summary">Restrict visibility for all apps in select categories</string>
+    <string name="apps_scopes_restrict_queries">Restrict visibility of user apps</string>
+    <string name="apps_scopes_restrict_rules_to_visible">Restrict rules to only visible apps</string>
+    <string name="apps_scopes_restrict_self">Restrict self-visibility</string>
+    <string name="apps_scopes_restrict_shared_cert">Restrict visibility of same-cert apps</string>
+    <string name="apps_scopes_restrict_system">Restrict visibility of system apps</string>
+    <string name="apps_scopes_restricted_shared_cert_apps">Restricted shared certificate apps</string>
+    <string name="apps_scopes_restricted_system_apps">Restricted system apps</string>
+    <string name="apps_scopes_restricted_user_apps">Restricted user apps</string>
+    <string name="apps_scopes_select_visible">Select visible</string>
+    <string name="apps_scopes_show_only_visible">Show only visible apps</string>
+    <string name="apps_scopes_summary_disabled">Disabled</string>
+    <string name="apps_scopes_summary_enabled">Enabled</string>
+    <string name="apps_scopes_visibility_title">Apps visibility</string>
+    <string name="apps_scopes_visible_shared_cert_apps">Shared cert apps</string>
+    <string name="apps_scopes_visible_system_apps">System apps</string>
+    <string name="apps_scopes_visible_user_apps">User apps</string>
+    <string name="apps_scopes_no_apps_match">No apps match this criteria</string>
+    <string name="apps_scopes_filter_options">Filter options</string>
+
     <string name="conn_checks_grapheneos_server">GrapheneOS server</string>
     <string name="conn_checks_google_server">Standard (Google) server</string>
     <string name="conn_checks_disabled">Off</string>

--- a/src/com/android/settings/spa/SettingsSpaEnvironment.kt
+++ b/src/com/android/settings/spa/SettingsSpaEnvironment.kt
@@ -24,6 +24,8 @@ import com.android.settings.spa.about.AboutPhonePageProvider
 import com.android.settings.spa.app.AllAppListPageProvider
 import com.android.settings.spa.app.AppsMainPageProvider
 import com.android.settings.spa.app.appcompat.UserAspectRatioAppsPageProvider
+import com.android.settings.spa.app.appinfo.AppAppsScopesPageProvider
+import com.android.settings.spa.app.appinfo.AppAppsScopesPickerPageProvider
 import com.android.settings.spa.app.appinfo.AppInfoSettingsProvider
 import com.android.settings.spa.app.appinfo.CloneAppInfoSettingsProvider
 import com.android.settings.spa.app.backgroundinstall.BackgroundInstalledAppsPageProvider
@@ -112,6 +114,8 @@ open class SettingsSpaEnvironment(context: Context) : SpaEnvironment(context) {
             com.android.settings.network.telephony.carriersettingsoverride.CarrierSettingsOverridesProvider,
             AllAppListPageProvider,
             AppInfoSettingsProvider,
+            AppAppsScopesPageProvider,
+            AppAppsScopesPickerPageProvider,
             SpecialAppAccessPageProvider,
             NotificationMainPageProvider,
             AppListNotificationsPageProvider.AllApps,

--- a/src/com/android/settings/spa/app/appinfo/AppAppsScopesPageProvider.kt
+++ b/src/com/android/settings/spa/app/appinfo/AppAppsScopesPageProvider.kt
@@ -1,0 +1,791 @@
+/*
+ * Copyright (C) 2026 GrapheneOS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.spa.app.appinfo
+
+import android.app.Activity
+import android.app.AppsScope
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ApplicationInfo
+import android.content.pm.GosPackageState
+import android.content.pm.GosPackageStateFlag
+import android.content.pm.PackageManager
+import android.graphics.drawable.Drawable
+import android.net.Uri
+import android.os.Bundle
+import android.os.UserHandle
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavType
+import androidx.navigation.navArgument
+import com.android.settings.R
+import com.android.settings.spa.SpaActivity.Companion.startSpaActivity
+import com.android.settingslib.spa.framework.common.SettingsPageProvider
+import com.android.settingslib.spa.framework.compose.navigator
+import com.android.settingslib.spa.framework.compose.rememberDrawablePainter
+import com.android.settingslib.spa.widget.preference.Preference
+import com.android.settingslib.spa.widget.preference.PreferenceModel
+import com.android.settingslib.spa.widget.preference.SwitchPreference
+import com.android.settingslib.spa.widget.preference.SwitchPreferenceModel
+import com.android.settingslib.spa.widget.scaffold.RegularScaffold
+import com.android.settingslib.spa.widget.ui.Category
+import com.android.settingslib.spaprivileged.model.app.AppRecord
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import android.os.UserManager
+
+object AppAppsScopesPageProvider : SettingsPageProvider {
+    override val name = "AppAppsScopes"
+
+    private const val PACKAGE_NAME = "packageName"
+    private const val USER_ID = "userId"
+
+    override val parameter = listOf(
+        navArgument(PACKAGE_NAME) { type = NavType.StringType },
+        navArgument(USER_ID) { type = NavType.IntType },
+    )
+
+    fun getRoute(packageName: String, userId: Int): String = "$name/$packageName/$userId"
+
+    @Composable
+    override fun Page(arguments: Bundle?) {
+        val packageName = arguments?.getString(PACKAGE_NAME) ?: return
+        val userId = arguments.getInt(USER_ID)
+        val context = LocalContext.current
+
+        val scope = rememberCoroutineScope()
+        val appsScopeState = remember { AppsScopeState(context, packageName, userId, scope) }
+        val loading = appsScopeState.loading.collectAsStateWithLifecycle().value
+
+        RegularScaffold(title = stringResource(R.string.apps_scope)) {
+            if (loading) {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator()
+                }
+            } else {
+                MainSwitch(appsScopeState)
+                RestoreButton(appsScopeState)
+                RestrictAllButton(appsScopeState)
+                if (appsScopeState.enabled.collectAsStateWithLifecycle().value) {
+                    Restrictions(appsScopeState)
+                    AllowedPackages(appsScopeState)
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun RestoreButton(state: AppsScopeState) {
+        Preference(remember {
+            object : PreferenceModel {
+                override val title = state.context.getString(R.string.apps_scopes_restore)
+                override val summary = { state.context.getString(R.string.apps_scopes_restore_summary) }
+                override val onClick = { state.restore() }
+            }
+        })
+    }
+
+    @Composable
+    private fun RestrictAllButton(state: AppsScopeState) {
+        var openDialog by remember { mutableStateOf(false) }
+
+        if (openDialog) {
+            AlertDialog(
+                onDismissRequest = { openDialog = false },
+                title = { Text(stringResource(R.string.apps_scopes_restrict_all_dialog_title)) },
+                text = {
+                    Column {
+                        val options = listOf(
+                            R.string.apps_scopes_restrict_all_option_all,
+                            R.string.apps_scopes_restrict_all_option_user,
+                            R.string.apps_scopes_restrict_all_option_system
+                        )
+                        options.forEachIndexed { index, resId ->
+                            TextButton(
+                                onClick = {
+                                    state.restrictAll(index)
+                                    openDialog = false
+                                },
+                                modifier = Modifier.fillMaxWidth()
+                            ) {
+                                Text(
+                                    text = stringResource(resId),
+                                    modifier = Modifier.fillMaxWidth(),
+                                    textAlign = TextAlign.Start
+                                )
+                            }
+                        }
+                    }
+                },
+                confirmButton = {},
+                dismissButton = {
+                    TextButton(onClick = { openDialog = false }) {
+                        Text(stringResource(android.R.string.cancel))
+                    }
+                }
+            )
+        }
+
+        Preference(remember {
+            object : PreferenceModel {
+                override val title = state.context.getString(R.string.apps_scopes_restrict_all)
+                override val summary = { state.context.getString(R.string.apps_scopes_restrict_all_summary) }
+                override val onClick = { openDialog = true }
+            }
+        })
+    }
+
+    @Composable
+    private fun AllowedPackages(state: AppsScopeState) {
+        val packages = state.allowedPackages.collectAsStateWithLifecycle().value
+
+        val addPackageTitle = stringResource(R.string.apps_scopes_add_package)
+        val addPackageRoute = AppAppsScopesPickerPageProvider.getRoute(state.packageName, state.userId)
+        val addPackageOnClick = navigator(addPackageRoute)
+
+        Category(title = stringResource(R.string.apps_scopes_allowed_packages_title)) {
+            Preference(remember(addPackageRoute) {
+                object : PreferenceModel {
+                    override val title = addPackageTitle
+                    override val onClick = addPackageOnClick
+                }
+            })
+        }
+
+        val (sharedCertApps, others) = remember(packages) {
+            val pm = state.context.packageManager
+            packages.partition {
+                pm.checkSignatures(state.packageName, it.app.packageName) == PackageManager.SIGNATURE_MATCH
+            }
+        }
+        val (systemApps, userApps) = remember(others) {
+            others.partition { (it.app.flags and ApplicationInfo.FLAG_SYSTEM) != 0 }
+        }
+
+        if (sharedCertApps.isNotEmpty()) {
+            RenderAppGroups(
+                apps = sharedCertApps,
+                allowedTitleRes = R.string.apps_scopes_allowed_shared_cert_apps,
+                restrictedTitleRes = R.string.apps_scopes_restricted_shared_cert_apps,
+                state = state
+            )
+        }
+
+        if (userApps.isNotEmpty()) {
+            RenderAppGroups(
+                apps = userApps,
+                allowedTitleRes = R.string.apps_scopes_allowed_user_apps,
+                restrictedTitleRes = R.string.apps_scopes_restricted_user_apps,
+                state = state
+            )
+        }
+
+        if (systemApps.isNotEmpty()) {
+            RenderAppGroups(
+                apps = systemApps,
+                allowedTitleRes = R.string.apps_scopes_allowed_system_apps,
+                restrictedTitleRes = R.string.apps_scopes_restricted_system_apps,
+                state = state
+            )
+        }
+    }
+
+    @Composable
+    private fun RenderAppGroups(
+        apps: List<AllowedAppRecord>,
+        allowedTitleRes: Int,
+        restrictedTitleRes: Int,
+        state: AppsScopeState
+    ) {
+        val (allowed, restricted) = apps.partition { it.allowed }
+
+        if (allowed.isNotEmpty()) {
+            Category(title = stringResource(allowedTitleRes) + " (${allowed.size})") {
+                for (item in allowed) {
+                    key(item.app.packageName) {
+                        AllowedAppItem(state, item)
+                    }
+                }
+            }
+        }
+
+        if (restricted.isNotEmpty()) {
+            Category(title = stringResource(restrictedTitleRes) + " (${restricted.size})") {
+                for (item in restricted) {
+                    key(item.app.packageName) {
+                        AllowedAppItem(state, item)
+                    }
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun AllowedAppItem(state: AppsScopeState, item: AllowedAppRecord) {
+        CustomAllowedAppItem(item) {
+            state.removePackage(item.app.packageName)
+        }
+    }
+
+    @Composable
+    private fun CustomAllowedAppItem(
+        item: AllowedAppRecord,
+        onClick: () -> Unit
+    ) {
+        val isVisible = item.isNaturallyVisible
+
+        val backgroundColor = if (isVisible) {
+            Color.Transparent
+        } else {
+             MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.2f)
+        }
+
+        val context = LocalContext.current
+        val icon = produceState<Drawable?>(initialValue = null, key1 = item.app.packageName) {
+            withContext(Dispatchers.IO) {
+                value = item.app.loadIcon(context.packageManager)
+            }
+        }
+
+        Row(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(backgroundColor)
+                .clickable(onClick = onClick)
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            val drawable = icon.value
+            if (drawable != null) {
+                Image(
+                    painter = rememberDrawablePainter(drawable),
+                    contentDescription = item.label,
+                    modifier = Modifier
+                        .padding(end = 16.dp)
+                        .size(48.dp)
+                )
+            } else {
+                Box(
+                    modifier = Modifier
+                        .padding(end = 16.dp)
+                        .size(48.dp)
+                )
+            }
+
+            Text(
+                text = item.label,
+                modifier = Modifier.weight(1f),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+        }
+    }
+
+    @Composable
+    private fun MainSwitch(state: AppsScopeState) {
+        val enabled = state.enabled.collectAsStateWithLifecycle().value
+        SwitchPreference(remember(enabled) {
+            object : SwitchPreferenceModel {
+                override val title = state.context.getString(R.string.apps_scopes_main_switch)
+                override val checked = { enabled }
+                override val onCheckedChange = { newChecked: Boolean -> state.setEnabled(newChecked) }
+            }
+        })
+    }
+
+    @Composable
+    private fun Restrictions(state: AppsScopeState) {
+        Category(title = stringResource(R.string.apps_scope)) {
+            val flags = state.flags.collectAsStateWithLifecycle().value
+
+            // Standard restrictSelf flag
+            SwitchPreference(remember(flags) {
+                object : SwitchPreferenceModel {
+                    override val title = state.context.getString(R.string.apps_scopes_restrict_self)
+                    override val checked = { (flags and AppsScope.FLAG_RESTRICT_SELF) != 0 }
+                    override val onCheckedChange = { newChecked: Boolean -> state.setRestrictSelf(newChecked) }
+                }
+            })
+
+            RestrictionSwitch(state, AppsScope.FLAG_RESTRICT_SHARED_CERT, R.string.apps_scopes_restrict_shared_cert)
+            RestrictionSwitch(state, AppsScope.FLAG_RESTRICT_SYSTEM, R.string.apps_scopes_restrict_system)
+            RestrictionSwitch(state, AppsScope.FLAG_RESTRICT_QUERIES, R.string.apps_scopes_restrict_queries)
+        }
+    }
+
+    @Composable
+    private fun RestrictionSwitch(state: AppsScopeState, flag: Int, titleRes: Int) {
+        val flags = state.flags.collectAsStateWithLifecycle().value
+        SwitchPreference(remember(flags) {
+            object : SwitchPreferenceModel {
+                override val title = state.context.getString(titleRes)
+                override val checked = { (flags and flag) != 0 }
+                override val onCheckedChange = { newChecked: Boolean -> state.setFlag(flag, newChecked) }
+            }
+        })
+    }
+}
+
+internal object AppsScopeConstants {
+    val QUERY_FLAGS: PackageManager.ApplicationInfoFlags = PackageManager.ApplicationInfoFlags.of(
+        PackageManager.MATCH_UNINSTALLED_PACKAGES.toLong() or
+        PackageManager.MATCH_DISABLED_COMPONENTS.toLong() or
+        PackageManager.MATCH_INSTANT.toLong() or
+        PackageManager.MATCH_ARCHIVED_PACKAGES
+    )
+}
+
+private data class AllowedAppRecord(
+    override val app: ApplicationInfo,
+    val label: String,
+    val isNaturallyVisible: Boolean,
+    val allowed: Boolean,
+) : AppRecord
+
+private class AppsScopeState(val context: Context, val packageName: String, val userId: Int, private val scope: CoroutineScope) {
+    val enabled = MutableStateFlow(false)
+    val flags = MutableStateFlow(0)
+    val allowedPackages = MutableStateFlow<List<AllowedAppRecord>>(emptyList())
+    val loading = MutableStateFlow(true)
+    private val writeMutex = Mutex()
+
+    init {
+        refresh()
+    }
+
+    private fun refresh() {
+        scope.launch {
+            loading.value = true
+            withContext(Dispatchers.IO) {
+                val gps = GosPackageState.get(packageName, userId)
+                val isEnabled = gps.hasFlag(GosPackageStateFlag.APPS_SCOPES_ENABLED)
+                val config = gps.appsScope
+                val pm = context.packageManager
+
+                val newFlags: Int
+                val newAllowedPackages: List<AllowedAppRecord>
+
+                if (config != null) {
+                    newFlags = config.flags
+                    val records = config.specificRules.map { (pkg, allowed) ->
+                        try {
+                            val ai = pm.getApplicationInfoAsUser(pkg, AppsScopeConstants.QUERY_FLAGS, userId)
+
+                            val isVisible = try { // Check Natural Visibility
+                                 pm.canPackageQuery(packageName + ".unfiltered", pkg)
+                            } catch (e: PackageManager.NameNotFoundException) {
+                                false
+                            }
+
+                            AllowedAppRecord(ai, ai.loadLabel(pm).toString(), isVisible, allowed)
+                        } catch (e: PackageManager.NameNotFoundException) {
+                            AllowedAppRecord(ApplicationInfo().apply { packageName = pkg }, pkg, false, allowed)
+                        }
+                    }
+                    newAllowedPackages = records.sortedBy { it.label.lowercase() }
+                } else {
+                    newFlags = 0
+                    newAllowedPackages = emptyList()
+                }
+
+                withContext(Dispatchers.Main) {
+                    enabled.value = isEnabled
+                    flags.value = newFlags
+                    allowedPackages.value = newAllowedPackages
+                    loading.value = false
+                }
+            }
+        }
+    }
+
+    fun setEnabled(enable: Boolean) {
+        scope.launch {
+            writeMutex.withLock {
+                withContext(Dispatchers.IO) {
+                    val gps = GosPackageState.get(packageName, userId)
+                    val ed = gps.createEditor(packageName, userId)
+                    ed.setFlagState(GosPackageStateFlag.APPS_SCOPES_ENABLED, enable)
+                    ed.apply()
+                }
+            }
+            refresh()
+        }
+    }
+
+    fun restore() {
+        scope.launch {
+            writeMutex.withLock {
+                withContext(Dispatchers.IO) {
+                    // Clear GosPackageState. This will trigger storage cleanup via persistence layer.
+                    val gps = GosPackageState.get(packageName, userId)
+                    val ed = gps.createEditor(packageName, userId)
+                    ed.setFlagState(GosPackageStateFlag.APPS_SCOPES_ENABLED, false)
+                    ed.setAppsScopeConfig(null)
+                    ed.apply()
+                }
+            }
+            refresh()
+        }
+    }
+
+    fun setRestrictSelf(value: Boolean) {
+        scope.launch {
+            writeMutex.withLock {
+                withContext(Dispatchers.IO) {
+                    val gps = GosPackageState.get(packageName, userId)
+                    val ed = gps.createEditor(packageName, userId)
+                    val config = gps.appsScope
+                    val builder = AppsScope.Builder.from(config)
+
+                    if (value) {
+                        builder.addFlag(AppsScope.FLAG_RESTRICT_SELF)
+                    } else {
+                        builder.clearFlag(AppsScope.FLAG_RESTRICT_SELF)
+                    }
+
+                    ed.setAppsScopeConfig(AppsScope.serialize(builder.build()))
+                    ed.apply()
+                }
+            }
+            refresh()
+        }
+    }
+
+    fun setFlag(flag: Int, value: Boolean) {
+        scope.launch {
+            writeMutex.withLock {
+                val oldFlags = flags.value
+                val hasChanged = ((oldFlags and flag) != 0) != value
+                if (!hasChanged) return@withLock
+
+                withContext(Dispatchers.IO) {
+                    val gps = GosPackageState.get(packageName, userId)
+                    val ed = gps.createEditor(packageName, userId)
+                    val config = gps.appsScope
+                    val builder = AppsScope.Builder.from(config)
+
+                    if (value) builder.addFlag(flag) else builder.clearFlag(flag)
+
+                    // --- Inversion Logic (matching HMAC) ---
+                    if (flag == AppsScope.FLAG_RESTRICT_QUERIES ||
+                        flag == AppsScope.FLAG_RESTRICT_SYSTEM ||
+                        flag == AppsScope.FLAG_RESTRICT_SHARED_CERT) {
+
+                        val pm = context.packageManager
+                        val allApps = pm.getInstalledApplicationsAsUser(AppsScopeConstants.QUERY_FLAGS, userId)
+
+                        val relevantApps = allApps.map { app ->
+                            async {
+                                if (app.packageName == packageName) return@async null
+                                val isSystem = (app.flags and ApplicationInfo.FLAG_SYSTEM) != 0
+                                val matches = when (flag) {
+                                    AppsScope.FLAG_RESTRICT_SYSTEM -> isSystem
+                                    AppsScope.FLAG_RESTRICT_SHARED_CERT -> {
+                                        pm.checkSignatures(packageName, app.packageName) == PackageManager.SIGNATURE_MATCH
+                                    }
+                                    else -> { // FLAG_RESTRICT_QUERIES
+                                        !isSystem && pm.checkSignatures(packageName, app.packageName) != PackageManager.SIGNATURE_MATCH
+                                    }
+                                }
+                                if (matches) app else null
+                            }
+                        }.awaitAll().filterNotNull()
+
+                        val newFlags = if (value) oldFlags or flag else oldFlags and flag.inv()
+                        val newIsWhitelistMode = (newFlags and flag) != 0
+
+                        val visibleAppsAsync = relevantApps.map { app ->
+                            async {
+                                val pkg = app.packageName
+                                val isVisible = try { // Check Natural Visibility
+                                    pm.canPackageQuery(packageName + ".unfiltered", pkg)
+                                } catch (e: PackageManager.NameNotFoundException) {
+                                    false
+                                }
+                                if (isVisible) app else null
+                            }
+                        }.awaitAll().filterNotNull()
+
+                        for (app in visibleAppsAsync) {
+                            val pkg = app.packageName
+
+                            val currentRule = config?.specificRules?.get(pkg)
+                            val oldIsWhitelistMode = (oldFlags and flag) != 0
+
+                            // Visibility Calculation (Current State):
+                            // In Whitelist mode: Visible if Rule=true.
+                            // In Blacklist mode: Visible if Rule!=false (null or true).
+                            val currentlyVisible = if (oldIsWhitelistMode) {
+                                currentRule == true
+                            } else {
+                                currentRule != false
+                            }
+
+                            // Target: Maintain currentlyVisible in newDefaultMode
+                            // If newDefaultMode = Whitelist (Hidden by default):
+                            //   If Visible -> Rule=true (Allowed)
+                            //   If Hidden -> Rule=null (Default)
+                            // If newDefaultMode = Blacklist (Visible by default):
+                            //   If Visible -> Rule=null (Default)
+                            //   If Hidden -> Rule=false (Restricted)
+
+                            if (newIsWhitelistMode) {
+                                if (currentlyVisible) {
+                                    builder.addPackage(pkg, true)
+                                } else {
+                                    builder.removePackage(pkg)
+                                }
+                            } else {
+                                if (currentlyVisible) {
+                                    builder.removePackage(pkg)
+                                } else {
+                                    builder.addPackage(pkg, false)
+                                }
+                            }
+                        }
+                    }
+
+                    ed.setAppsScopeConfig(AppsScope.serialize(builder.build()))
+                    ed.apply()
+                }
+            }
+            refresh()
+        }
+    }
+
+    fun addPackage(pkg: String) {
+        scope.launch {
+            writeMutex.withLock {
+                withContext(Dispatchers.IO) {
+                    val gps = GosPackageState.get(packageName, userId)
+                    val ed = gps.createEditor(packageName, userId)
+                    val config = gps.appsScope
+                    val flags = config?.flags ?: 0
+
+                    // When adding a package from the picker, we want to make it an EXCEPTION
+                    // to its category's current state.
+                    val ai = context.packageManager.getApplicationInfoAsUser(pkg, AppsScopeConstants.QUERY_FLAGS, userId)
+                    val isSystem = ai.flags and ApplicationInfo.FLAG_SYSTEM != 0
+                    val flag = if (isSystem) AppsScope.FLAG_RESTRICT_SYSTEM else AppsScope.FLAG_RESTRICT_QUERIES
+                    val isRestricted = (flags and flag) != 0
+
+                    val builder = AppsScope.Builder.from(config)
+                    // If currently Restricted (Whitelist mode) -> Add rule 'true' to Allow
+                    // If currently Allowed (Blacklist mode) -> Add rule 'false' to Restrict
+                    builder.addPackage(pkg, isRestricted)
+
+                    ed.setAppsScopeConfig(AppsScope.serialize(builder.build()))
+                    ed.apply()
+                }
+            }
+            refresh()
+        }
+    }
+
+    fun removePackage(pkg: String) {
+        val currentPackages = allowedPackages.value
+        allowedPackages.value = currentPackages.filter { it.app.packageName != pkg }
+
+        scope.launch {
+            writeMutex.withLock {
+                withContext(Dispatchers.IO) {
+                    val gps = GosPackageState.get(packageName, userId)
+                    val ed = gps.createEditor(packageName, userId)
+                    val config = gps.appsScope
+                    val builder = AppsScope.Builder.from(config)
+                    builder.removePackage(pkg)
+                    ed.setAppsScopeConfig(AppsScope.serialize(builder.build()))
+                    ed.apply()
+                }
+            }
+            // refresh() // No need to refresh entire state
+        }
+    }
+
+    fun restrictAll(option: Int) {
+        scope.launch {
+            writeMutex.withLock {
+                withContext(Dispatchers.IO) {
+                    // Ensure enabled
+                    val gps = GosPackageState.get(packageName, userId)
+                    val ed = gps.createEditor(packageName, userId)
+                    ed.setFlagState(GosPackageStateFlag.APPS_SCOPES_ENABLED, true)
+
+                    val config = gps.appsScope
+                    val builder = AppsScope.Builder.from(config)
+
+                    // Do NOT touch RESTRICT_SELF.
+                    // Flags to enable based on option:
+                    // 0 (All): All flags (except self)
+                    // 1 (User): Queries, Shared Cert
+                    // 2 (System): System
+
+                    val flagsToEnable = when (option) {
+                        0 -> AppsScope.FLAG_RESTRICT_QUERIES or AppsScope.FLAG_RESTRICT_SHARED_CERT or
+                             AppsScope.FLAG_RESTRICT_SYSTEM
+                        1 -> AppsScope.FLAG_RESTRICT_QUERIES or AppsScope.FLAG_RESTRICT_SHARED_CERT
+                        2 -> AppsScope.FLAG_RESTRICT_SYSTEM
+                        else -> 0
+                    }
+
+                    builder.addFlag(flagsToEnable)
+
+                    val pm = context.packageManager
+                    val allApps = pm.getInstalledApplicationsAsUser(AppsScopeConstants.QUERY_FLAGS, userId)
+
+                    val relevantApps = allApps.filter { app ->
+                        if (app.packageName == packageName) return@filter false // Exclude self
+                        val isSystem = (app.flags and ApplicationInfo.FLAG_SYSTEM) != 0
+
+                        when (option) {
+                            0 -> true       // All
+                            1 -> !isSystem  // Only user apps
+                            2 -> isSystem   // Only system apps
+                            else -> false
+                        }
+                    }
+
+                    val settingsStoragePkg = "com.android.providers.settings"
+
+                    val visibleAppsAsync = relevantApps.map { app ->
+                        async {
+                            val pkg = app.packageName
+                            if (pkg == settingsStoragePkg) return@async app
+                            val isVisible = try { // Check Natural Visibility
+                                pm.canPackageQuery(packageName + ".unfiltered", pkg)
+                            } catch (e: PackageManager.NameNotFoundException) {
+                                false
+                            }
+                            if (isVisible) app else null
+                        }
+                    }.awaitAll().filterNotNull()
+
+                    for (app in visibleAppsAsync) {
+                        val pkg = app.packageName
+                        if (pkg == settingsStoragePkg) {
+                            builder.addPackage(pkg, true)
+                            continue
+                        }
+
+                        builder.removePackage(pkg)
+                    }
+
+                    ed.setAppsScopeConfig(AppsScope.serialize(builder.build()))
+                    ed.apply()
+                }
+            }
+            refresh()
+        }
+    }
+}
+
+/**
+ * Bridge activity that receives the `android.settings.APPS_SCOPE_DETAILS` intent
+ * from Launcher3 and navigates to the SPA-based Apps Scope settings page.
+ *
+ * Expected intent data: `package:<packageName>`
+ * Optional extra: [Intent.EXTRA_USER] (UserHandle)
+ */
+class AppsScopeActivity : Activity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val intentData: Uri? = intent?.data
+        if (intentData == null) {
+            finish()
+            return
+        }
+
+        val packageName = intentData.schemeSpecificPart
+        if (packageName.isNullOrEmpty()) {
+            finish()
+            return
+        }
+
+        // Validate packageName format to reject malformed input from external intents
+        val packageNamePattern = Regex("^[a-zA-Z][a-zA-Z0-9_]*(\\.[a-zA-Z][a-zA-Z0-9_]*)+$")
+        if (!packageNamePattern.matches(packageName)) {
+            finish()
+            return
+        }
+
+        val userHandle = intent?.getParcelableExtra(Intent.EXTRA_USER, UserHandle::class.java)
+        val userId = userHandle?.identifier ?: UserHandle.myUserId()
+
+        val launchedFromUid = getLaunchedFromUid()
+        val launchedFromUserId = UserHandle.getUserId(launchedFromUid)
+
+        if (launchedFromUserId != userId && launchedFromUid != android.os.Process.SYSTEM_UID && launchedFromUid != 0) {
+            val um = getSystemService(UserManager::class.java)
+            if (um == null || !um.isSameProfileGroup(launchedFromUserId, userId)) {
+                finish()
+                return
+            }
+        }
+
+        try {
+            packageManager.getPackageInfoAsUser(packageName, 0, userId)
+        } catch (e: PackageManager.NameNotFoundException) {
+            finish()
+            return
+        }
+
+        val destination = "${AppAppsScopesPageProvider.name}/$packageName/$userId"
+        startSpaActivity(destination)
+        finish()
+    }
+}

--- a/src/com/android/settings/spa/app/appinfo/AppAppsScopesPickerPageProvider.kt
+++ b/src/com/android/settings/spa/app/appinfo/AppAppsScopesPickerPageProvider.kt
@@ -1,0 +1,643 @@
+/*
+ * Copyright (C) 2026 GrapheneOS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.spa.app.appinfo
+
+import android.app.AppsScope
+import android.content.pm.ApplicationInfo
+import android.content.pm.GosPackageState
+import android.content.pm.PackageManager
+import android.graphics.drawable.Drawable
+import android.os.Bundle
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Tune
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavType
+import androidx.navigation.navArgument
+import com.android.settings.R
+import com.android.settingslib.spa.framework.common.SettingsPageProvider
+import com.android.settingslib.spa.framework.compose.rememberDrawablePainter
+import com.android.settingslib.spa.widget.scaffold.MoreOptionsAction
+import com.android.settingslib.spa.widget.scaffold.SearchScaffold
+import com.android.settingslib.spa.widget.ui.SpinnerOption
+import com.android.settingslib.spaprivileged.model.app.AppListModel
+import com.android.settingslib.spaprivileged.model.app.AppRecord
+import com.android.settingslib.spaprivileged.template.app.AppList
+import com.android.settingslib.spaprivileged.template.app.AppListConfig
+import com.android.settingslib.spaprivileged.template.app.AppListInput
+import com.android.settingslib.spaprivileged.template.app.AppListItemModel
+import com.android.settingslib.spaprivileged.template.app.AppListState
+import com.android.settingslib.spaprivileged.template.common.UserProfilePager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+
+object AppAppsScopesPickerPageProvider : SettingsPageProvider {
+    override val name = "AppAppsScopesPicker"
+
+    private const val PACKAGE_NAME = "packageName"
+    private const val USER_ID = "userId"
+
+    override val parameter = listOf(
+        navArgument(PACKAGE_NAME) { type = NavType.StringType },
+        navArgument(USER_ID) { type = NavType.IntType },
+    )
+
+    fun getRoute(packageName: String, userId: Int): String =
+        "$name/$packageName/$userId"
+
+    @Composable
+    override fun Page(arguments: Bundle?) {
+        val packageName = arguments?.getString(PACKAGE_NAME) ?: return
+        val userId = arguments.getInt(USER_ID)
+        val context = LocalContext.current
+
+        val scope = rememberCoroutineScope()
+        val listModel = remember { AppAppsScopePickerListModel(context, packageName, userId, scope) }
+        val counts = listModel.countsFlow.collectAsStateWithLifecycle().value
+
+        var showFilterDialog by remember { mutableStateOf(false) }
+        val showOnlyVisible = listModel.showOnlyVisibleAppsFlow.collectAsStateWithLifecycle().value
+        val restrictRules = listModel.restrictRulesToVisibleFlow.collectAsStateWithLifecycle().value
+
+        SearchScaffold(
+            title = stringResource(R.string.apps_scopes_visibility_title) + " (${counts.first}/${counts.second})",
+            actions = {
+                IconButton(onClick = { showFilterDialog = true }) {
+                    Icon(
+                        imageVector = Icons.Outlined.Tune,
+                        contentDescription = stringResource(R.string.apps_scopes_filter_options),
+                        tint = MaterialTheme.colorScheme.onSurface
+                    )
+                }
+                MoreOptionsAction {
+                    MenuItem(text = stringResource(R.string.apps_scopes_select_visible)) {
+                        listModel.toggleAll(true)
+                    }
+                    MenuItem(text = stringResource(R.string.apps_scopes_deselect_visible)) {
+                        listModel.toggleAll(false)
+                    }
+                }
+            }
+        ) { bottomPadding, searchQuery ->
+            // Filter options dialog
+            if (showFilterDialog) {
+                FilterOptionsDialog(
+                    showOnlyVisible = showOnlyVisible,
+                    onShowOnlyVisibleChange = listModel::setShowOnlyVisibleApps,
+                    restrictRules = restrictRules,
+                    onRestrictRulesChange = listModel::setRestrictRulesToVisible,
+                    onDismiss = { showFilterDialog = false }
+                )
+            }
+
+            UserProfilePager { userGroup ->
+                Column(modifier = Modifier.fillMaxSize()) {
+                    val filterState = listModel.filterStateFlow.collectAsStateWithLifecycle().value
+
+                    // -- Segmented Filter: All | Enabled | Disabled --
+                    SegmentedFilterBar(
+                        selectedIndex = filterState,
+                        onSelect = listModel::setFilterState
+                    )
+
+                    // -- App List area (stable size, no flickering) --
+                    val appListInput = AppListInput(
+                        config = AppListConfig(
+                            userIds = userGroup.userInfos.map { it.id },
+                            showInstantApps = false,
+                            matchAnyUserForAdmin = false,
+                        ),
+                        listModel = listModel,
+                        state = AppListState(
+                            showSystem = { true },
+                            searchQuery = searchQuery,
+                        ),
+                        header = {},
+                        noItemMessage = context.getString(R.string.apps_scopes_no_apps_match),
+                        bottomPadding = bottomPadding,
+                    )
+
+                    val loading = listModel.loadingFlow.collectAsStateWithLifecycle().value
+                    if (loading) {
+                        Box(
+                            modifier = Modifier
+                                .weight(1f)
+                                .fillMaxWidth(),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            CircularProgressIndicator()
+                        }
+                    } else {
+                        Box(
+                            modifier = Modifier
+                                .weight(1f)
+                                .fillMaxWidth()
+                        ) {
+                            with(appListInput) {
+                                val sq = this.state.searchQuery
+                                LaunchedEffect(sq) {
+                                    listModel.updateState(sq)
+                                }
+                                AppList()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // -- Segmented Filter Bar ----------------------------------------------
+
+    @Composable
+    private fun SegmentedFilterBar(selectedIndex: Int, onSelect: (Int) -> Unit) {
+        val options = listOf(
+            R.string.apps_scopes_filter_all,
+            R.string.apps_scopes_filter_enabled,
+            R.string.apps_scopes_filter_disabled
+        )
+        val shape = RoundedCornerShape(8.dp)
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 4.dp),
+            horizontalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            options.forEachIndexed { index, resId ->
+                val selected = selectedIndex == index
+                val bgColor = if (selected)
+                    MaterialTheme.colorScheme.secondaryContainer
+                else
+                    MaterialTheme.colorScheme.surfaceContainerHigh
+
+                val textColor = if (selected)
+                    MaterialTheme.colorScheme.onSecondaryContainer
+                else
+                    MaterialTheme.colorScheme.onSurface
+
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(36.dp)
+                        .clip(shape)
+                        .background(bgColor)
+                        .clickable(role = Role.Tab) { onSelect(index) },
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = stringResource(resId),
+                        color = textColor,
+                        style = MaterialTheme.typography.bodyLarge,
+                        textAlign = TextAlign.Center,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+        }
+    }
+
+    // -- Filter Options Dialog ----------------------------------------------
+
+    @Composable
+    private fun FilterOptionsDialog(
+        showOnlyVisible: Boolean,
+        onShowOnlyVisibleChange: (Boolean) -> Unit,
+        restrictRules: Boolean,
+        onRestrictRulesChange: (Boolean) -> Unit,
+        onDismiss: () -> Unit
+    ) {
+        val context = LocalContext.current
+        AlertDialog(
+            onDismissRequest = onDismiss,
+            title = {
+                Text(context.getString(R.string.apps_scopes_filter_options))
+            },
+            text = {
+                Column {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { onShowOnlyVisibleChange(!showOnlyVisible) }
+                            .padding(vertical = 12.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = context.getString(R.string.apps_scopes_show_only_visible),
+                            modifier = Modifier.weight(1f),
+                            style = MaterialTheme.typography.bodyLarge
+                        )
+                        Switch(
+                            checked = showOnlyVisible,
+                            onCheckedChange = null
+                        )
+                    }
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { onRestrictRulesChange(!restrictRules) }
+                            .padding(vertical = 12.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = context.getString(R.string.apps_scopes_restrict_rules_to_visible),
+                            modifier = Modifier.weight(1f),
+                            style = MaterialTheme.typography.bodyLarge
+                        )
+                        Switch(
+                            checked = restrictRules,
+                            onCheckedChange = null
+                        )
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = onDismiss) {
+                    Text(context.getString(android.R.string.ok))
+                }
+            }
+        )
+    }
+}
+
+// -- Data Model ------------------------------------------------------------
+
+private data class AppAppsScopePickerRecord(
+    override val app: ApplicationInfo,
+    val isSharedCert: Boolean,
+    val isNaturallyVisible: Boolean,
+    val label: String,
+) : AppRecord
+
+// -- List Model ------------------------------------------------------------
+
+private class AppAppsScopePickerListModel(
+    private val context: android.content.Context,
+    private val packageName: String,
+    private val userId: Int,
+    private val scope: CoroutineScope,
+) : AppListModel<AppAppsScopePickerRecord> {
+
+    private val writeMutex = Mutex()
+    private val flagsFlow = MutableStateFlow(0)
+    private val specificRulesFlow = MutableStateFlow<Map<String, Boolean>>(emptyMap())
+    val filterStateFlow = MutableStateFlow(0)
+    val showOnlyVisibleAppsFlow = MutableStateFlow(true)
+    val restrictRulesToVisibleFlow = MutableStateFlow(true)
+    private val _loadingFlow = MutableStateFlow(false)
+    val loadingFlow: StateFlow<Boolean> = _loadingFlow
+    val countsFlow = MutableStateFlow(0 to 0)
+    private var allRecords = emptyList<AppAppsScopePickerRecord>()
+    private val recordsCache = mutableMapOf<Int, List<AppAppsScopePickerRecord>>()
+    private var currentOption = 0
+    private var searchQuery: (() -> String)? = null
+
+    init {
+        refresh()
+    }
+
+    fun updateState(searchQuery: () -> String) {
+        this.searchQuery = searchQuery
+    }
+
+    override fun getSpinnerOptions(recordList: List<AppAppsScopePickerRecord>): List<SpinnerOption> {
+        return listOf(
+            SpinnerOption(id = 0, text = context.getString(R.string.apps_scopes_visible_user_apps)),
+            SpinnerOption(id = 1, text = context.getString(R.string.apps_scopes_visible_system_apps)),
+            SpinnerOption(id = 2, text = context.getString(R.string.apps_scopes_visible_shared_cert_apps)),
+        )
+    }
+
+
+    override fun transform(
+        userIdFlow: Flow<Int>,
+        appListFlow: Flow<List<ApplicationInfo>>,
+    ): Flow<List<AppAppsScopePickerRecord>> {
+        return userIdFlow.map { userId ->
+            _loadingFlow.value = true
+            try {
+                recordsCache.getOrPut(userId) {
+                    val pm = context.packageManager
+
+                    val apps = withContext(Dispatchers.IO) {
+                        pm.getInstalledApplicationsAsUser(
+                            AppsScopeConstants.QUERY_FLAGS, userId
+                        )
+                    }
+
+                    withContext(Dispatchers.IO) {
+                        apps.map { app ->
+                            val isSharedCert = pm.checkSignatures(
+                                packageName, app.packageName
+                            ) == PackageManager.SIGNATURE_MATCH
+                            val isNaturallyVisible = try {
+                                pm.canPackageQuery(packageName + ".unfiltered", app.packageName)
+                            } catch (_: PackageManager.NameNotFoundException) {
+                                false
+                            }
+                            AppAppsScopePickerRecord(
+                                app = app,
+                                isSharedCert = isSharedCert,
+                                isNaturallyVisible = isNaturallyVisible,
+                                label = app.loadLabel(pm).toString(),
+                            )
+                        }
+                    }
+                }
+            } finally {
+                _loadingFlow.value = false
+            }
+        }.onEach { allRecords = it }
+    }
+
+    override fun filter(
+        userIdFlow: Flow<Int>,
+        option: Int,
+        recordListFlow: Flow<List<AppAppsScopePickerRecord>>,
+    ): Flow<List<AppAppsScopePickerRecord>> {
+        currentOption = option
+        return combine(
+            recordListFlow, filterStateFlow, showOnlyVisibleAppsFlow, flagsFlow, specificRulesFlow
+        ) { recordList, filterState, showOnlyVisible, flags, rules ->
+            val categoryList = recordList.filter { matchesCategory(it, option) }
+
+            val naturallyVisibleList = if (showOnlyVisible) {
+                categoryList.filter { it.isNaturallyVisible }
+            } else {
+                categoryList
+            }
+
+            val displayedList = when (filterState) {
+                1 -> naturallyVisibleList.filter { isVisibilityEnabled(it, flags, rules) }
+                2 -> naturallyVisibleList.filter { !isVisibilityEnabled(it, flags, rules) }
+                else -> naturallyVisibleList
+            }
+
+            val total = displayedList.size
+            val enabled = displayedList.count { isVisibilityEnabled(it, flags, rules) }
+            countsFlow.value = enabled to total
+
+            displayedList
+        }
+    }
+
+    override fun getGroupTitle(option: Int, record: AppAppsScopePickerRecord): String? = null
+
+    @Composable
+    override fun AppListItemModel<AppAppsScopePickerRecord>.AppItem() {
+        val flags = flagsFlow.collectAsStateWithLifecycle().value
+        val rules = specificRulesFlow.collectAsStateWithLifecycle().value
+        val isVisible = isVisibilityEnabled(record, flags, rules)
+
+        AppListSwitchItem(
+            record = record,
+            checked = isVisible,
+            onCheckedChange = { newChecked -> togglePackage(record, newChecked) }
+        )
+    }
+
+    @Composable
+    private fun AppListSwitchItem(
+        record: AppAppsScopePickerRecord,
+        checked: Boolean,
+        onCheckedChange: (Boolean) -> Unit
+    ) {
+        val backgroundColor = if (record.isNaturallyVisible) {
+            Color.Transparent
+        } else {
+            MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.15f)
+        }
+
+        val context = LocalContext.current
+        val icon = produceState<Drawable?>(initialValue = null, key1 = record.app.packageName) {
+            withContext(Dispatchers.IO) {
+                value = try { record.app.loadIcon(context.packageManager) } catch (_: PackageManager.NameNotFoundException) { null }
+            }
+        }
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(backgroundColor)
+                .clickable(role = Role.Switch) { onCheckedChange(!checked) }
+                .padding(horizontal = 16.dp, vertical = 10.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Image(
+                painter = rememberDrawablePainter(icon.value),
+                contentDescription = null,
+                modifier = Modifier
+                    .padding(end = 12.dp)
+                    .size(40.dp),
+                contentScale = ContentScale.Fit
+            )
+
+            Text(
+                text = record.label,
+                modifier = Modifier.weight(1f),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+            Switch(
+                checked = checked,
+                onCheckedChange = null
+            )
+        }
+    }
+
+    // -- Business Logic ------------------------------------------------
+
+    private fun togglePackage(record: AppAppsScopePickerRecord, visible: Boolean) {
+        val pkg = record.app.packageName
+        if (restrictRulesToVisibleFlow.value && !record.isNaturallyVisible) return
+
+        scope.launch {
+            writeMutex.withLock {
+                withContext(Dispatchers.IO) {
+                    val gps = GosPackageState.get(packageName, userId)
+                    val ed = gps.createEditor(packageName, userId)
+                    val config = gps.appsScope
+                    val flags = config?.flags ?: 0
+                    val builder = AppsScope.Builder.from(config)
+
+                    val flag = getRestrictionFlag(record)
+                    val isWhitelistMode = (flags and flag) != 0
+
+                    if (visible) {
+                        if (isWhitelistMode) builder.addPackage(pkg, true)
+                        else builder.removePackage(pkg)
+                    } else {
+                        if (isWhitelistMode) builder.removePackage(pkg)
+                        else builder.addPackage(pkg, false)
+                    }
+
+                    ed.setAppsScopeConfig(AppsScope.serialize(builder.build()))
+                    ed.apply()
+                }
+            }
+            refresh()
+        }
+    }
+
+    private fun refresh() {
+        recordsCache.clear()
+        scope.launch {
+            withContext(Dispatchers.IO) {
+                val config = GosPackageState.get(packageName, userId).appsScope
+                val newFlags = config?.flags ?: 0
+                val newRules = config?.specificRules ?: emptyMap<String, Boolean>()
+
+                withContext(Dispatchers.Main) {
+                    flagsFlow.value = newFlags
+                    specificRulesFlow.value = newRules
+                }
+            }
+        }
+    }
+
+    fun setFilterState(state: Int) {
+        filterStateFlow.value = state
+    }
+
+    fun setShowOnlyVisibleApps(show: Boolean) {
+        showOnlyVisibleAppsFlow.value = show
+    }
+
+    fun setRestrictRulesToVisible(restrict: Boolean) {
+        restrictRulesToVisibleFlow.value = restrict
+    }
+
+    fun toggleAll(visible: Boolean) {
+        scope.launch {
+            writeMutex.withLock {
+                withContext(Dispatchers.IO) {
+                    val query = searchQuery?.invoke() ?: ""
+                    val gps = GosPackageState.get(packageName, userId)
+                    val ed = gps.createEditor(packageName, userId)
+                    val config = gps.appsScope
+                    val flags = config?.flags ?: 0
+                    val builder = AppsScope.Builder.from(config)
+
+                    val targetRecords = allRecords.filter { record ->
+                        matchesCategory(record, currentOption) &&
+                            (query.isEmpty() || record.label.contains(query, ignoreCase = true))
+                    }
+
+                    val flag = when (currentOption) {
+                        1 -> AppsScope.FLAG_RESTRICT_SYSTEM
+                        2 -> AppsScope.FLAG_RESTRICT_SHARED_CERT
+                        else -> AppsScope.FLAG_RESTRICT_QUERIES
+                    }
+                    val isWhitelistMode = (flags and flag) != 0
+                    val restrictRules = restrictRulesToVisibleFlow.value
+
+                    for (record in targetRecords) {
+                        val pkg = record.app.packageName
+                        if (restrictRules && !record.isNaturallyVisible) continue
+
+                        if (visible) {
+                            if (isWhitelistMode) builder.addPackage(pkg, true)
+                            else builder.removePackage(pkg)
+                        } else {
+                            if (isWhitelistMode) builder.removePackage(pkg)
+                            else builder.addPackage(pkg, false)
+                        }
+                    }
+                    ed.setAppsScopeConfig(AppsScope.serialize(builder.build()))
+                    ed.apply()
+                }
+            }
+            refresh()
+        }
+    }
+
+    private fun matchesCategory(record: AppAppsScopePickerRecord, option: Int): Boolean =
+        when (option) {
+            0 -> (record.app.flags and ApplicationInfo.FLAG_SYSTEM) == 0 && !record.isSharedCert
+            1 -> (record.app.flags and ApplicationInfo.FLAG_SYSTEM) != 0 && !record.isSharedCert
+            2 -> record.isSharedCert
+            else -> true
+        }
+
+    private fun getRestrictionFlag(record: AppAppsScopePickerRecord): Int =
+        when {
+            record.isSharedCert -> AppsScope.FLAG_RESTRICT_SHARED_CERT
+            (record.app.flags and ApplicationInfo.FLAG_SYSTEM) != 0 -> AppsScope.FLAG_RESTRICT_SYSTEM
+            else -> AppsScope.FLAG_RESTRICT_QUERIES
+        }
+
+    private fun isVisibilityEnabled(
+        record: AppAppsScopePickerRecord, flags: Int, rules: Map<String, Boolean>
+    ): Boolean {
+        val isWhitelistMode = (flags and getRestrictionFlag(record)) != 0
+        val currentRule = rules[record.app.packageName]
+        return if (isWhitelistMode) currentRule == true else currentRule != false
+    }
+}

--- a/src/com/android/settings/spa/app/appinfo/AppAppsScopesPreference.kt
+++ b/src/com/android/settings/spa/app/appinfo/AppAppsScopesPreference.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2026 GrapheneOS
+ * Copyright (C) 2024-2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.n * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.spa.app.appinfo
+
+import android.content.pm.ApplicationInfo
+import android.content.pm.GosPackageState
+import android.content.pm.GosPackageStateFlag
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.ui.res.stringResource
+import com.android.settings.R
+import com.android.settingslib.spa.framework.compose.navigator
+import com.android.settingslib.spa.widget.preference.Preference
+import com.android.settingslib.spa.widget.preference.PreferenceModel
+import com.android.settingslib.spaprivileged.model.app.installed
+import com.android.settingslib.spaprivileged.model.app.userId
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+@Composable
+fun AppAppsScopesPreference(app: ApplicationInfo) {
+    if (!app.installed) {
+        return
+    }
+
+    val appsScopeEnabled = produceState(initialValue = false, key1 = app.packageName, key2 = app.userId) {
+        value = withContext(Dispatchers.IO) {
+            GosPackageState.get(app.packageName, app.userId)
+                .hasFlag(GosPackageStateFlag.APPS_SCOPES_ENABLED)
+        }
+    }
+
+    val route = remember(app) { AppAppsScopesPageProvider.getRoute(app.packageName, app.userId) }
+    val onNavigate = navigator(route)
+    val summaryText = stringResource(if (appsScopeEnabled.value) R.string.apps_scopes_summary_enabled else R.string.apps_scopes_summary_disabled)
+
+    val titleText = stringResource(R.string.apps_scope)
+
+    Preference(remember(appsScopeEnabled.value) {
+        object : PreferenceModel {
+            override val title = titleText
+            override val summary = { summaryText }
+            override val onClick = onNavigate
+        }
+    })
+}

--- a/src/com/android/settings/spa/app/appinfo/AppInfoSettings.kt
+++ b/src/com/android/settings/spa/app/appinfo/AppInfoSettings.kt
@@ -154,6 +154,7 @@ private fun AppInfoSettings(packageInfoPresenter: PackageInfoPresenter) {
             ManageAgentAppFunctionAccessPreference(app)
             AppStorageScopesPreference(app)
             AppContactScopesPreference(app)
+            AppAppsScopesPreference(app)
             AppStoragePreference(app)
             InstantAppDomainsPreference(app)
             AppDataUsagePreference(app)


### PR DESCRIPTION
At the moment, the implementation impact the following files:
/system/framework/framework.jar
/system/framework/services.jar
/system_ext/priv-app/Settings/Settings.apk
/system_ext/priv-app/Launcher3QuickStep/Launcher3QuickStep.apk

It is a 3 repository PR:
https://github.com/GrapheneOS/platform_frameworks_base
https://github.com/GrapheneOS/platform_packages_apps_Launcher3
https://github.com/GrapheneOS/platform_packages_apps_Settings

Main points of what it is implemented for now:
Individual configuration to each application to enable/disable apps scopes.
A browser of all apps that the targeted app is able to see naturally, including system apps.
Any application can be hided to one particular target, using 2 methods:
*Blacklist: hide specific applications, while the default rule is not hide.
*Whitelist: hide everything unless you specifically allow an app to be seen.
The method of whitelist/blacklist can be setup individually for user apps, and system apps.
A quick option to wipe out the apps scopes configuration of the app
A quick option to restrict everything on the app.
It is integrated in the launcher so when you hold onto an app with the apps scopes enabled, you can see a shortcut to the apps scopes configuration of that app.
