### PR TITLE
#2133 Add mic spoofing to Settings

### DIFF
--- a/res/values/strings_ext.xml
+++ b/res/values/strings_ext.xml
@@ -93,6 +93,9 @@ No query or data is sent to the server. These files contain orbits and statuses 
 
     <string name="storage_scopes">Storage Scopes</string>
 
+    <string name="microphone_spoofing">Microphone Spoofing</string>
+    <string name="mic_spoofing_enable">Enable Microphone Spoofing</string>
+
     <string name="conn_checks_grapheneos_server">GrapheneOS server</string>
     <string name="conn_checks_google_server">Standard (Google) server</string>
     <string name="conn_checks_disabled">Off</string>

--- a/src/com/android/settings/spa/app/appinfo/AppInfoSettings.kt
+++ b/src/com/android/settings/spa/app/appinfo/AppInfoSettings.kt
@@ -154,6 +154,7 @@ private fun AppInfoSettings(packageInfoPresenter: PackageInfoPresenter) {
             ManageAgentAppFunctionAccessPreference(app)
             AppStorageScopesPreference(app)
             AppContactScopesPreference(app)
+            AppMicSpoofingPreference(app)
             AppStoragePreference(app)
             InstantAppDomainsPreference(app)
             AppDataUsagePreference(app)

--- a/src/com/android/settings/spa/app/appinfo/AppMicSpoofingPreference.kt
+++ b/src/com/android/settings/spa/app/appinfo/AppMicSpoofingPreference.kt
@@ -1,0 +1,38 @@
+package com.android.settings.spa.app.appinfo
+
+import android.annotation.SuppressLint
+import android.content.pm.ApplicationInfo
+import android.content.pm.GosPackageState
+import android.content.pm.GosPackageStateFlag
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import com.android.settings.R
+import com.android.settings.spa.app.micspoofing.launchMicSpoofingConfig
+import com.android.settingslib.spa.widget.preference.Preference
+import com.android.settingslib.spa.widget.preference.PreferenceModel
+import com.android.settingslib.spaprivileged.model.app.userHandle
+import com.android.settingslib.spaprivileged.model.app.userId
+
+@Composable
+fun AppMicSpoofingPreference(app: ApplicationInfo) {
+    val isEnabled = GosPackageState
+        .get(app.packageName, app.userId)
+        .hasFlag(GosPackageStateFlag.MIC_SPOOFING_ENABLED)
+
+    val context = LocalContext.current
+    val summaryText = stringResource(
+        if (isEnabled) R.string.switch_on_text else R.string.switch_off_text,
+    )
+
+    Preference(object : PreferenceModel {
+        override val title = stringResource(R.string.microphone_spoofing)
+
+        override val summary = { summaryText }
+
+        @SuppressLint("MissingPermission")
+        override val onClick = {
+            launchMicSpoofingConfig(context, app.packageName, app.userHandle)
+        }
+    })
+}

--- a/src/com/android/settings/spa/app/micspoofing/MicSpoofingSettingsUtils.kt
+++ b/src/com/android/settings/spa/app/micspoofing/MicSpoofingSettingsUtils.kt
@@ -1,0 +1,19 @@
+package com.android.settings.spa.app.micspoofing
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.ext.micspoofing.MicSpoofingApi
+import android.os.UserHandle
+
+@SuppressLint("MissingPermission")
+fun launchMicSpoofingConfig(
+    context: Context,
+    packageName: String,
+    userHandle: UserHandle,
+) {
+    MicSpoofingApi
+        .createConfigActivityIntent(packageName)
+        .let { intent ->
+            context.startActivityAsUser(intent, userHandle)
+        }
+}

--- a/tests/spa_unit/AndroidManifest.xml
+++ b/tests/spa_unit/AndroidManifest.xml
@@ -27,6 +27,12 @@
     <uses-permission android:name="com.android.settings.BATTERY_DATA" />
 
     <application android:debuggable="true">
+        <!-- Settings-core manifest contributes this provider with a fixed authority
+             Remove it from the test APK to avoid install conflict with Settings app -->
+        <provider
+                android:name="com.android.settings.sudconfig.SudConfigProvider"
+                tools:node="remove"/>
+
         <provider android:name="com.android.settings.slices.SettingsSliceProvider"
                   android:authorities="${applicationId}.slices"
                   tools:replace="android:authorities"/>

--- a/tests/spa_unit/src/com/android/settings/spa/app/appinfo/AppMicSpoofingPreferenceTest.kt
+++ b/tests/spa_unit/src/com/android/settings/spa/app/appinfo/AppMicSpoofingPreferenceTest.kt
@@ -1,0 +1,141 @@
+package com.android.settings.spa.app.appinfo
+
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ApplicationInfo
+import android.content.pm.GosPackageState
+import android.content.pm.GosPackageStateFlag
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.android.dx.mockito.inline.extended.ExtendedMockito
+import com.android.dx.mockito.inline.extended.ExtendedMockito.doReturn
+import com.android.settings.R
+import com.android.settingslib.spaprivileged.model.app.userHandle
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.doNothing
+import org.mockito.MockitoSession
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.spy
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+
+@RunWith(AndroidJUnit4::class)
+class AppMicSpoofingPreferenceTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Mock
+    private lateinit var gosPackageState: GosPackageState
+
+    private lateinit var mockSession: MockitoSession
+
+    private val context: Context = spy(ApplicationProvider.getApplicationContext()) {
+        doNothing().whenever(mock).startActivityAsUser(any(), any())
+    }
+
+    @Before
+    fun setUp() {
+        mockSession =
+            ExtendedMockito.mockitoSession()
+                .initMocks(this)
+                .mockStatic(GosPackageState::class.java)
+                .strictness(Strictness.LENIENT)
+                .startMocking()
+
+        doReturn(gosPackageState).`when`<GosPackageState> {
+            GosPackageState.get(
+                PACKAGE_NAME,
+                USER_ID
+            )
+        }
+    }
+
+    @After
+    fun tearDown() {
+        mockSession.finishMocking()
+    }
+
+    @Test
+    fun disabledFlag_displayedWithSwitchOffSummary() {
+        whenever(gosPackageState.hasFlag(GosPackageStateFlag.MIC_SPOOFING_ENABLED))
+            .thenReturn(false)
+
+        setContent()
+
+        composeTestRule.onNodeWithText(context.getString(R.string.microphone_spoofing))
+            .assertIsDisplayed()
+        composeTestRule.onNodeWithText(context.getString(R.string.switch_off_text))
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun enabledFlag_displayed() {
+        whenever(gosPackageState.hasFlag(GosPackageStateFlag.MIC_SPOOFING_ENABLED))
+            .thenReturn(true)
+
+        setContent()
+
+        composeTestRule.onNodeWithText(context.getString(R.string.microphone_spoofing))
+            .assertIsDisplayed()
+        composeTestRule.onNodeWithText(context.getString(R.string.switch_on_text))
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun onClick_startsConfigActivityIntent() {
+        whenever(gosPackageState.hasFlag(GosPackageStateFlag.MIC_SPOOFING_ENABLED))
+            .thenReturn(true)
+
+        setContent()
+
+        composeTestRule.onNodeWithText(context.getString(R.string.microphone_spoofing))
+            .performClick()
+
+        verify(context).startActivityAsUser(
+            argThat { intent: Intent? ->
+                intent != null &&
+                        intent.component?.packageName == PERMISSION_CONTROLLER_PKG &&
+                        intent.component?.className ==
+                        "$PERMISSION_CONTROLLER_PKG.micspoofing.MicSpoofingActivity" &&
+                        intent.getStringExtra(Intent.EXTRA_PACKAGE_NAME) == PACKAGE_NAME
+            },
+            eq(APP.userHandle),
+        )
+    }
+
+    private fun setContent() {
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalContext provides context) {
+                AppMicSpoofingPreference(APP)
+            }
+        }
+    }
+
+    private companion object {
+        const val USER_ID = 0
+        const val APP_ID = 12345
+        const val PACKAGE_NAME = "test.package"
+        const val PERMISSION_CONTROLLER_PKG = "com.android.permissioncontroller"
+
+        val APP = ApplicationInfo().apply {
+            packageName = PACKAGE_NAME
+            uid = android.os.UserHandle.getUid(USER_ID, APP_ID)
+            flags = ApplicationInfo.FLAG_INSTALLED
+        }
+    }
+}


### PR DESCRIPTION
Implements https://github.com/GrapheneOS/os-issue-tracker/issues/2133

Adds Settings entry points:
- app info row (`AppMicSpoofingPreference`) with enabled/disabled summary and config intent
- special access page listing `RECORD_AUDIO` apps, toggle support, permission revocation on enable, and configure action

**Tests:**
```shell
atest -c \
  SettingsSpaUnitTests:com.android.settings.spa.app.appinfo.AppMicSpoofingPreferenceTest \
  SettingsSpaUnitTests:com.android.settings.spa.app.specialaccess.MicrophoneSpoofingTest
```