### PR TITLE
secure paste: add clipboard access settings

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -6448,5 +6448,21 @@
                 android:value="@string/menu_key_apps"/>
         </activity>
 
+        <activity
+            android:name=".Settings$AppClipboardReadActivity"
+            android:exported="true">
+
+            <intent-filter>
+                <action android:name="android.settings.OPEN_APP_CLIPBOARD_READ_SETTINGS" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="package" />
+            </intent-filter>
+
+            <meta-data android:name="com.android.settings.FRAGMENT_CLASS"
+                android:value="com.android.settings.applications.AppClipboardReadFragment"/>
+            <meta-data android:name="com.android.settings.HIGHLIGHT_MENU_KEY"
+                android:value="@string/menu_key_apps"/>
+        </activity>
+
     </application>
 </manifest>

--- a/res/values/strings_ext.xml
+++ b/res/values/strings_ext.xml
@@ -340,4 +340,29 @@ May cause unreliable service. Use at your own risk.
     <string name="cert_transparency_dl_footer">"Certificate Transparency (CT) is an Internet standard designed to enhance the security of digital certificates. It requires Certificate Authorities (CAs) to submit all issued certificates to a public log that records them, increasing transparency and accountability in the certificate issuance process.
 
 By maintaining a verifiable record of all certificates, CT makes it significantly harder for malicious actors to forge certificates or for CAs to mistakenly issue them. This helps protect apps from man-in-the-middle attacks and other security threats."</string>
+    <string name="app_clipboard_read_title">Clipboard access</string>
+    <string name="app_clipboard_read_summary">Control how apps access the clipboard and whether access messages are shown</string>
+    <string name="app_clipboard_read_intro">Choose when apps can read clipboard items and whether to show a message when they do.</string>
+    <string name="app_clipboard_read_messages_category_title">Messages</string>
+    <string name="app_clipboard_read_app_access_category_title">App access</string>
+    <string name="app_default_clipboard_read_main_switch_title">Allow apps to read the clipboard</string>
+    <string name="app_default_clipboard_read_main_switch_summary">This setting applies to third-party apps across all users. When off, apps can read only items they copied or items you paste into them. Some apps may not work correctly.</string>
+    <string name="app_clipboard_read_apps_title">Manage app access</string>
+    <string name="app_clipboard_read_apps_summary">Choose which apps can read items copied by other apps without you using Paste</string>
+    <string name="app_default_clipboard_read_footer">"Apps can always read the current clipboard item if they copied it.
+
+For compatibility, apps can still see clipboard metadata, such as whether an item exists, its type, and when it was copied. Enabled accessibility services that can view and interact with screen content can initiate Paste actions and may access pasted content. Some apps and system features, including your default input method, can always read clipboard items regardless of these settings."</string>
+    <string name="app_clipboard_read_allowed">Allow</string>
+    <string name="app_clipboard_read_blocked">Paste only</string>
+    <string name="app_clipboard_read_dvr_default_setting">Follow system clipboard access setting</string>
+    <string name="app_clipboard_read_ir_is_system_app">This setting does not apply to system apps</string>
+    <string name="app_clipboard_read_ir_is_default_ime">Your default input method always has clipboard access</string>
+    <string name="app_clipboard_read_footer">"Warning: Using Paste only may cause this app to stop working. This setting controls whether the app can read clipboard items from other apps such as text, images, and links.
+
+When set to Allow, this app can read clipboard items while in use. When set to Paste only, it can read the current item if it copied it. It can read other items from other apps only when you use Paste.
+
+For compatibility, this app can still see clipboard metadata, such as whether an item exists, its type, and when it was copied. Enabled accessibility services that can view and interact with screen content can initiate Paste actions in this app and may access pasted content."</string>
+    <string name="app_clipboard_read_shared_uid_warning">"The clipboard access setting and temporary Paste access are shared among these apps:
+%1$s"</string>
+
 </resources>

--- a/res/values/strings_ext.xml
+++ b/res/values/strings_ext.xml
@@ -364,7 +364,7 @@ For compatibility, apps can still see clipboard metadata, such as whether an ite
 When set to Allow, this app can read clipboard items while in use. When set to Paste only, it can read the current item if it copied it. It can read other items from other apps only when you use Paste.
 
 For compatibility, this app can still see clipboard metadata, such as whether an item exists, its type, and when it was copied. Enabled accessibility services that can view and interact with screen content can initiate Paste actions in this app and may access pasted content."</string>
-    <string name="app_clipboard_read_shared_uid_warning">"The clipboard access setting and temporary Paste access are shared among these apps:
+    <string name="app_clipboard_read_shared_uid_warning">"The clipboard access setting, blocked access message setting, and temporary Paste access are shared among these apps:
 %1$s"</string>
 
 </resources>

--- a/res/values/strings_ext.xml
+++ b/res/values/strings_ext.xml
@@ -342,11 +342,13 @@ May cause unreliable service. Use at your own risk.
 By maintaining a verifiable record of all certificates, CT makes it significantly harder for malicious actors to forge certificates or for CAs to mistakenly issue them. This helps protect apps from man-in-the-middle attacks and other security threats."</string>
     <string name="app_clipboard_read_title">Clipboard access</string>
     <string name="app_clipboard_read_summary">Control how apps access the clipboard and whether access messages are shown</string>
-    <string name="app_clipboard_read_intro">Choose when apps can read clipboard items and whether to show a message when they do.</string>
+    <string name="app_clipboard_read_intro">Choose when apps can read clipboard items and whether to show messages when access succeeds or is blocked.</string>
     <string name="app_clipboard_read_messages_category_title">Messages</string>
     <string name="app_clipboard_read_app_access_category_title">App access</string>
     <string name="app_default_clipboard_read_main_switch_title">Allow apps to read the clipboard</string>
     <string name="app_default_clipboard_read_main_switch_summary">This setting applies to third-party apps across all users. When off, apps can read only items they copied or items you paste into them. Some apps may not work correctly.</string>
+    <string name="show_clip_access_denial_notification">Show when clipboard access is blocked</string>
+    <string name="show_clip_access_denial_notification_summary">Show a message when an app is prevented from reading clipboard content</string>
     <string name="app_clipboard_read_apps_title">Manage app access</string>
     <string name="app_clipboard_read_apps_summary">Choose which apps can read items copied by other apps without you using Paste</string>
     <string name="app_default_clipboard_read_footer">"Apps can always read the current clipboard item if they copied it.

--- a/res/xml/app_clipboard_access.xml
+++ b/res/xml/app_clipboard_access.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:settings="http://schemas.android.com/apk/res-auto"
+    android:title="@string/app_clipboard_read_title">
+
+    <com.android.settingslib.widget.TopIntroPreference
+        android:title="@string/app_clipboard_read_intro"
+        settings:searchable="false" />
+
+    <PreferenceCategory
+        android:key="clipboard_access_messages"
+        android:title="@string/app_clipboard_read_messages_category_title">
+
+        <SwitchPreferenceCompat
+            android:key="show_clip_access_notification"
+            android:title="@string/show_clip_access_notification"
+            android:summary="@string/show_clip_access_notification_summary"
+            settings:controller=
+                "com.android.settings.privacy.ShowClipAccessNotificationPreferenceController" />
+
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:key="clipboard_app_access"
+        android:title="@string/app_clipboard_read_app_access_category_title">
+
+        <SwitchPreferenceCompat
+            android:key="app_default_clipboard_read"
+            android:title="@string/app_default_clipboard_read_main_switch_title"
+            android:summary="@string/app_default_clipboard_read_main_switch_summary"
+            settings:boolSettingField=
+                "android.ext.settings.ExtSettings ALLOW_CLIPBOARD_READ_BY_DEFAULT" />
+
+        <Preference
+            android:key="app_clipboard_read_app_list"
+            android:title="@string/app_clipboard_read_apps_title"
+            android:summary="@string/app_clipboard_read_apps_summary"
+            settings:controller=
+                "com.android.settings.applications.ClipboardReadAppListPrefController" />
+
+    </PreferenceCategory>
+
+    <com.android.settingslib.widget.FooterPreference
+        android:key="app_clipboard_read_footer"
+        android:title="@string/app_default_clipboard_read_footer"
+        settings:searchable="false" />
+
+</PreferenceScreen>

--- a/res/xml/app_clipboard_access.xml
+++ b/res/xml/app_clipboard_access.xml
@@ -19,13 +19,6 @@
             settings:controller=
                 "com.android.settings.privacy.ShowClipAccessNotificationPreferenceController" />
 
-        <SwitchPreferenceCompat
-            android:key="show_clip_access_denial_notification"
-            android:title="@string/show_clip_access_denial_notification"
-            android:summary="@string/show_clip_access_denial_notification_summary"
-            settings:boolSettingField=
-                "android.ext.settings.ExtSettings SHOW_CLIPBOARD_ACCESS_DENIAL_NOTIFICATIONS" />
-
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/res/xml/app_clipboard_access.xml
+++ b/res/xml/app_clipboard_access.xml
@@ -19,6 +19,13 @@
             settings:controller=
                 "com.android.settings.privacy.ShowClipAccessNotificationPreferenceController" />
 
+        <SwitchPreferenceCompat
+            android:key="show_clip_access_denial_notification"
+            android:title="@string/show_clip_access_denial_notification"
+            android:summary="@string/show_clip_access_denial_notification_summary"
+            settings:boolSettingField=
+                "android.ext.settings.ExtSettings SHOW_CLIPBOARD_ACCESS_DENIAL_NOTIFICATIONS" />
+
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/res/xml/privacy_controls_settings.xml
+++ b/res/xml/privacy_controls_settings.xml
@@ -34,11 +34,10 @@
         android:summary="@string/mic_toggle_description"
         settings:controller="com.android.settings.privacy.MicToggleController"/>
 
-    <!-- Clipboard access notifications -->
-    <SwitchPreferenceCompat
-        android:key="show_clip_access_notification"
-        android:title="@string/show_clip_access_notification"
-        android:summary="@string/show_clip_access_notification_summary"
-        settings:controller="com.android.settings.privacy.ShowClipAccessNotificationPreferenceController"/>
+    <Preference
+        android:key="app_clipboard_read"
+        android:title="@string/app_clipboard_read_title"
+        android:summary="@string/app_clipboard_read_summary"
+        android:fragment="com.android.settings.applications.ClipboardAccessFragment" />
 
 </PreferenceScreen>

--- a/res/xml/privacy_dashboard_settings.xml
+++ b/res/xml/privacy_dashboard_settings.xml
@@ -167,11 +167,10 @@
         android:summary="@string/content_capture_summary"
         settings:controller="com.android.settings.privacy.EnableContentCaptureWithServiceSettingsPreferenceController"/>
 
-    <!-- Clipboard access notifications -->
-    <SwitchPreferenceCompat
-        android:key="show_clip_access_notification"
-        android:title="@string/show_clip_access_notification"
-        android:summary="@string/show_clip_access_notification_summary"
-        settings:controller="com.android.settings.privacy.ShowClipAccessNotificationPreferenceController"/>
+    <Preference
+        android:key="app_clipboard_read"
+        android:title="@string/app_clipboard_read_title"
+        android:summary="@string/app_clipboard_read_summary"
+        android:fragment="com.android.settings.applications.ClipboardAccessFragment" />
 
 </PreferenceScreen>

--- a/res/xml/safety_center_privacy_controls_settings.xml
+++ b/res/xml/safety_center_privacy_controls_settings.xml
@@ -78,12 +78,11 @@
             settings:controller="com.android.settings.privacy.MicToggleController"
             android:order="50" />
 
-        <!-- Clipboard access notifications -->
-        <SwitchPreferenceCompat
-            android:key="show_clip_access_notification"
-            android:title="@string/show_clip_access_notification"
-            android:summary="@string/show_clip_access_notification_summary"
-            settings:controller="com.android.settings.privacy.ShowClipAccessNotificationPreferenceController"
+        <Preference
+            android:key="app_clipboard_read"
+            android:title="@string/app_clipboard_read_title"
+            android:summary="@string/app_clipboard_read_summary"
+            android:fragment="com.android.settings.applications.ClipboardAccessFragment"
             android:order="60" />
 
         <!-- Show passwords -->

--- a/src/com/android/settings/Settings.java
+++ b/src/com/android/settings/Settings.java
@@ -698,6 +698,8 @@ public class Settings extends SettingsActivity {
 
     public static class AppManagePlayIntegrityApiActivity extends SettingsActivity {}
 
+    public static class AppClipboardReadActivity extends SettingsActivity {}
+
     public static class ExploitProtectionActivity extends SettingsActivity {}
 
     public static class NotificationBundlesActivity extends SettingsActivity { /* empty */ }

--- a/src/com/android/settings/applications/AppClipboardRead.kt
+++ b/src/com/android/settings/applications/AppClipboardRead.kt
@@ -1,0 +1,98 @@
+package com.android.settings.applications
+
+import android.app.settings.SettingsEnums
+import android.content.Context
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageManager
+import android.ext.settings.app.AppSwitch
+import android.ext.settings.app.AswAllowClipboardRead
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import com.android.settings.R
+import com.android.settings.dashboard.DashboardFragment
+import com.android.settings.search.BaseSearchIndexProvider
+import com.android.settings.spa.app.appinfo.AswPreference
+import com.android.settingslib.search.SearchIndexable
+import com.android.settingslib.widget.FooterPreference
+
+object AswAdapterClipboardRead : AswAdapter<AswAllowClipboardRead>() {
+
+    override fun getAppSwitch() = AswAllowClipboardRead.I
+
+    override fun getAswTitle(ctx: Context) = ctx.getText(R.string.app_clipboard_read_title)
+    override fun getOnTitle(ctx: Context) = ctx.getText(R.string.app_clipboard_read_allowed)
+    override fun getOffTitle(ctx: Context) = ctx.getText(R.string.app_clipboard_read_blocked)
+
+    override fun getDetailFragmentClass() = AppClipboardReadFragment::class
+}
+
+@Composable
+fun AppClipboardReadPreference(app: ApplicationInfo) {
+    AswPreference(LocalContext.current, app, AswAdapterClipboardRead)
+}
+
+class AppClipboardReadFragment : AswAppInfoFragment<AswAllowClipboardRead>() {
+
+    override fun getAswAdapter() = AswAdapterClipboardRead
+
+    override fun shouldKillUidAfterChange() = false
+
+    override fun getSummaryForDefaultValueReason(dvr: Int): CharSequence? {
+        val id = when (dvr) {
+            AppSwitch.DVR_DEFAULT_SETTING -> R.string.app_clipboard_read_dvr_default_setting
+            else -> return null
+        }
+        return getText(id)
+    }
+
+    override fun getSummaryForImmutabilityReason(ir: Int): CharSequence? {
+        val id = when (ir) {
+            AppSwitch.IR_IS_SYSTEM_APP -> R.string.app_clipboard_read_ir_is_system_app
+            AppSwitch.IR_IS_DEFAULT_IME -> R.string.app_clipboard_read_ir_is_default_ime
+            else -> return null
+        }
+        return getText(id)
+    }
+
+    override fun updateFooter(fp: FooterPreference) {
+        val footer = getText(R.string.app_clipboard_read_footer)
+        val packageManager = requireContext().packageManager
+        val uidPackages = packageManager.getPackagesForUid(getAppInfo().uid) ?: emptyArray()
+        if (uidPackages.size < 2) {
+            fp.title = footer
+            return
+        }
+
+        val packageList = uidPackages.joinToString("\n") { packageName ->
+            val label = try {
+                packageManager.getApplicationInfoAsUser(packageName, 0, mUserId)
+                    .loadLabel(packageManager)
+            } catch (_: PackageManager.NameNotFoundException) {
+                packageName
+            }
+            "• $label"
+        }
+        fp.title = footer.toString() + "\n\n" +
+            getString(R.string.app_clipboard_read_shared_uid_warning, packageList)
+    }
+}
+
+@SearchIndexable
+class ClipboardAccessFragment : DashboardFragment() {
+    override fun getPreferenceScreenResId() = R.xml.app_clipboard_access
+
+    override fun getMetricsCategory() = SettingsEnums.PAGE_UNKNOWN
+
+    override fun getLogTag() = "ClipboardAccess"
+
+    companion object {
+        @JvmField
+        val SEARCH_INDEX_DATA_PROVIDER = BaseSearchIndexProvider(R.xml.app_clipboard_access)
+    }
+}
+
+class ClipboardReadAppListPrefController(context: Context, preferenceKey: String) :
+    AswAppListPrefController(context, preferenceKey, AswAdapterClipboardRead) {
+
+    override fun getAvailabilityStatus() = AVAILABLE
+}

--- a/src/com/android/settings/applications/AppClipboardRead.kt
+++ b/src/com/android/settings/applications/AppClipboardRead.kt
@@ -23,6 +23,12 @@ object AswAdapterClipboardRead : AswAdapter<AswAllowClipboardRead>() {
     override fun getOnTitle(ctx: Context) = ctx.getText(R.string.app_clipboard_read_allowed)
     override fun getOffTitle(ctx: Context) = ctx.getText(R.string.app_clipboard_read_blocked)
 
+    override fun getNotificationToggleTitle(ctx: Context) =
+        ctx.getText(R.string.show_clip_access_denial_notification)
+    override fun getNotificationToggleSummary(ctx: Context) =
+        ctx.getText(R.string.show_clip_access_denial_notification_summary)
+    override fun isNotificationToggleEnabled(appSwitchState: Boolean) = !appSwitchState
+
     override fun getDetailFragmentClass() = AppClipboardReadFragment::class
 }
 

--- a/src/com/android/settings/applications/AswAdapter.kt
+++ b/src/com/android/settings/applications/AswAdapter.kt
@@ -39,6 +39,7 @@ abstract class AswAdapter<T : AppSwitch> {
 
     open fun getNotificationToggleTitle(ctx: Context): CharSequence? = null
     open fun getNotificationToggleSummary(ctx: Context): CharSequence? = null
+    open fun isNotificationToggleEnabled(appSwitchState: Boolean) = appSwitchState
 
     abstract fun getAswTitle(ctx: Context): CharSequence
 

--- a/src/com/android/settings/applications/AswAppInfoFragment.java
+++ b/src/com/android/settings/applications/AswAppInfoFragment.java
@@ -139,7 +139,7 @@ public abstract class AswAppInfoFragment<T extends AppSwitch>
 
         if (notifTogglePref != null) {
             notifTogglePref.isChecked = adapter.getAppSwitch().isNotificationEnabled(ps);
-            notifTogglePref.isEnabled = state;
+            notifTogglePref.isEnabled = adapter.isNotificationToggleEnabled(state);
         }
 
         return new Entry[] { def, enabled, disabled };

--- a/src/com/android/settings/core/gateway/SettingsGateway.java
+++ b/src/com/android/settings/core/gateway/SettingsGateway.java
@@ -237,6 +237,7 @@ public class SettingsGateway {
             com.android.settings.applications.AppStorageDynCodeLoadingFragment.class.getName(),
             com.android.settings.applications.AppManagePlayIntegrityApiFragment.class.getName(),
             com.android.settings.applications.AppExecSpawningFragment.class.getName(),
+            com.android.settings.applications.AppClipboardReadFragment.class.getName(),
             com.android.settings.safetycenter.ExploitProtectionFragment.class.getName(),
             AdvancedConnectedDeviceDashboardFragment.class.getName(),
             CreateShortcut.class.getName(),

--- a/src/com/android/settings/privacy/PrivacyControlsFragment.java
+++ b/src/com/android/settings/privacy/PrivacyControlsFragment.java
@@ -39,7 +39,6 @@ public class PrivacyControlsFragment extends DashboardFragment {
         final List<AbstractPreferenceController> controllers = new ArrayList<>();
         controllers.add(new CameraToggleController(context, CAMERA_KEY));
         controllers.add(new MicToggleController(context, MIC_KEY));
-        controllers.add(new ShowClipAccessNotificationPreferenceController(context));
         return controllers;
     }
 

--- a/src/com/android/settings/safetycenter/ui/PrivacyControlsScreenApi.kt
+++ b/src/com/android/settings/safetycenter/ui/PrivacyControlsScreenApi.kt
@@ -43,6 +43,8 @@ class PrivacyControlsScreenApi :
         subpageRegistryKey = SafetyCenterSubpageRegistry.PRIVACY_CONTROLS_SUBPAGE_KEY,
     ) {
 
+    override fun hasCompleteHierarchy() = false
+
     init {
         // Camera Access toggle
         preference(

--- a/src/com/android/settings/spa/SettingsSpaEnvironment.kt
+++ b/src/com/android/settings/spa/SettingsSpaEnvironment.kt
@@ -156,6 +156,7 @@ open class SettingsSpaEnvironment(context: Context) : SpaEnvironment(context) {
                     com.android.settings.applications.AswAdapterStorageDynCodeLoading.makeAppListPageProvider(),
                     com.android.settings.applications.AswAdapterManagePlayIntegrityApi.makeAppListPageProvider(),
                     com.android.settings.applications.AswAdapterUseExecSpawning.makeAppListPageProvider(),
+                    com.android.settings.applications.AswAdapterClipboardRead.makeAppListPageProvider(),
                     com.android.settings.network.telephony.carriersettingsoverride.CarrierSettingsOverridesProvider,
                 )
             )

--- a/src/com/android/settings/spa/app/appinfo/AppInfoSettings.kt
+++ b/src/com/android/settings/spa/app/appinfo/AppInfoSettings.kt
@@ -210,6 +210,7 @@ private fun AppInfoSettings(packageInfoPresenter: PackageInfoPresenter) {
 
         Category(title = stringResource(R.string.advanced_apps)) {
             com.android.settings.applications.AppManagePlayIntegrityApiPreference(app)
+            com.android.settings.applications.AppClipboardReadPreference(app)
             if (android.companion.virtualdevice.flags.Flags.computerControlAccess()) {
                 ComputerControlAutomationAppListProvider.InfoPageEntryItem(app)
             }


### PR DESCRIPTION
Add a Clipboard access page for choosing whether third-party apps can read items copied by other app
identities without an explicit Paste action. Apps can still read the current clipboard item when it
was copied by their own app identity. The device owner controls the default, while each user can
manage individual apps

Open the page from Settings > Security & privacy > Privacy controls > Clipboard access. For an
individual app, long-press its launcher icon and choose App info > Clipboard access