### PR TITLE
[temp] handle stallion-BD6A.251031.001.A4 charging limit string

### DIFF
--- a/res/values/strings_google.xml
+++ b/res/values/strings_google.xml
@@ -22,4 +22,7 @@
     <string name="charging_optimization_entry_summary_charge_limit"/>
     <string name="charging_optimization_summary_off"/>
     <string name="charging_optimization_title"/>
+    <!-- SettingsIntelligenceGoogle: Used in stallion-BD6A.251031.001.A4 -->
+    <string name="charging_optimization_footer_charge_limit"/>
+    <string name="charging_optimization_summary_charge_limit"/>
 </resources>

--- a/src/com/android/settings/fuelgauge/BatteryChargingOptimizationFragment.java
+++ b/src/com/android/settings/fuelgauge/BatteryChargingOptimizationFragment.java
@@ -2,6 +2,7 @@ package com.android.settings.fuelgauge;
 
 import android.ext.power.BatteryChargeLimit;
 import android.ext.settings.BoolSetting;
+import android.icu.text.MessageFormat;
 import android.icu.text.NumberFormat;
 import android.os.RemoteException;
 import android.util.Log;
@@ -10,6 +11,9 @@ import com.android.settings.R;
 import com.android.settings.ext.BoolSettingFragment;
 import com.android.settingslib.widget.FooterPreference;
 import com.google.android.settings.fuelgauge.GoogleBattery;
+
+import java.util.Locale;
+import java.util.Map;
 
 import vendor.google.google_battery.IGoogleBattery;
 
@@ -53,6 +57,13 @@ public class BatteryChargingOptimizationFragment extends BoolSettingFragment {
 
     @Override
     protected CharSequence getMainSwitchTitle() {
+        final String template = requireContext().getString(R.string.charging_optimization_summary_charge_limit);
+        if (template.contains("{batteryLimitLevel}")) {
+            // ICU MessageFormat variant in stallion-BD6A.251031.001.A4
+            return MessageFormat.format(
+                    template, Map.of("batteryLimitLevel", BatteryChargeLimit.CHARGE_LEVEL));
+        }
+        // String.format variant in other devices
         return requireContext().getString(
                 R.string.charging_optimization_entry_summary_charge_limit,
                 NumberFormat.getPercentInstance().format(BatteryChargeLimit.CHARGE_LEVEL / 100f));
@@ -67,11 +78,19 @@ public class BatteryChargingOptimizationFragment extends BoolSettingFragment {
 
     @Override
     protected FooterPreference makeFooterPref(FooterPreference.Builder builder) {
-        String text = requireContext().getString(
-                R.string.charging_optimization_footer_message_charge_limit,
-                NumberFormat.getPercentInstance().format(BatteryChargeLimit.CHARGE_LEVEL / 100f),
-                NumberFormat.getPercentInstance().format(1f));
-
+        final String template = requireContext().getString(R.string.charging_optimization_footer_charge_limit);
+        final String text;
+        if (template.contains("{batteryLimitLevel}")) {
+            // ICU MessageFormat variant in stallion-BD6A.251031.001.A4
+            text = MessageFormat.format(
+                    template, Map.of("batteryLimitLevel", BatteryChargeLimit.CHARGE_LEVEL));
+        } else {
+            // String.format variant in other devices
+            text = requireContext().getString(
+                    R.string.charging_optimization_footer_message_charge_limit,
+                    NumberFormat.getPercentInstance().format(BatteryChargeLimit.CHARGE_LEVEL / 100f),
+                    NumberFormat.getPercentInstance().format(1f));
+        }
         builder.setTitle(text);
 
         FooterPreference pref = builder.build();


### PR DESCRIPTION
Requires https://github.com/GrapheneOS/adevtool/pull/310

stallion-BD6A.251031.001.A4 uses ICU MessageFormat-based strings. Note that stallion-CP1A.260305.018 uses the same charging_optimization_footer_message_charge_limit and charging_optimization_entry_summary_charge_limit as the other devices.