### PR TITLE
Settings: Reset tether offload developer setting correctly

### DIFF
--- a/src/com/android/settings/development/TetheringHardwareAccelPreferenceController.java
+++ b/src/com/android/settings/development/TetheringHardwareAccelPreferenceController.java
@@ -60,15 +60,21 @@ public class TetheringHardwareAccelPreferenceController extends DeveloperOptions
     public void updateState(Preference preference) {
         final int tetheringMode = Settings.Global.getInt(
                 mContext.getContentResolver(),
-                Settings.Global.TETHER_OFFLOAD_DISABLED, 0 /* default */);
+                Settings.Global.TETHER_OFFLOAD_DISABLED, SETTING_VALUE_ON);
         ((TwoStatePreference) mPreference).setChecked(tetheringMode != SETTING_VALUE_OFF);
     }
 
     @Override
     protected void onDeveloperOptionsSwitchDisabled() {
         super.onDeveloperOptionsSwitchDisabled();
+        // The default is to enable tether offload, i.e. SETTING_VALUE_ON == 0.
+        // packages/modules/Connectivity/Tethering/src/com/android/networkstack/tethering/OffloadHardwareInterface.java#DEFAULT_TETHER_OFFLOAD_DISABLED
+        // is 0
         Settings.Global.putInt(mContext.getContentResolver(),
-                Settings.Global.TETHER_OFFLOAD_DISABLED, SETTING_VALUE_OFF);
-        ((TwoStatePreference) mPreference).setChecked(false);
+                Settings.Global.TETHER_OFFLOAD_DISABLED, SETTING_VALUE_ON);
+        // The sysprop callback refreshes this via updatePreferenceStates() when dev options 
+        // disabled, but keep direct state consistent for completeness + the SettingsRoboTest for
+        // this controller checks for this directly.
+        ((TwoStatePreference) mPreference).setChecked(true);
     }
 }

--- a/tests/robotests/src/com/android/settings/development/TetheringHardwareAccelPreferenceControllerTest.java
+++ b/tests/robotests/src/com/android/settings/development/TetheringHardwareAccelPreferenceControllerTest.java
@@ -102,8 +102,8 @@ public class TetheringHardwareAccelPreferenceControllerTest {
         final int mode = Settings.Global.getInt(mContext.getContentResolver(),
                 Settings.Global.TETHER_OFFLOAD_DISABLED, -1 /* default */);
 
-        assertThat(mode).isEqualTo(TetheringHardwareAccelPreferenceController.SETTING_VALUE_OFF);
+        assertThat(mode).isEqualTo(TetheringHardwareAccelPreferenceController.SETTING_VALUE_ON);
         verify(mPreference).setEnabled(false);
-        verify(mPreference).setChecked(false);
+        verify(mPreference).setChecked(true);
     }
 }


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/os-issue-tracker/issues/7939

Tethering offload is enabled by default, i.e tether_offload_disabled is 0. When developer settings is disabled, we want it set back to 0 i.e tethering offload enabled.

Commit has been edited for completeness and also updates test expectation.

Test: `atest SettingsRoboTests:com.android.settings.development.TetheringHardwareAccelPreferenceControllerTest`
