### PR TITLE
Add 10 hour as an option for auto-reboot feature

### DIFF
--- a/src/com/android/settings/security/AutoRebootPrefController.java
+++ b/src/com/android/settings/security/AutoRebootPrefController.java
@@ -34,6 +34,7 @@ public class AutoRebootPrefController extends IntSettingPrefController {
         entries.add(1, DAYS);
         entries.add(18, HOURS);
         entries.add(12, HOURS);
+        entries.add(10, HOURS);
         entries.add(8, HOURS);
         entries.add(4, HOURS);
         entries.add(2, HOURS);


### PR DESCRIPTION
10 hour option is a nice balance between convenience vs security when the user does not want the phone to reboot overnight but still maintain short auto-reboot timer.

Closes https://github.com/GrapheneOS/os-issue-tracker/issues/8473