### PR TITLE
Add carrier override for inflating cell signal

### DIFF
--- a/res/values/strings_ext.xml
+++ b/res/values/strings_ext.xml
@@ -322,4 +322,8 @@ May cause unreliable service. Use at your own risk.
     <string name="carrier_settings_override_wfc_availability_enabled_roaming_not_editable">Available but roaming not editable</string>
     <string name="carrier_settings_override_cross_sim">Cross SIM calling / backup calling availability</string>
     <string name="carrier_settings_override_cross_sim_description">Only for dual SIM setups. If enabled, then when the SIM is roaming or out of service and Wi‑Fi isn\’t available, calls can be made over another SIM’s data connection. Wi-Fi calling should be set to available to use this.</string>
+    <string name="carrier_settings_override_inflate_signal">Inflate cell signal</string>
+    <string name="carrier_settings_override_inflate_signal_description">When inflated, the status bar displays signal out of 5 bars instead of 4</string>
+    <string name="carrier_settings_override_inflate_true">Display 5 bars</string>
+    <string name="carrier_settings_override_inflate_false">Display 4 bars</string>
 </resources>

--- a/src/com/android/settings/network/telephony/carriersettingsoverride/CarrierConfigOverrideOptions.kt
+++ b/src/com/android/settings/network/telephony/carriersettingsoverride/CarrierConfigOverrideOptions.kt
@@ -44,7 +44,8 @@ val allowedUserChangeableCarrierConfigOptions: List<ChangeableCarrierConfigOptio
         VoNREnabled,
         Enable5G,
         WiFiCallingAvailable,
-        CrossSIMAvailable
+        CrossSIMAvailable,
+        InflateSignal
 
     ).also { list ->
        list.onEach { flag ->
@@ -322,4 +323,25 @@ data object CrossSIMAvailable : ChangeableCarrierConfigOption(
     override val titleStringRes = R.string.carrier_settings_override_cross_sim
     override val dialogDescriptionStringRes: Int
         get() = R.string.carrier_settings_override_cross_sim_description
+}
+
+data object InflateSignal : ChangeableCarrierConfigOption(
+    keysWithType = listOf(
+        CarrierConfigManager.KEY_INFLATE_SIGNAL_STRENGTH_BOOL to KeyType.BOOLEAN,
+    ),
+    allPossibleConfigStates = listOf(
+        ConfigState.Uniform(
+            CarrierConfigTypedValue.Bool(true),
+            R.string.carrier_settings_override_inflate_true,
+            R.string.carrier_settings_override_inflate_true,
+        ),
+        ConfigState.Uniform(
+            CarrierConfigTypedValue.Bool(false),
+            R.string.carrier_settings_override_inflate_false,
+            R.string.carrier_settings_override_inflate_false,
+        ),
+    )
+) {
+    override val titleStringRes = R.string.carrier_settings_override_inflate_signal
+    override val dialogDescriptionStringRes = R.string.carrier_settings_override_inflate_signal_description
 }


### PR DESCRIPTION
Android 16 has a feature to stack the cell signal of two SIMs on top of each other. However, if one SIM has the KEY_INFLATE_SIGNAL_STRENGTH_BOOL set to true by default, one SIM will display out of 5 bars and another out of 4 bars. This will cause the two SIMs statuses to display next to each other instead of stacked, which takes up the entire status bar and makes it difficult to display any other status.

I did not test this PR, but I tested toggling the KEY_INFLATE_SIGNAL_STRENGTH_BOOL on Pixel IMS and it behaves as expected.