### PR TITLE
backport 16QPR3 changes to ProfileSelectFragment + fix crash when opening credential settings from private profile

### DIFF
--- a/src/com/android/settings/dashboard/profileselector/ProfileSelectFragment.java
+++ b/src/com/android/settings/dashboard/profileselector/ProfileSelectFragment.java
@@ -59,6 +59,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Base fragment class for profile settings.
@@ -224,35 +225,54 @@ public abstract class ProfileSelectFragment extends DashboardFragment {
         return TAG;
     }
 
+    /**
+     * Despite the name of this function, this returns the index of the tab in the
+     * {@link TabLayout} given by {@link R.id.tabs}. {@link #onCreateView} treats this tabId as an
+     * index.
+     *
+     * <p>
+     * However, it's possible to have tabId != tabIndex in certain cases like launching
+     * android.settings.CREDENTIAL_PROVIDER in an app from a private profile. {@link #PRIVATE_TAB}
+     * is 2, but if there was no work profile, then there would only be Personal (index 0) and
+     * Private (index 1) tabs. Using {@link #PRIVATE_TAB} (2) as the index results in an NPE in
+     * onCreateView. If there was a work profile, then there would be Personal, Private, and Work
+     * tabs. The intent android.settings.CREDENTIAL_PROVIDER from private profile will actually
+     * select the Work tab, because the index {@link #PRIVATE_TAB} (2) is used with Work tab in that
+     * index.
+     *
+     * <p> We fixed this from upstream so that the actual tab index is always returned. This is
+     * marked {@link VisibleForTesting}, so we don't expect this function to be used anywhere else.
+     */
     @VisibleForTesting
     int getTabId(Activity activity, Bundle bundle) {
+        var adapter = (ViewPagerAdapter) Objects.requireNonNull(mViewPager.getAdapter());
         if (bundle != null) {
             final int extraTab = bundle.getInt(SettingsActivity.EXTRA_SHOW_FRAGMENT_TAB, -1);
             if (extraTab != -1) {
-                return ((ViewPagerAdapter) mViewPager.getAdapter())
-                        .getPositionForProfileTab(extraTab);
+                // very confusing function name: upstream is returning position here, not tab id
+                return adapter.getPositionForProfileTab(extraTab);
             }
             final int userId = bundle.getInt(EXTRA_USER_ID, activity.getUserId());
             final boolean isWorkProfile = UserManager.get(activity).isManagedProfile(userId);
             if (isWorkProfile) {
-                return WORK_TAB;
+                return adapter.getPositionForProfileTab(WORK_TAB);
             }
             UserInfo userInfo = UserManager.get(activity).getUserInfo(userId);
             if (userInfo != null && userInfo.isPrivateProfile()) {
-                return PRIVATE_TAB;
+                return adapter.getPositionForProfileTab(PRIVATE_TAB);
             }
         }
         // Start intent from a specific user eg: adb shell --user 10
         final int intentUser = activity.getIntent().getContentUserHint();
         if (UserManager.get(activity).isManagedProfile(intentUser)) {
-            return WORK_TAB;
+            return adapter.getPositionForProfileTab(WORK_TAB);
         }
         UserInfo userInfo = UserManager.get(activity).getUserInfo(intentUser);
         if (userInfo != null && userInfo.isPrivateProfile()) {
-            return PRIVATE_TAB;
+            return adapter.getPositionForProfileTab(PRIVATE_TAB);
         }
 
-        return PERSONAL_TAB;
+        return adapter.getPositionForProfileTab(PERSONAL_TAB);
     }
 
     private CharSequence getPageTitle(int position) {

--- a/src/com/android/settings/dashboard/profileselector/ProfileSelectFragment.java
+++ b/src/com/android/settings/dashboard/profileselector/ProfileSelectFragment.java
@@ -310,6 +310,10 @@ public abstract class ProfileSelectFragment extends DashboardFragment {
 
         try {
             UserManager userManager = context.getSystemService(UserManager.class);
+            // ProfileSelectFragment can be used in a private or work profile via an app launching
+            // Settings.ACTION_CREDENTIAL_PROVIDER. When this happens, UserHandle.myUserId() will
+            // actually be the userId of the private / work profile. userManager.getProfiles returns
+            // the entire profile group, so the parent and its profiles will always be in there.
             List<UserInfo> userInfos = userManager.getProfiles(UserHandle.myUserId());
 
             for (UserInfo userInfo : userInfos) {

--- a/src/com/android/settings/dashboard/profileselector/ProfileSelectFragment.java
+++ b/src/com/android/settings/dashboard/profileselector/ProfileSelectFragment.java
@@ -317,7 +317,13 @@ public abstract class ProfileSelectFragment extends DashboardFragment {
             List<UserInfo> userInfos = userManager.getProfiles(UserHandle.myUserId());
 
             for (UserInfo userInfo : userInfos) {
-                if (userInfo.canHaveProfile()) {
+                // 16 QPR3: userInfo.isMain() was changed to userInfo.canHaveProfile(). However,
+                // userInfo.canHaveProfile() doesn't return true in full secondary (non-guest) users
+                // until the aconfig flag android.multiuser.profiles_for_all and
+                // config_supportProfilesOnNonMainUser are both enabled. Use downstream check for it
+                // in canHaveProfile(UserManager.USER_TYPE_PROFILE_PRIVATE) for now
+                if (userInfo.canHaveProfile()
+                        || userInfo.canHaveProfile(UserManager.USER_TYPE_PROFILE_PRIVATE)) {
                     fragments.add(
                             createAndGetFragment(
                                     ProfileType.PERSONAL,

--- a/src/com/android/settings/dashboard/profileselector/ProfileSelectFragment.java
+++ b/src/com/android/settings/dashboard/profileselector/ProfileSelectFragment.java
@@ -232,12 +232,7 @@ public abstract class ProfileSelectFragment extends DashboardFragment {
                 return ((ViewPagerAdapter) mViewPager.getAdapter())
                         .getPositionForProfileTab(extraTab);
             }
-            final UserManager userManager = getSystemService(UserManager.class);
-            UserHandle mainUser = userManager.getMainUser();
-            if (mainUser == null) {
-                mainUser = UserHandle.SYSTEM;
-            }
-            final int userId = bundle.getInt(EXTRA_USER_ID, mainUser.getIdentifier());
+            final int userId = bundle.getInt(EXTRA_USER_ID, activity.getUserId());
             final boolean isWorkProfile = UserManager.get(activity).isManagedProfile(userId);
             if (isWorkProfile) {
                 return WORK_TAB;
@@ -318,7 +313,7 @@ public abstract class ProfileSelectFragment extends DashboardFragment {
             List<UserInfo> userInfos = userManager.getProfiles(UserHandle.myUserId());
 
             for (UserInfo userInfo : userInfos) {
-                if (userInfo.isMain()) {
+                if (userInfo.canHaveProfile()) {
                     fragments.add(
                             createAndGetFragment(
                                     ProfileType.PERSONAL,

--- a/src/com/android/settings/dashboard/profileselector/ProfileSelectFragment.java
+++ b/src/com/android/settings/dashboard/profileselector/ProfileSelectFragment.java
@@ -237,14 +237,7 @@ public abstract class ProfileSelectFragment extends DashboardFragment {
             if (mainUser == null) {
                 mainUser = UserHandle.SYSTEM;
             }
-            UserHandle activityUser = activity.getUser();
-            final int userIdFallback;
-            if (mainUser.getIdentifier() != activityUser.getIdentifier()) {
-                userIdFallback = activityUser.getIdentifier();
-            } else {
-                userIdFallback = mainUser.getIdentifier();
-            }
-            final int userId = bundle.getInt(EXTRA_USER_ID, userIdFallback);
+            final int userId = bundle.getInt(EXTRA_USER_ID, mainUser.getIdentifier());
             final boolean isWorkProfile = UserManager.get(activity).isManagedProfile(userId);
             if (isWorkProfile) {
                 return WORK_TAB;
@@ -347,18 +340,6 @@ public abstract class ProfileSelectFragment extends DashboardFragment {
                                         userInfo.id,
                                         bundle != null ? bundle.deepCopy() : new Bundle(),
                                         privateFragmentConstructor));
-                        UserInfo parentUserInfo = userInfos.stream()
-                                .filter(info -> info.id == UserHandle.myUserId())
-                                .toList().get(0);
-                        if (!parentUserInfo.isMain() && parentUserInfo.canHaveProfile(
-                                UserManager.USER_TYPE_PROFILE_PRIVATE)) {
-                            fragments.add(0,
-                                    createAndGetFragment(
-                                            ProfileType.PERSONAL,
-                                            parentUserInfo.id,
-                                            bundle != null ? bundle.deepCopy() : new Bundle(),
-                                            personalFragmentConstructor));
-                        }
                     }
                 } else {
                     Log.d(TAG, "Not showing tab for unsupported user " + userInfo);

--- a/tests/robotests/src/com/android/settings/biometrics/fingerprint/FingerprintSettingsFragmentTest.java
+++ b/tests/robotests/src/com/android/settings/biometrics/fingerprint/FingerprintSettingsFragmentTest.java
@@ -80,7 +80,6 @@ import androidx.test.core.app.ApplicationProvider;
 import com.android.settings.biometrics.fingerprint.feature.FingerprintExtPreferencesProvider;
 import com.android.internal.widget.LockPatternUtils;
 import com.android.settings.biometrics.fingerprint.feature.PrimarySwitchIntentPreference;
-import com.android.settings.biometrics.fingerprint.feature.SfpsRestToUnlockFeature;
 import com.android.settings.password.ChooseLockSettingsHelper;
 import com.android.settings.password.ConfirmDeviceCredentialActivity;
 import com.android.settings.search.BaseSearchIndexProvider;
@@ -164,8 +163,6 @@ public class FingerprintSettingsFragmentTest {
     private FakeFeatureFactory mFeatureFactory;
     @Mock
     private LockPatternUtils mLockPatternUtils;
-    @Mock
-    private SfpsRestToUnlockFeature mSfpsRestToUnlockFeature;
 
     @Before
     public void setUp() {
@@ -195,8 +192,6 @@ public class FingerprintSettingsFragmentTest {
 
         when(mFakeFeatureFactory.securityFeatureProvider.getLockPatternUtils(mContext))
                 .thenReturn(mLockPatternUtils);
-        when(mFakeFeatureFactory.mFingerprintFeatureProvider.getSfpsRestToUnlockFeature(mContext))
-                .thenReturn(mSfpsRestToUnlockFeature);
 
         when(mLockPatternUtils.checkUserSupportsBiometricSecondFactor(anyInt())).thenReturn(true);
     }

--- a/tests/robotests/src/com/android/settings/dashboard/profileselector/ProfileSelectFragmentTest.java
+++ b/tests/robotests/src/com/android/settings/dashboard/profileselector/ProfileSelectFragmentTest.java
@@ -99,8 +99,22 @@ public class ProfileSelectFragmentTest {
         mUserManager = ShadowUserManager.getShadow();
     }
 
+    private void setUpViewPager(ProfileSelectFragment fragment) {
+        ViewPager2 viewPager = new ViewPager2(mContext);
+        ViewPagerAdapter viewPagerAdapter =
+                new TestViewPagerAdapter(mFragmentManager, mLifecycle, fragment);
+        when(mFragmentManager.beginTransaction()).thenReturn(mFragmentTransaction);
+        viewPager.setAdapter(viewPagerAdapter);
+        mFragment.setViewPager(viewPager);
+        fragment.setViewPager(viewPager);
+        mFragmentManager.beginTransaction().add(fragment, "tag");
+    }
+
     @Test
     public void getTabId_no_setCorrectTab() {
+        TestProfileSelectFragment profileSelectFragment = new TestProfileSelectFragment();
+        setUpViewPager(profileSelectFragment);
+
         assertThat(mFragment.getTabId(mActivity, null)).isEqualTo(PERSONAL_TAB);
     }
 
@@ -108,16 +122,8 @@ public class ProfileSelectFragmentTest {
     public void getTabId_setArgumentWork_setCorrectTab() {
         final Bundle bundle = new Bundle();
         bundle.putInt(SettingsActivity.EXTRA_SHOW_FRAGMENT_TAB, WORK_TAB);
-        ViewPager2 viewPager = new ViewPager2(mContext);
         TestProfileSelectFragment profileSelectFragment = new TestProfileSelectFragment();
-        ViewPagerAdapter viewPagerAdapter =
-                new TestViewPagerAdapter(mFragmentManager, mLifecycle, profileSelectFragment);
-
-        when(mFragmentManager.beginTransaction()).thenReturn(mFragmentTransaction);
-        viewPager.setAdapter(viewPagerAdapter);
-        mFragment.setViewPager(viewPager);
-        profileSelectFragment.setViewPager(viewPager);
-        mFragmentManager.beginTransaction().add(profileSelectFragment, "tag");
+        setUpViewPager(profileSelectFragment);
 
         // The expected position '2' comes from the order in which fragments are added in
         // TestProfileSelectFragment#getFragments()
@@ -128,16 +134,8 @@ public class ProfileSelectFragmentTest {
     public void getTabId_setArgumentPrivate_setCorrectTab() {
         final Bundle bundle = new Bundle();
         bundle.putInt(SettingsActivity.EXTRA_SHOW_FRAGMENT_TAB, PRIVATE_TAB);
-        ViewPager2 viewPager = new ViewPager2(mContext);
         TestProfileSelectFragment profileSelectFragment = new TestProfileSelectFragment();
-        ViewPagerAdapter viewPagerAdapter =
-                new TestViewPagerAdapter(mFragmentManager, mLifecycle, profileSelectFragment);
-
-        when(mFragmentManager.beginTransaction()).thenReturn(mFragmentTransaction);
-        viewPager.setAdapter(viewPagerAdapter);
-        mFragment.setViewPager(viewPager);
-        profileSelectFragment.setViewPager(viewPager);
-        mFragmentManager.beginTransaction().add(profileSelectFragment, "tag");
+        setUpViewPager(profileSelectFragment);
 
         // The expected position '1' comes from the order in which fragments are added in
         // TestProfileSelectFragment#getFragments()
@@ -148,16 +146,8 @@ public class ProfileSelectFragmentTest {
     public void getTabId_setArgumentPersonal_setCorrectTab() {
         final Bundle bundle = new Bundle();
         bundle.putInt(SettingsActivity.EXTRA_SHOW_FRAGMENT_TAB, PERSONAL_TAB);
-        ViewPager2 viewPager = new ViewPager2(mContext);
         TestProfileSelectFragment profileSelectFragment = new TestProfileSelectFragment();
-        ViewPagerAdapter viewPagerAdapter =
-                new TestViewPagerAdapter(mFragmentManager, mLifecycle, profileSelectFragment);
-
-        when(mFragmentManager.beginTransaction()).thenReturn(mFragmentTransaction);
-        viewPager.setAdapter(viewPagerAdapter);
-        mFragment.setViewPager(viewPager);
-        profileSelectFragment.setViewPager(viewPager);
-        mFragmentManager.beginTransaction().add(profileSelectFragment, "tag");
+        setUpViewPager(profileSelectFragment);
 
         assertThat(mFragment.getTabId(mActivity, bundle)).isEqualTo(PERSONAL_TAB);
     }
@@ -169,8 +159,11 @@ public class ProfileSelectFragmentTest {
         final Set<Integer> profileIds = new HashSet<>();
         profileIds.add(10);
         mUserManager.setManagedProfiles(profileIds);
+        TestProfileSelectFragment profileSelectFragment = new TestProfileSelectFragment();
+        setUpViewPager(profileSelectFragment);
 
-        assertThat(mFragment.getTabId(mActivity, bundle)).isEqualTo(WORK_TAB);
+        // Work fragment is at position 2 in TestProfileSelectFragment#getFragments()
+        assertThat(mFragment.getTabId(mActivity, bundle)).isEqualTo(2);
     }
 
     @Test
@@ -178,14 +171,19 @@ public class ProfileSelectFragmentTest {
         final Bundle bundle = new Bundle();
         bundle.putInt(EXTRA_USER_ID, 11);
         mUserManager.setPrivateProfile(11, "private", 0);
+        TestProfileSelectFragment profileSelectFragment = new TestProfileSelectFragment();
+        setUpViewPager(profileSelectFragment);
 
-        assertThat(mFragment.getTabId(mActivity, bundle)).isEqualTo(PRIVATE_TAB);
+        // Private fragment is at position 1 in TestProfileSelectFragment#getFragments()
+        assertThat(mFragment.getTabId(mActivity, bundle)).isEqualTo(1);
     }
 
     @Test
     public void getTabId_setPersonalId_getCorrectTab() {
         final Bundle bundle = new Bundle();
         bundle.putInt(EXTRA_USER_ID, 0);
+        TestProfileSelectFragment profileSelectFragment = new TestProfileSelectFragment();
+        setUpViewPager(profileSelectFragment);
 
         assertThat(mFragment.getTabId(mActivity, bundle)).isEqualTo(PERSONAL_TAB);
     }
@@ -198,8 +196,47 @@ public class ProfileSelectFragmentTest {
         final Intent intent = spy(new Intent());
         when(intent.getContentUserHint()).thenReturn(10);
         when(mActivity.getIntent()).thenReturn(intent);
+        TestProfileSelectFragment profileSelectFragment = new TestProfileSelectFragment();
+        setUpViewPager(profileSelectFragment);
 
-        assertThat(mFragment.getTabId(mActivity, null)).isEqualTo(WORK_TAB);
+        // Work fragment is at position 2 in TestProfileSelectFragment#getFragments()
+        assertThat(mFragment.getTabId(mActivity, null)).isEqualTo(2);
+    }
+
+    @Test
+    public void getTabId_privateProfileNoWorkProfile_getsCorrectPosition() {
+        final int privateUserId = 11;
+        when(mActivity.getUserId()).thenReturn(privateUserId);
+        mUserManager.setPrivateProfile(privateUserId, PRIVATE_USER_NAME, 0);
+
+        // Bundle with no EXTRA_USER_ID -- falls back to activity.getUserId()
+        final Bundle bundle = new Bundle();
+
+        // Adapter with only Personal (pos 0) and Private (pos 1) -- no Work
+        TestPersonalAndPrivateOnlyFragment profileSelectFragment =
+                new TestPersonalAndPrivateOnlyFragment();
+        setUpViewPager(profileSelectFragment);
+
+        // Should return position 1 (where Private actually is), not PRIVATE_TAB (2)
+        assertThat(mFragment.getTabId(mActivity, bundle)).isEqualTo(1);
+    }
+
+    @Test
+    public void getTabId_privateProfileWithWorkProfile_getsPrivateNotWork() {
+        final int privateUserId = 11;
+        when(mActivity.getUserId()).thenReturn(privateUserId);
+        mUserManager.setPrivateProfile(privateUserId, PRIVATE_USER_NAME, 0);
+
+        // Bundle with no EXTRA_USER_ID, falls back to activity.getUserId()
+        final Bundle bundle = new Bundle();
+
+        // Adapter with all 3 tabs: Personal (pos 0), Private (pos 1), Work (pos 2).
+        // getTabId should not return PRIVATE_TAB (2), which is the Work tab position.
+        TestProfileSelectFragment profileSelectFragment = new TestProfileSelectFragment();
+        setUpViewPager(profileSelectFragment);
+
+        // Should return position 1 (Private), not 2 (which is Work in this ordering)
+        assertThat(mFragment.getTabId(mActivity, bundle)).isEqualTo(1);
     }
 
     @Test
@@ -328,6 +365,28 @@ public class ProfileSelectFragmentTest {
                     privateFragment,
                     workFragment
             };
+        }
+    }
+
+    /**
+     * Simulates a user with a personal and private profile but no work profile. The ordering
+     * reflects the iteration order in {@link ProfileSelectFragment#getFragments} when no work
+     * profile is present.
+     */
+    public static class TestPersonalAndPrivateOnlyFragment extends ProfileSelectFragment {
+        @Override
+        public Fragment[] getFragments() {
+            Fragment personalFragment = new SettingsPreferenceFragmentTest.TestFragment();
+            Bundle personalBundle = new Bundle();
+            personalBundle.putInt(EXTRA_PROFILE, ProfileType.PERSONAL);
+            personalFragment.setArguments(personalBundle);
+
+            Fragment privateFragment = new SettingsPreferenceFragmentTest.TestFragment();
+            Bundle privateBundle = new Bundle();
+            privateBundle.putInt(EXTRA_PROFILE, ProfileType.PRIVATE);
+            privateFragment.setArguments(privateBundle);
+
+            return new Fragment[]{personalFragment, privateFragment};
         }
     }
 

--- a/tests/robotests/src/com/android/settings/dashboard/profileselector/ProfileSelectFragmentTest.java
+++ b/tests/robotests/src/com/android/settings/dashboard/profileselector/ProfileSelectFragmentTest.java
@@ -17,6 +17,7 @@
 package com.android.settings.dashboard.profileselector;
 
 import static android.content.Intent.EXTRA_USER_ID;
+import static android.content.pm.UserInfo.FLAG_FULL;
 import static android.content.pm.UserInfo.FLAG_MAIN;
 import static android.os.UserManager.USER_TYPE_FULL_SYSTEM;
 import static android.os.UserManager.USER_TYPE_PROFILE_MANAGED;
@@ -204,7 +205,7 @@ public class ProfileSelectFragmentTest {
     @Test
     public void testGetFragments_whenPrivateDisabled_returnsOneFragment() {
         mUserManager.addProfile(
-                new UserInfo(0, PRIMARY_USER_NAME, null, FLAG_MAIN, USER_TYPE_FULL_SYSTEM));
+                new UserInfo(0, PRIMARY_USER_NAME, null, FLAG_MAIN | FLAG_FULL, USER_TYPE_FULL_SYSTEM));
         mUserManager.addProfile(
                 new UserInfo(11, PRIVATE_USER_NAME, null, 0, USER_TYPE_PROFILE_PRIVATE));
         Fragment[] fragments = ProfileSelectFragment.getFragments(
@@ -225,7 +226,7 @@ public class ProfileSelectFragmentTest {
     @Test
     public void testGetFragments_whenPrivateEnabled_returnsTwoFragments() {
         mUserManager.addProfile(
-                new UserInfo(0, PRIMARY_USER_NAME, null, FLAG_MAIN, USER_TYPE_FULL_SYSTEM));
+                new UserInfo(0, PRIMARY_USER_NAME, null, FLAG_MAIN | FLAG_FULL, USER_TYPE_FULL_SYSTEM));
         mUserManager.addProfile(
                 new UserInfo(11, PRIVATE_USER_NAME, null, 0, USER_TYPE_PROFILE_PRIVATE));
         Fragment[] fragments = ProfileSelectFragment.getFragments(
@@ -246,7 +247,7 @@ public class ProfileSelectFragmentTest {
     @Test
     public void testGetFragments_whenAllProfiles_returnsThreeFragments() {
         mUserManager.addProfile(
-                new UserInfo(0, PRIMARY_USER_NAME, null, FLAG_MAIN, USER_TYPE_FULL_SYSTEM));
+                new UserInfo(0, PRIMARY_USER_NAME, null, FLAG_MAIN | FLAG_FULL, USER_TYPE_FULL_SYSTEM));
         mUserManager.addProfile(
                 new UserInfo(10, MANAGED_USER_NAME, null, 0, USER_TYPE_PROFILE_MANAGED));
         mUserManager.addProfile(
@@ -269,7 +270,7 @@ public class ProfileSelectFragmentTest {
     @Test
     public void testGetFragments_whenAvailableBundle_returnsFragmentsWithCorrectBundles() {
         mUserManager.addProfile(
-                new UserInfo(0, PRIMARY_USER_NAME, null, FLAG_MAIN, USER_TYPE_FULL_SYSTEM));
+                new UserInfo(0, PRIMARY_USER_NAME, null, FLAG_MAIN | FLAG_FULL, USER_TYPE_FULL_SYSTEM));
         mUserManager.addProfile(
                 new UserInfo(10, MANAGED_USER_NAME, null, 0, USER_TYPE_PROFILE_MANAGED));
         mUserManager.addProfile(


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/os-issue-tracker/issues/7531

Backport the changes done in 16 QPR3 settings app in advance so less conflicts in the future. The code looks the same in 17 Beta 3.