### PR TITLE
add a one-time tethering acceleration fixup task

### DIFF
--- a/src/com/android/settings/SettingsApplication.java
+++ b/src/com/android/settings/SettingsApplication.java
@@ -81,6 +81,7 @@ public class SettingsApplication extends Application {
             com.android.settingslib.utils.ThreadUtils.postOnBackgroundThread(() -> {
                 com.android.settings.users.UserRestrictions.fixupPrivateSpaceRestrictions(this);
                 VanadiumLibraryCleanup.run(this);
+                com.android.settings.development.TetheringHardwareAccelFixup.run(this);
             });
         }
 

--- a/src/com/android/settings/development/TetheringHardwareAccelFixup.java
+++ b/src/com/android/settings/development/TetheringHardwareAccelFixup.java
@@ -1,0 +1,68 @@
+package com.android.settings.development;
+
+import android.content.Context;
+import android.os.Build;
+import android.provider.Settings;
+import android.util.Log;
+
+import java.io.File;
+import java.io.IOException;
+
+public final class TetheringHardwareAccelFixup {
+    private static final String TAG = "TetheringHardwareAccelFixup";
+
+    private static final String MARKER_FILE_NAME = "tethering_hardware_accel_fixed_up";
+
+    private TetheringHardwareAccelFixup() {
+    }
+
+    public static void run(Context context) {
+        try {
+            runInner(context);
+        } catch (Throwable e) {
+            Log.e(TAG, "unable to fix up tethering hardware acceleration setting", e);
+        }
+    }
+
+    private static void runInner(Context context) throws IOException {
+        final File markerFile = getMarkerFile(context);
+        if (markerFile.isFile()) {
+            return;
+        }
+
+        final boolean developmentSettingsEnabled = Settings.Global.getInt(
+                context.getContentResolver(),
+                Settings.Global.DEVELOPMENT_SETTINGS_ENABLED,
+                Build.TYPE.equals("eng") ? 1 : 0) != 0;
+        if (developmentSettingsEnabled) {
+            return;
+        }
+
+        // The setting stores the disabled state, so 0/null means tether offload is enabled.
+        final int rowsDeleted = context.getContentResolver().delete(
+                Settings.Global.getUriFor(Settings.Global.TETHER_OFFLOAD_DISABLED),
+                null,
+                null);
+        if (rowsDeleted == 1) {
+            Log.i(TAG, "erased tether offload setting while developer options are disabled");
+        } else {
+            final String currentValue = Settings.Global.getString(context.getContentResolver(),
+                    Settings.Global.TETHER_OFFLOAD_DISABLED);
+            if (currentValue != null) {
+                Log.w(TAG, "unable to erase tether offload setting, rows deleted: "
+                        + rowsDeleted + ", current value: " + currentValue);
+                return;
+            }
+            Log.i(TAG, "tether offload setting is already absent, rows deleted: "
+                    + rowsDeleted + ", current value: " + currentValue);
+        }
+
+        if (!markerFile.createNewFile()) {
+            Log.w(TAG, "markerFile.createNewFile() returned false");
+        }
+    }
+
+    static File getMarkerFile(Context context) {
+        return new File(context.getFilesDir(), MARKER_FILE_NAME);
+    }
+}

--- a/tests/robotests/src/com/android/settings/development/TetheringHardwareAccelFixupTest.java
+++ b/tests/robotests/src/com/android/settings/development/TetheringHardwareAccelFixupTest.java
@@ -1,0 +1,109 @@
+package com.android.settings.development;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import android.content.Context;
+import android.provider.Settings;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+
+import java.io.File;
+
+@RunWith(RobolectricTestRunner.class)
+public class TetheringHardwareAccelFixupTest {
+    private Context mContext;
+
+    @Before
+    public void setUp() {
+        mContext = RuntimeEnvironment.application;
+        clearState();
+    }
+
+    @After
+    public void tearDown() {
+        clearState();
+    }
+
+    @Test
+    public void run_devOptionsDisabledAndTetherOffloadDisabled_erasesSetting() {
+        Settings.Global.putInt(mContext.getContentResolver(),
+                Settings.Global.DEVELOPMENT_SETTINGS_ENABLED, 0);
+        Settings.Global.putInt(mContext.getContentResolver(),
+                Settings.Global.TETHER_OFFLOAD_DISABLED,
+                TetheringHardwareAccelPreferenceController.SETTING_VALUE_OFF);
+
+        TetheringHardwareAccelFixup.run(mContext);
+
+        assertThat(getTetherOffloadDisabledValue()).isNull();
+        assertThat(TetheringHardwareAccelFixup.getMarkerFile(mContext).isFile()).isTrue();
+    }
+
+    @Test
+    public void run_devOptionsDisabledAndTetherOffloadEnabled_erasesSetting() {
+        Settings.Global.putInt(mContext.getContentResolver(),
+                Settings.Global.DEVELOPMENT_SETTINGS_ENABLED, 0);
+        Settings.Global.putInt(mContext.getContentResolver(),
+                Settings.Global.TETHER_OFFLOAD_DISABLED,
+                TetheringHardwareAccelPreferenceController.SETTING_VALUE_ON);
+
+        TetheringHardwareAccelFixup.run(mContext);
+
+        assertThat(getTetherOffloadDisabledValue()).isNull();
+        assertThat(TetheringHardwareAccelFixup.getMarkerFile(mContext).isFile()).isTrue();
+    }
+
+    @Test
+    public void run_devOptionsEnabledAndTetherOffloadDisabled_keepsSetting() {
+        Settings.Global.putInt(mContext.getContentResolver(),
+                Settings.Global.DEVELOPMENT_SETTINGS_ENABLED, 1);
+        Settings.Global.putInt(mContext.getContentResolver(),
+                Settings.Global.TETHER_OFFLOAD_DISABLED,
+                TetheringHardwareAccelPreferenceController.SETTING_VALUE_OFF);
+
+        TetheringHardwareAccelFixup.run(mContext);
+
+        assertThat(getTetherOffloadDisabled()).isEqualTo(
+                TetheringHardwareAccelPreferenceController.SETTING_VALUE_OFF);
+        assertThat(TetheringHardwareAccelFixup.getMarkerFile(mContext).isFile()).isFalse();
+    }
+
+    @Test
+    public void run_markerExists_doesNotChangeSetting() throws Exception {
+        File markerFile = TetheringHardwareAccelFixup.getMarkerFile(mContext);
+        assertThat(markerFile.createNewFile()).isTrue();
+        Settings.Global.putInt(mContext.getContentResolver(),
+                Settings.Global.DEVELOPMENT_SETTINGS_ENABLED, 0);
+        Settings.Global.putInt(mContext.getContentResolver(),
+                Settings.Global.TETHER_OFFLOAD_DISABLED,
+                TetheringHardwareAccelPreferenceController.SETTING_VALUE_OFF);
+
+        TetheringHardwareAccelFixup.run(mContext);
+
+        assertThat(getTetherOffloadDisabled()).isEqualTo(
+                TetheringHardwareAccelPreferenceController.SETTING_VALUE_OFF);
+    }
+
+    private int getTetherOffloadDisabled() {
+        return Settings.Global.getInt(mContext.getContentResolver(),
+                Settings.Global.TETHER_OFFLOAD_DISABLED,
+                TetheringHardwareAccelPreferenceController.SETTING_VALUE_ON);
+    }
+
+    private String getTetherOffloadDisabledValue() {
+        return Settings.Global.getString(mContext.getContentResolver(),
+                Settings.Global.TETHER_OFFLOAD_DISABLED);
+    }
+
+    private void clearState() {
+        Settings.Global.putString(mContext.getContentResolver(),
+                Settings.Global.DEVELOPMENT_SETTINGS_ENABLED, null);
+        Settings.Global.putString(mContext.getContentResolver(),
+                Settings.Global.TETHER_OFFLOAD_DISABLED, null);
+        TetheringHardwareAccelFixup.getMarkerFile(mContext).delete();
+    }
+}


### PR DESCRIPTION
See https://github.com/GrapheneOS/os-issue-tracker/issues/7939

Prior to the previous commit, users that have enabled then disabled developer options would have the tethering accleration disabled even though it's supposed to default to enabled. Re-enable it for them if developer options are off.

Test: atest SettingsRoboTests:com.android.settings.development.TetheringHardwareAccelFixupTest