### PR TITLE
platform_packages_apps_Settings: Allow Apple's servers for captive portal check

### DIFF
--- a/res/values/strings_ext.xml
+++ b/res/values/strings_ext.xml
@@ -94,6 +94,7 @@ No query or data is sent to the server. These files contain orbits and statuses 
     <string name="storage_scopes">Storage Scopes</string>
 
     <string name="conn_checks_grapheneos_server">GrapheneOS server</string>
+    <string name="conn_checks_apple_server">Apple server</string>
     <string name="conn_checks_google_server">Standard (Google) server</string>
     <string name="conn_checks_disabled">Off</string>
 

--- a/src/com/android/settings/network/ConnectivityChecksPrefController.java
+++ b/src/com/android/settings/network/ConnectivityChecksPrefController.java
@@ -18,6 +18,7 @@ public class ConnectivityChecksPrefController extends IntSettingPrefController {
     @Override
     protected void getEntries(Entries entries) {
         entries.add(R.string.conn_checks_grapheneos_server, ConnChecksSetting.VAL_GRAPHENEOS);
+        entries.add(R.string.conn_checks_apple_server, ConnChecksSetting.VAL_APPLE);
         entries.add(R.string.conn_checks_google_server, ConnChecksSetting.VAL_STANDARD);
         entries.add(R.string.conn_checks_disabled, ConnChecksSetting.VAL_DISABLED);
     }


### PR DESCRIPTION
Part of https://github.com/GrapheneOS/os-issue-tracker/issues/6728