### PR TITLE
show night light settings even if Pixel Comfort View config set

### DIFF
--- a/src/com/android/settings/display/NightDisplayExtensions.kt
+++ b/src/com/android/settings/display/NightDisplayExtensions.kt
@@ -27,10 +27,7 @@ val Context.isNightDisplaySettingsAvailable: Boolean
 val Context.nightDisplayAvailabilityStatus: Int
     get() {
         val nightDisplayAvailable =
-            ColorDisplayManager.isNightDisplayAvailable(this) &&
-                !resources.getBoolean(
-                    NightDisplayConstants.NIGHT_DISPLAY_SETTINGS_PAGE_BLOCKER_RES_ID
-                )
+            ColorDisplayManager.isNightDisplayAvailable(this)
         return if (nightDisplayAvailable) {
             try {
                 // These settings are not available if shown on an external display.

--- a/tests/robotests/src/com/android/settings/display/NightDisplayActivationPreferenceControllerTest.java
+++ b/tests/robotests/src/com/android/settings/display/NightDisplayActivationPreferenceControllerTest.java
@@ -96,6 +96,7 @@ public class NightDisplayActivationPreferenceControllerTest {
     }
 
     @Test
+    @org.junit.Ignore("Night Light settings are intentionally available when config_cv_available is true.")
     public void configuredNightDisplayAvailableAndBlocked_isUnavailable() {
         NightDisplayTestUtils.setNightDisplayAvailable(true);
         NightDisplayTestUtils.setNightDisplaySettingsBlocked(true);

--- a/tests/robotests/src/com/android/settings/display/NightDisplayApiScreenTest.kt
+++ b/tests/robotests/src/com/android/settings/display/NightDisplayApiScreenTest.kt
@@ -101,6 +101,7 @@ class NightDisplayApiScreenTest {
     }
 
     @Test
+    @org.junit.Ignore("Night Light settings are intentionally available when config_cv_available is true.")
     fun getLaunchIntent_nightDisplaySettingsBlocked_fails() {
         NightDisplayTestUtils.setNightDisplaySettingsBlocked(true)
         val failure = assertFailsWith<HardwareUnsupportedException> { tester.getLaunchIntent() }

--- a/tests/robotests/src/com/android/settings/display/NightDisplayAutoModePreferenceControllerTest.java
+++ b/tests/robotests/src/com/android/settings/display/NightDisplayAutoModePreferenceControllerTest.java
@@ -88,6 +88,7 @@ public class NightDisplayAutoModePreferenceControllerTest {
     }
 
     @Test
+    @org.junit.Ignore("Night Light settings are intentionally available when config_cv_available is true.")
     public void configuredNightDisplayAvailableAndBlocked_isUnavailable() {
         NightDisplayTestUtils.setNightDisplayAvailable(true);
         NightDisplayTestUtils.setNightDisplaySettingsBlocked(true);

--- a/tests/robotests/src/com/android/settings/display/NightDisplayCustomEndTimePreferenceControllerTest.java
+++ b/tests/robotests/src/com/android/settings/display/NightDisplayCustomEndTimePreferenceControllerTest.java
@@ -77,6 +77,7 @@ public class NightDisplayCustomEndTimePreferenceControllerTest {
     }
 
     @Test
+    @org.junit.Ignore("Night Light settings are intentionally available when config_cv_available is true.")
     public void configuredNightDisplayAvailableAndBlocked_isUnavailable() {
         NightDisplayTestUtils.setNightDisplayAvailable(true);
         NightDisplayTestUtils.setNightDisplaySettingsBlocked(true);

--- a/tests/robotests/src/com/android/settings/display/NightDisplayCustomStartTimePreferenceControllerTest.java
+++ b/tests/robotests/src/com/android/settings/display/NightDisplayCustomStartTimePreferenceControllerTest.java
@@ -77,6 +77,7 @@ public class NightDisplayCustomStartTimePreferenceControllerTest {
     }
 
     @Test
+    @org.junit.Ignore("Night Light settings are intentionally available when config_cv_available is true.")
     public void configuredNightDisplayAvailableAndBlocked_isUnavailable() {
         NightDisplayTestUtils.setNightDisplayAvailable(true);
         NightDisplayTestUtils.setNightDisplaySettingsBlocked(true);

--- a/tests/robotests/src/com/android/settings/display/NightDisplayIntensityPreferenceControllerTest.java
+++ b/tests/robotests/src/com/android/settings/display/NightDisplayIntensityPreferenceControllerTest.java
@@ -93,6 +93,7 @@ public class NightDisplayIntensityPreferenceControllerTest {
     }
 
     @Test
+    @org.junit.Ignore("Night Light settings are intentionally available when config_cv_available is true.")
     public void configuredNightDisplayAvailableAndBlocked_isUnavailable() {
         NightDisplayTestUtils.setNightDisplayAvailable(true);
         NightDisplayTestUtils.setNightDisplaySettingsBlocked(true);

--- a/tests/robotests/src/com/android/settings/display/NightDisplayPreferenceControllerTest.java
+++ b/tests/robotests/src/com/android/settings/display/NightDisplayPreferenceControllerTest.java
@@ -96,6 +96,7 @@ public class NightDisplayPreferenceControllerTest {
     }
 
     @Test
+    @org.junit.Ignore("Night Light settings are intentionally available when config_cv_available is true.")
     public void configuredNightDisplayAvailableAndBlocked_returnUnsupportedOnDevice() {
         NightDisplayTestUtils.setNightDisplayAvailable(true);
         NightDisplayTestUtils.setNightDisplaySettingsBlocked(true);

--- a/tests/robotests/src/com/android/settings/display/NightDisplayScreenTest.kt
+++ b/tests/robotests/src/com/android/settings/display/NightDisplayScreenTest.kt
@@ -93,6 +93,7 @@ class NightDisplayScreenTest {
     }
 
     @Test
+    @org.junit.Ignore("Night Light settings are intentionally available when config_cv_available is true.")
     fun configuredAvailableAndBlocked() {
         mockResources.stub {
             on { getBoolean(NightDisplayConstants.NIGHT_DISPLAY_AVAILABLE_RES_ID) } doReturn true

--- a/tests/robotests/src/com/android/settings/display/NightDisplayTopIntroPreferenceControllerTest.java
+++ b/tests/robotests/src/com/android/settings/display/NightDisplayTopIntroPreferenceControllerTest.java
@@ -77,6 +77,7 @@ public class NightDisplayTopIntroPreferenceControllerTest {
     }
 
     @Test
+    @org.junit.Ignore("Night Light settings are intentionally available when config_cv_available is true.")
     public void configuredNightDisplayAvailableAndBlocked_returnUnsupportedOnDevice() {
         NightDisplayTestUtils.setNightDisplayAvailable(true);
         NightDisplayTestUtils.setNightDisplaySettingsBlocked(true);


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/os-issue-tracker/issues/8024

In SettingsGoogle, the night light settings are just moved into the Comfort View screen.  There's no difference in between how night light backend is handed in the Pixel Comfort View screen and the night light settings in AOSP

Pixel Comfort View support itself requires res id fixes

Test: manual, on a Pixel with config_cv_available enable via overlays such as rango, night light settings + night light QS tile long press to open settings works