### PR TITLE
show lockscreen widgets Settings entry by default (for emulator)

### DIFF
--- a/res/values/config.xml
+++ b/res/values/config.xml
@@ -741,7 +741,7 @@
     <bool name="config_show_glanceable_hub_toggle_setting">false</bool>
 
     <!-- Whether to show the "glanceable hub" settings on mobile. -->
-    <bool name="config_show_glanceable_hub_toggle_setting_mobile">false</bool>
+    <bool name="config_show_glanceable_hub_toggle_setting_mobile">true</bool>
 
     <!-- Whether to show a "restrict to wireless charging" settings option in screensaver and hub
          mode settings (false by default). -->


### PR DESCRIPTION
On Pixels (including stallion BD6A), config_show_glanceable_hub_toggle_setting_mobile is set to true via GlanceableHubSettingsConfigOverlay, which makes WidgetsOnLockscreenPreferenceController return AVAILABLE on phones.  Default it to true so the entry also appears on the emulator.