### PR TITLE
New option for controlling VPN disguise

### DIFF
--- a/res/values/strings_ext.xml
+++ b/res/values/strings_ext.xml
@@ -322,4 +322,10 @@ May cause unreliable service. Use at your own risk.
     <string name="carrier_settings_override_wfc_availability_enabled_roaming_not_editable">Available but roaming not editable</string>
     <string name="carrier_settings_override_cross_sim">Cross SIM calling / backup calling availability</string>
     <string name="carrier_settings_override_cross_sim_description">Only for dual SIM setups. If enabled, then when the SIM is roaming or out of service and Wi‑Fi isn\’t available, calls can be made over another SIM’s data connection. Wi-Fi calling should be set to available to use this.</string>
+
+    <string name="vpn_disguise">Disguise VPN as a Wi-Fi or mobile network</string>
+    <string name="vpn_disguise_enabled">VPN disguised</string>
+    <string name="vpn_disguise_enabled_for_nonsystem">VPN disguised for non-system apps</string>
+    <string name="vpn_disguise_disabled">VPN not disguised</string>
+    <string name="vpn_disguise_footer">VPN can be reported to the apps as a normal network</string>
 </resources>

--- a/res/xml/more_security_privacy_settings.xml
+++ b/res/xml/more_security_privacy_settings.xml
@@ -142,6 +142,12 @@
             android:fragment="com.android.settings.network.telephony.CellularSecuritySettingsFragment"
             settings:controller="com.android.settings.network.CellularSecurityPreferenceController"
             settings:searchable="false"/>
+
+	<Preference
+	    android:key="vpn_disguise"
+            android:title="@string/vpn_disguise"
+            android:fragment="com.android.settings.applications.AppDefaultVpnDisguiseFragment"
+            settings:controller="com.android.settings.applications.AppDefaultVpnDisguisePrefController" />
     </PreferenceCategory>
 
     <!-- Security section. -->

--- a/src/com/android/settings/applications/AppVpnDisguise.kt
+++ b/src/com/android/settings/applications/AppVpnDisguise.kt
@@ -1,0 +1,75 @@
+package com.android.settings.applications
+
+import android.content.Context
+import android.content.pm.ApplicationInfo
+import android.ext.settings.ExtSettings
+import android.ext.settings.app.VpnDisguise
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import androidx.preference.PreferenceScreen
+import com.android.settings.R
+import com.android.settings.ext.BoolSettingFragment
+import com.android.settings.ext.BoolSettingFragmentPrefController
+import com.android.settings.ext.ExtSettingControllerHelper
+import com.android.settings.spa.app.appinfo.AswPreference
+import com.android.settingslib.widget.FooterPreference
+
+object AswAdapterVpnDisguise : AswAdapter<VpnDisguise>() {
+
+    override fun getAppSwitch() = VpnDisguise.I
+
+    override fun getAswTitle(ctx: Context) = ctx.getText(R.string.vpn_disguise)
+
+    override fun getOnTitle(ctx: Context) = ctx.getText(R.string.vpn_disguise_enabled)
+    override fun getOffTitle(ctx: Context) = ctx.getText(R.string.vpn_disguise_disabled)
+
+    override fun getDetailFragmentClass() = AppVpnDisguiseFragment::class
+}
+
+@Composable
+fun AppVpnDisguisePreference(app: ApplicationInfo) {
+    val context = LocalContext.current
+    AswPreference(context, app, AswAdapterVpnDisguise)
+}
+
+class AppVpnDisguiseFragment : AswAppInfoFragment<VpnDisguise>() {
+
+    override fun getAswAdapter() = AswAdapterVpnDisguise
+
+    override fun getTitle() = getText(R.string.vpn_disguise)
+
+    override fun updateFooter(fp: FooterPreference) {
+        fp.setTitle(R.string.vpn_disguise_footer)
+    }
+}
+
+class AppDefaultVpnDisguisePrefController(ctx: Context, key: String) :
+        BoolSettingFragmentPrefController(ctx, key, ExtSettings.VPN_DISGUISE_BY_DEFAULT) {
+
+    override fun getSummaryOn() = resText(R.string.vpn_disguise_enabled_for_nonsystem)
+    override fun getSummaryOff() = resText(R.string.vpn_disguise_disabled)
+}
+
+class AppDefaultVpnDisguiseFragment : BoolSettingFragment() {
+
+    override fun getSetting() = ExtSettings.VPN_DISGUISE_BY_DEFAULT
+
+    override fun getTitle() = resText(R.string.vpn_disguise)
+
+    override fun getMainSwitchTitle() = resText(R.string.vpn_disguise)
+
+    override fun addExtraPrefs(screen: PreferenceScreen) {
+        AswAdapterVpnDisguise.addAppListPageLink(screen)
+    }
+
+    override fun makeFooterPref(builder: FooterPreference.Builder): FooterPreference {
+        return builder.setTitle(R.string.vpn_disguise_footer).build()
+    }
+}
+
+class VpnDisguiseAppListPrefController(context: Context, preferenceKey: String) :
+    AswAppListPrefController(context, preferenceKey, AswAdapterVpnDisguise) {
+
+    override fun getAvailabilityStatus() = ExtSettingControllerHelper
+        .getSecondaryUserOnlySettingAvailability(mContext)
+}

--- a/src/com/android/settings/spa/SettingsSpaEnvironment.kt
+++ b/src/com/android/settings/spa/SettingsSpaEnvironment.kt
@@ -109,6 +109,7 @@ open class SettingsSpaEnvironment(context: Context) : SpaEnvironment(context) {
             com.android.settings.applications.AswAdapterMemoryDynCodeLoading.makeAppListPageProvider(),
             com.android.settings.applications.AswAdapterStorageDynCodeLoading.makeAppListPageProvider(),
             com.android.settings.applications.AswAdapterManagePlayIntegrityApi.makeAppListPageProvider(),
+            com.android.settings.applications.AswAdapterVpnDisguise.makeAppListPageProvider(),
             com.android.settings.network.telephony.carriersettingsoverride.CarrierSettingsOverridesProvider,
             AllAppListPageProvider,
             AppInfoSettingsProvider,

--- a/src/com/android/settings/spa/app/appinfo/AppInfoSettings.kt
+++ b/src/com/android/settings/spa/app/appinfo/AppInfoSettings.kt
@@ -163,6 +163,7 @@ private fun AppInfoSettings(packageInfoPresenter: PackageInfoPresenter) {
             AppOpenByDefaultPreference(app)
             DefaultAppShortcuts(app)
             AppLogcatPreference(app)
+            com.android.settings.applications.AppVpnDisguisePreference(app)
         }
 
         Category(title = stringResource(R.string.unused_apps_category)) {


### PR DESCRIPTION
Currently an app is notified whether VPN is active even if it's not routed through it. Some apps like Canadian banks refuse to work if any VPN is active at all. This patchset solves it twofold:

* Apps that are not system and not routed through VPN don't receive VPN notifications anymore
* Optionally if enabled apps that are routed through VPN get fake network info. I call this option VPN disguise.

Fixes https://github.com/GrapheneOS/os-issue-tracker/issues/5225