### PR TITLE
Settings: add airplane mode disable authentication

### DIFF
--- a/res/values/preference_purposes.xml
+++ b/res/values/preference_purposes.xml
@@ -71,6 +71,7 @@
     <string name="adaptive_connectivity_purpose" translatable="false">Allows users to manage adaptive connectivity features, such as automatically switching between Wi-Fi and mobile networks to ensure connection stability or optimize battery life.</string>
     <string name="adaptive_connectivity_mobile_network_enabled_purpose" translatable="false">Whether to automatically select the best network connection to extend battery life.</string>
     <string name="adaptive_connectivity_wifi_enabled_purpose" translatable="false">Whether to automatically switch to the mobile network when the Wi-Fi connection is poor or unavailable.</string>
+    <string name="airplane_mode_authentication_purpose" translatable="false">Whether fresh system authentication is required before airplane mode can be turned off.</string>
     <string name="airplane_mode_footer_purpose" translatable="false">airplane_mode_footer</string>
     <string name="airplane_mode_settings_airplane_mode_on_purpose" translatable="false">Whether or not airplane mode is currently enabled, which disables wireless communications.</string>
     <string name="airplane_mode_settings_purpose" translatable="false">Describes the page within settings where Airplane Mode can be toggled and related options can be configured.</string>

--- a/res/values/strings_ext.xml
+++ b/res/values/strings_ext.xml
@@ -40,6 +40,10 @@
 
     <string name="keyguard_camera_title">Allow camera access when locked</string>
 
+    <string name="airplane_mode_authentication_title">Confirm turning off airplane mode</string>
+    <string name="airplane_mode_authentication_setting_title">Require authentication to turn off airplane mode</string>
+    <string name="airplane_mode_authentication_summary">Use the system authentication prompt before turning off airplane mode</string>
+
     <string name="auto_reboot_title">Auto reboot</string>
     <string name="auto_reboot_footer">Automatically reboot the device if it hasn\'t been unlocked within the selected duration of time.</string>
 

--- a/res/xml/network_provider_internet.xml
+++ b/res/xml/network_provider_internet.xml
@@ -72,6 +72,14 @@
         settings:controller="com.android.settings.network.AirplaneModePreferenceController"
         settings:userRestriction="no_airplane_mode"/>
 
+    <com.android.settingslib.RestrictedSwitchPreference
+        android:key="require_authentication_to_disable_airplane_mode"
+        android:title="@string/airplane_mode_authentication_setting_title"
+        android:summary="@string/airplane_mode_authentication_summary"
+        android:order="-4"
+        settings:controller="com.android.settings.network.AirplaneModeAuthenticationPreferenceController"
+        settings:userRestriction="no_airplane_mode"/>
+
     <com.android.settingslib.RestrictedPreference
         android:fragment="com.android.settings.network.tether.TetherSettings"
         android:key="tether_settings"

--- a/src/com/android/settings/network/AirplaneModeAuthenticationHelper.kt
+++ b/src/com/android/settings/network/AirplaneModeAuthenticationHelper.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.network
+
+import android.app.KeyguardManager
+import android.content.Context
+import android.hardware.biometrics.BiometricManager.Authenticators.BIOMETRIC_STRONG
+import android.hardware.biometrics.BiometricManager.Authenticators.DEVICE_CREDENTIAL
+import android.hardware.biometrics.BiometricPrompt
+import android.os.CancellationSignal
+import androidx.annotation.VisibleForTesting
+import com.android.settings.R
+import java.util.concurrent.Executor
+
+/** Runs an action only after a fresh system biometric or device-credential authentication. */
+open class AirplaneModeAuthenticationHelper
+@VisibleForTesting
+internal constructor(
+    private val context: Context,
+    private val keyguardManager: KeyguardManager,
+    private val executor: Executor,
+) {
+    constructor(context: Context) :
+        this(
+            context,
+            context.getSystemService(KeyguardManager::class.java),
+            context.mainExecutor,
+        )
+
+    private val lock = Any()
+    private var activeCancellationSignal: CancellationSignal? = null
+
+    @VisibleForTesting
+    internal var cancellationSignalFactory: () -> CancellationSignal = { CancellationSignal() }
+
+    @VisibleForTesting
+    internal var showPrompt:
+        (CancellationSignal, Executor, BiometricPrompt.AuthenticationCallback) -> Unit =
+        { cancellationSignal, callbackExecutor, callback ->
+            BiometricPrompt.Builder(context)
+                .setTitle(context.getString(R.string.airplane_mode_authentication_title))
+                .setAllowedAuthenticators(BIOMETRIC_STRONG or DEVICE_CREDENTIAL)
+                .setConfirmationRequired(true)
+                .build()
+                .authenticate(cancellationSignal, callbackExecutor, callback)
+        }
+
+    open fun runAfterAuthentication(action: Runnable) {
+        if (!keyguardManager.isDeviceSecure) {
+            action.run()
+            return
+        }
+
+        val cancellationSignal =
+            synchronized(lock) {
+                if (activeCancellationSignal != null) return
+                cancellationSignalFactory().also { activeCancellationSignal = it }
+            }
+        val callback =
+            object : BiometricPrompt.AuthenticationCallback() {
+                override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
+                    finish(cancellationSignal, action)
+                }
+
+                override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
+                    finish(cancellationSignal, null)
+                }
+            }
+
+        try {
+            showPrompt(cancellationSignal, executor, callback)
+        } catch (_: RuntimeException) {
+            finish(cancellationSignal, null)
+        }
+    }
+
+    open fun cancel() {
+        val cancellationSignal = synchronized(lock) { activeCancellationSignal }
+        cancellationSignal?.cancel()
+        finish(cancellationSignal, null)
+    }
+
+    private fun finish(cancellationSignal: CancellationSignal?, action: Runnable?) {
+        val shouldRun =
+            synchronized(lock) {
+                if (activeCancellationSignal !== cancellationSignal) return
+                activeCancellationSignal = null
+                action != null
+            }
+        if (shouldRun) action!!.run()
+    }
+}

--- a/src/com/android/settings/network/AirplaneModeAuthenticationPreference.kt
+++ b/src/com/android/settings/network/AirplaneModeAuthenticationPreference.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.android.settings.network
+
+import android.app.KeyguardManager
+import android.content.Context
+import android.ext.settings.ExtSettings
+import androidx.preference.Preference
+import com.android.settings.R
+import com.android.settingslib.datastore.KeyValueStore
+import com.android.settingslib.datastore.SettingsGlobalStore
+import com.android.settingslib.metadata.PreferenceAvailabilityProvider
+import com.android.settingslib.metadata.PreferenceLifecycleContext
+import com.android.settingslib.metadata.PreferenceLifecycleProvider
+import com.android.settingslib.metadata.PreferenceSummaryProvider
+import com.android.settingslib.metadata.ReadWritePermit
+import com.android.settingslib.metadata.SensitivityLevel
+import com.android.settingslib.metadata.SwitchPreference
+import com.android.settingslib.metadata.preferencesapi.preconditions.PreconditionStability
+import com.android.settingslib.preference.SwitchPreferenceBinding
+
+/** Catalyst metadata for the opt-in airplane-mode authentication requirement. */
+class AirplaneModeAuthenticationPreference :
+    SwitchPreference(
+        key = KEY,
+        purpose = R.string.airplane_mode_authentication_purpose,
+        title = R.string.airplane_mode_authentication_setting_title,
+    ),
+    SwitchPreferenceBinding,
+    PreferenceAvailabilityProvider,
+    PreferenceLifecycleProvider,
+    PreferenceSummaryProvider {
+
+    internal var authenticationHelper: AirplaneModeAuthenticationHelper? = null
+
+    internal var isDeviceSecure: (Context) -> Boolean = {
+        it.getSystemService(KeyguardManager::class.java).isDeviceSecure
+    }
+
+    internal var isAuthenticationRequired: (Context) -> Boolean = {
+        ExtSettings.REQUIRE_AUTHENTICATION_TO_DISABLE_AIRPLANE_MODE.get(it)
+    }
+
+    override fun storage(context: Context): KeyValueStore =
+        SettingsGlobalStore.get(context).apply { setDefaultValue(KEY, false) }
+
+    override fun getSummary(context: Context): CharSequence =
+        context.getText(R.string.airplane_mode_authentication_summary)
+
+    override val availabilityDescription = "The current user must have a secure screen lock."
+
+    override fun getAvailabilityStability() = PreconditionStability.UNSTABLE
+
+    override fun isAvailable(context: Context) = isDeviceSecure(context)
+
+    override fun getReadPermissions(context: Context) = SettingsGlobalStore.getReadPermissions()
+
+    override fun getWritePermissions(context: Context) = SettingsGlobalStore.getWritePermissions()
+
+    override fun getReadPermit(context: Context, callingPid: Int, callingUid: Int) =
+        ReadWritePermit.ALLOW
+
+    override fun getWritePermit(
+        context: Context,
+        value: Boolean?,
+        callingPid: Int,
+        callingUid: Int,
+    ) =
+        if (value != true && isAuthenticationRequired(context)) {
+            ReadWritePermit.DISALLOW
+        } else {
+            ReadWritePermit.ALLOW
+        }
+
+    override val sensitivityLevel
+        get() = SensitivityLevel.MUST_PROVIDE_UNDO
+
+    override fun onCreate(context: PreferenceLifecycleContext) {
+        context.requirePreference<Preference>(key).onPreferenceChangeListener =
+            Preference.OnPreferenceChangeListener { _, newValue ->
+                if (newValue == false && isAuthenticationRequired(context)) {
+                    getAuthenticationHelper(context).runAfterAuthentication {
+                        if (isAuthenticationRequired(context)) {
+                            storage(context).setBoolean(KEY, false)
+                        }
+                    }
+                    return@OnPreferenceChangeListener false
+                }
+                true
+            }
+    }
+
+    override fun onDestroy(context: PreferenceLifecycleContext) {
+        super.onDestroy(context)
+        authenticationHelper?.cancel()
+        authenticationHelper = null
+    }
+
+    private fun getAuthenticationHelper(context: Context): AirplaneModeAuthenticationHelper =
+        authenticationHelper ?: AirplaneModeAuthenticationHelper(context).also {
+            authenticationHelper = it
+        }
+
+    companion object {
+        val KEY: String = ExtSettings.REQUIRE_AUTHENTICATION_TO_DISABLE_AIRPLANE_MODE.key
+    }
+}

--- a/src/com/android/settings/network/AirplaneModeAuthenticationPreferenceController.java
+++ b/src/com/android/settings/network/AirplaneModeAuthenticationPreferenceController.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.network;
+
+import android.content.Context;
+import android.ext.settings.ExtSettings;
+
+import androidx.annotation.VisibleForTesting;
+
+import com.android.internal.widget.LockPatternUtils;
+import com.android.settings.core.BasePreferenceController;
+import com.android.settings.ext.BoolSettingPrefController;
+import com.android.settingslib.core.lifecycle.LifecycleObserver;
+import com.android.settingslib.core.lifecycle.events.OnDestroy;
+
+/** Controls the opt-in authentication requirement for disabling airplane mode. */
+public class AirplaneModeAuthenticationPreferenceController
+        extends BoolSettingPrefController implements LifecycleObserver, OnDestroy {
+    private final LockPatternUtils mLockPatternUtils;
+    private AirplaneModeAuthenticationHelper mAuthenticationHelper;
+
+    public AirplaneModeAuthenticationPreferenceController(Context context, String key) {
+        super(context, key, ExtSettings.REQUIRE_AUTHENTICATION_TO_DISABLE_AIRPLANE_MODE);
+        mLockPatternUtils = new LockPatternUtils(context);
+    }
+
+    @Override
+    public int getAvailabilityStatus() {
+        if (!mLockPatternUtils.isSecure(mContext.getUserId())) {
+            return BasePreferenceController.CONDITIONALLY_UNAVAILABLE;
+        }
+        return super.getAvailabilityStatus();
+    }
+
+    @Override
+    public boolean setChecked(boolean isChecked) {
+        if (!isChecked && isChecked()) {
+            getAuthenticationHelper().runAfterAuthentication(this::disableAfterAuthentication);
+            return false;
+        }
+        return super.setChecked(isChecked);
+    }
+
+    private void disableAfterAuthentication() {
+        if (isChecked()) {
+            super.setChecked(false);
+        }
+    }
+
+    private AirplaneModeAuthenticationHelper getAuthenticationHelper() {
+        if (mAuthenticationHelper == null) {
+            mAuthenticationHelper = new AirplaneModeAuthenticationHelper(mContext);
+        }
+        return mAuthenticationHelper;
+    }
+
+    @VisibleForTesting
+    void setAuthenticationHelper(AirplaneModeAuthenticationHelper authenticationHelper) {
+        mAuthenticationHelper = authenticationHelper;
+    }
+
+    @Override
+    public void onDestroy() {
+        if (mAuthenticationHelper != null) {
+            mAuthenticationHelper.cancel();
+        }
+    }
+}

--- a/src/com/android/settings/network/AirplaneModePreference.kt
+++ b/src/com/android/settings/network/AirplaneModePreference.kt
@@ -20,11 +20,13 @@ import android.app.Activity
 import android.app.settings.SettingsEnums.ACTION_AIRPLANE_TOGGLE
 import android.content.Context
 import android.content.Intent
+import android.ext.settings.ExtSettings
 import android.os.UserHandle
 import android.os.UserManager
 import android.provider.Settings
 import android.telephony.TelephonyManager
 import androidx.annotation.DrawableRes
+import androidx.annotation.VisibleForTesting
 import androidx.preference.Preference
 import com.android.settings.AirplaneModeEnabler
 import com.android.settings.R
@@ -59,6 +61,14 @@ open class AirplaneModePreference :
     PreferenceLifecycleProvider,
     PreferenceRestrictionMixin {
 
+    @VisibleForTesting
+    internal var authenticationHelper: AirplaneModeAuthenticationHelper? = null
+
+    @VisibleForTesting
+    internal var isAuthenticationRequired: (Context) -> Boolean = {
+        ExtSettings.REQUIRE_AUTHENTICATION_TO_DISABLE_AIRPLANE_MODE.get(it)
+    }
+
     override val icon: Int
         @DrawableRes get() = R.drawable.ic_airplanemode_active
 
@@ -86,8 +96,14 @@ open class AirplaneModePreference :
     override fun getReadPermit(context: Context, callingPid: Int, callingUid: Int) =
         ReadWritePermit.ALLOW
 
-    override fun getWritePermit(context: Context, callingPid: Int, callingUid: Int) =
+    override fun getWritePermit(
+        context: Context,
+        value: Boolean?,
+        callingPid: Int,
+        callingUid: Int,
+    ) =
         when {
+            value != true && isAuthenticationRequired(context) -> ReadWritePermit.DISALLOW
             isSatelliteOn(context) || isInEcmMode(context) -> ReadWritePermit.DISALLOW
             else -> ReadWritePermit.ALLOW
         }
@@ -102,7 +118,7 @@ open class AirplaneModePreference :
 
     override fun onCreate(context: PreferenceLifecycleContext) {
         context.requirePreference<Preference>(key).onPreferenceChangeListener =
-            Preference.OnPreferenceChangeListener { _: Preference, _: Any ->
+            Preference.OnPreferenceChangeListener { _: Preference, newValue: Any ->
                 if (isInEcmMode(context)) {
                     showEcmDialog(context)
                     return@OnPreferenceChangeListener false
@@ -111,9 +127,33 @@ open class AirplaneModePreference :
                     showSatelliteDialog(context)
                     return@OnPreferenceChangeListener false
                 }
+                if (newValue == false && isAuthenticationRequired(context)) {
+                    val store = context.getKeyValueStore(KEY)
+                        ?: return@OnPreferenceChangeListener false
+                    if (store.getBoolean(KEY) != true) {
+                        return@OnPreferenceChangeListener false
+                    }
+                    getAuthenticationHelper(context).runAfterAuthentication {
+                        if (store.getBoolean(KEY) == true) {
+                            store.setBoolean(KEY, false)
+                        }
+                    }
+                    return@OnPreferenceChangeListener false
+                }
                 return@OnPreferenceChangeListener true
             }
     }
+
+    override fun onDestroy(context: PreferenceLifecycleContext) {
+        super.onDestroy(context)
+        authenticationHelper?.cancel()
+        authenticationHelper = null
+    }
+
+    private fun getAuthenticationHelper(context: Context): AirplaneModeAuthenticationHelper =
+        authenticationHelper ?: AirplaneModeAuthenticationHelper(context).also {
+            authenticationHelper = it
+        }
 
     override fun onActivityResult(
         context: PreferenceLifecycleContext,

--- a/src/com/android/settings/network/AirplaneModePreferenceController.java
+++ b/src/com/android/settings/network/AirplaneModePreferenceController.java
@@ -24,6 +24,7 @@ import android.app.Activity;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
+import android.ext.settings.ExtSettings;
 import android.net.Uri;
 import android.provider.SettingsSlicesContract;
 import android.telephony.TelephonyManager;
@@ -71,6 +72,7 @@ public class AirplaneModePreferenceController extends TogglePreferenceController
 
     private Fragment mFragment;
     private AirplaneModeEnabler mAirplaneModeEnabler;
+    private AirplaneModeAuthenticationHelper mAuthenticationHelper;
     private TwoStatePreference mAirplaneModePreference;
     private SatelliteRepository mSatelliteRepository;
     @VisibleForTesting
@@ -91,6 +93,11 @@ public class AirplaneModePreferenceController extends TogglePreferenceController
     @VisibleForTesting
     void setAirplaneModeEnabler(AirplaneModeEnabler airplaneModeEnabler) {
         mAirplaneModeEnabler = airplaneModeEnabler;
+    }
+
+    @VisibleForTesting
+    void setAuthenticationHelper(AirplaneModeAuthenticationHelper authenticationHelper) {
+        mAuthenticationHelper = authenticationHelper;
     }
 
     @Override
@@ -181,6 +188,9 @@ public class AirplaneModePreferenceController extends TogglePreferenceController
 
     @Override
     public void onDestroy() {
+        if (mAuthenticationHelper != null) {
+            mAuthenticationHelper.cancel();
+        }
         if (isAvailable()) {
             mAirplaneModeEnabler.close();
         }
@@ -205,10 +215,26 @@ public class AirplaneModePreferenceController extends TogglePreferenceController
         if (isChecked() == isChecked || mIsSatelliteOn.get()) {
             return false;
         }
+        if (!isChecked
+                && ExtSettings.REQUIRE_AUTHENTICATION_TO_DISABLE_AIRPLANE_MODE.get(mContext)) {
+            getAuthenticationHelper().runAfterAuthentication(() -> {
+                if (isAvailable() && isChecked()) {
+                    mAirplaneModeEnabler.setAirplaneMode(false);
+                }
+            });
+            return false;
+        }
         if (isAvailable()) {
             mAirplaneModeEnabler.setAirplaneMode(isChecked);
         }
         return true;
+    }
+
+    private AirplaneModeAuthenticationHelper getAuthenticationHelper() {
+        if (mAuthenticationHelper == null) {
+            mAuthenticationHelper = new AirplaneModeAuthenticationHelper(mContext);
+        }
+        return mAuthenticationHelper;
     }
 
     @Override

--- a/src/com/android/settings/network/AirplaneModeSettingsScreen.kt
+++ b/src/com/android/settings/network/AirplaneModeSettingsScreen.kt
@@ -101,6 +101,7 @@ open class AirplaneModeSettingsScreen(context: Context) :
     }
 
     override fun onDestroy(context: PreferenceLifecycleContext) {
+        super.onDestroy(context)
         if (isEntryPoint(context)) {
             airplaneModeObserver?.let {
                 storage.removeObserver(AirplaneModePreference.KEY, it)

--- a/src/com/android/settings/network/NetworkDashboardScreen.kt
+++ b/src/com/android/settings/network/NetworkDashboardScreen.kt
@@ -79,6 +79,7 @@ open class NetworkDashboardScreen : PreferenceScreenMixin, PreferenceIconProvide
             } else {
                 +AirplaneModePreference() order -5
             }
+            +AirplaneModeAuthenticationPreference() order -4
             if (Flags.catalystRestrictBackgroundParentEntry()) +DataSaverScreen.KEY order 10
         }
 

--- a/tests/robotests/src/com/android/settings/network/AirplaneModeAuthenticationHelperTest.kt
+++ b/tests/robotests/src/com/android/settings/network/AirplaneModeAuthenticationHelperTest.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.network
+
+import android.app.Application
+import android.app.KeyguardManager
+import android.hardware.biometrics.BiometricPrompt
+import android.os.CancellationSignal
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import java.util.concurrent.Executor
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class AirplaneModeAuthenticationHelperTest {
+    private val context = ApplicationProvider.getApplicationContext<Application>()
+    private val keyguardManager = mock<KeyguardManager>()
+    private val executor = Executor { it.run() }
+    private lateinit var helper: AirplaneModeAuthenticationHelper
+    private var callback: BiometricPrompt.AuthenticationCallback? = null
+    private var promptCount = 0
+
+    @Before
+    fun setUp() {
+        helper = AirplaneModeAuthenticationHelper(context, keyguardManager, executor)
+        helper.showPrompt =
+            { _: CancellationSignal,
+              _: Executor,
+              authenticationCallback: BiometricPrompt.AuthenticationCallback ->
+                promptCount++
+                callback = authenticationCallback
+            }
+    }
+
+    @Test
+    fun runAfterAuthentication_noSecureLock_runsImmediately() {
+        whenever(keyguardManager.isDeviceSecure).thenReturn(false)
+        var actionRan = false
+
+        helper.runAfterAuthentication { actionRan = true }
+
+        assertThat(actionRan).isTrue()
+        assertThat(promptCount).isEqualTo(0)
+    }
+
+    @Test
+    fun runAfterAuthentication_secureLock_waitsForSuccessfulSystemAuthentication() {
+        whenever(keyguardManager.isDeviceSecure).thenReturn(true)
+        var actionRan = false
+
+        helper.runAfterAuthentication { actionRan = true }
+
+        assertThat(actionRan).isFalse()
+        assertThat(promptCount).isEqualTo(1)
+
+        callback!!.onAuthenticationSucceeded(mock())
+
+        assertThat(actionRan).isTrue()
+    }
+
+    @Test
+    fun runAfterAuthentication_errorDoesNotRunAction() {
+        whenever(keyguardManager.isDeviceSecure).thenReturn(true)
+        var actionRan = false
+
+        helper.runAfterAuthentication { actionRan = true }
+        callback!!.onAuthenticationError(1, "cancelled")
+
+        assertThat(actionRan).isFalse()
+    }
+
+    @Test
+    fun runAfterAuthentication_promptAlreadyShowing_ignoresSecondRequest() {
+        whenever(keyguardManager.isDeviceSecure).thenReturn(true)
+        var firstActionRan = false
+        var secondActionRan = false
+
+        helper.runAfterAuthentication { firstActionRan = true }
+        helper.runAfterAuthentication { secondActionRan = true }
+        callback!!.onAuthenticationSucceeded(mock())
+
+        assertThat(promptCount).isEqualTo(1)
+        assertThat(firstActionRan).isTrue()
+        assertThat(secondActionRan).isFalse()
+    }
+
+    @Test
+    fun cancel_cancelsActiveSystemPrompt() {
+        whenever(keyguardManager.isDeviceSecure).thenReturn(true)
+        val cancellationSignal = mock<CancellationSignal>()
+        helper.cancellationSignalFactory = { cancellationSignal }
+
+        helper.runAfterAuthentication {}
+        helper.cancel()
+
+        verify(cancellationSignal).cancel()
+    }
+
+    @Test
+    fun cancel_withoutActivePrompt_doesNothing() {
+        whenever(keyguardManager.isDeviceSecure).thenReturn(true)
+        val cancellationSignal = mock<CancellationSignal>()
+        helper.cancellationSignalFactory = { cancellationSignal }
+
+        helper.cancel()
+
+        verify(cancellationSignal, never()).cancel()
+    }
+}

--- a/tests/robotests/src/com/android/settings/network/AirplaneModeAuthenticationPreferenceTest.kt
+++ b/tests/robotests/src/com/android/settings/network/AirplaneModeAuthenticationPreferenceTest.kt
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.android.settings.network
+
+import android.app.Application
+import android.ext.settings.ExtSettings
+import androidx.preference.Preference
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.android.settings.R
+import com.android.settingslib.metadata.PreferenceLifecycleContext
+import com.android.settingslib.metadata.ReadWritePermit
+import com.google.common.truth.Truth.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+@RunWith(AndroidJUnit4::class)
+class AirplaneModeAuthenticationPreferenceTest {
+    private val context = ApplicationProvider.getApplicationContext<Application>()
+    private lateinit var preference: AirplaneModeAuthenticationPreference
+
+    @Before
+    fun setUp() {
+        ExtSettings.REQUIRE_AUTHENTICATION_TO_DISABLE_AIRPLANE_MODE.put(context, false)
+        preference = AirplaneModeAuthenticationPreference()
+    }
+
+    @After
+    fun tearDown() {
+        ExtSettings.REQUIRE_AUTHENTICATION_TO_DISABLE_AIRPLANE_MODE.put(context, false)
+    }
+
+    @Test
+    fun isAvailable_secureLockConfigured_returnsTrue() {
+        preference.isDeviceSecure = { true }
+
+        assertThat(preference.isAvailable(context)).isTrue()
+    }
+
+    @Test
+    fun isAvailable_noSecureLock_returnsFalse() {
+        preference.isDeviceSecure = { false }
+
+        assertThat(preference.isAvailable(context)).isFalse()
+    }
+
+    @Test
+    fun storage_writesProtectedGlobalSetting() {
+        preference.storage(context).setBoolean(AirplaneModeAuthenticationPreference.KEY, true)
+
+        assertThat(ExtSettings.REQUIRE_AUTHENTICATION_TO_DISABLE_AIRPLANE_MODE.get(context)).isTrue()
+    }
+
+    @Test
+    fun metadata_hasExpectedSummaryAndReadPermit() {
+        assertThat(preference.getSummary(context))
+            .isEqualTo(context.getText(R.string.airplane_mode_authentication_summary))
+        assertThat(preference.getReadPermit(context, 0, 0)).isEqualTo(ReadWritePermit.ALLOW)
+    }
+
+    @Test
+    fun getWritePermit_requirementEnabled_blocksExternalDisable() {
+        preference.isAuthenticationRequired = { true }
+
+        val permit = preference.getWritePermit(context, false, 0, 0)
+
+        assertThat(permit).isEqualTo(ReadWritePermit.DISALLOW)
+    }
+
+    @Test
+    fun getWritePermit_requirementEnabled_blocksUnknownValue() {
+        preference.isAuthenticationRequired = { true }
+
+        val permit = preference.getWritePermit(context, null, 0, 0)
+
+        assertThat(permit).isEqualTo(ReadWritePermit.DISALLOW)
+    }
+
+    @Test
+    fun getWritePermit_requirementEnabled_allowsExternalEnable() {
+        preference.isAuthenticationRequired = { true }
+
+        val permit = preference.getWritePermit(context, true, 0, 0)
+
+        assertThat(permit).isEqualTo(ReadWritePermit.ALLOW)
+    }
+
+    @Test
+    fun onCreate_disabling_waitsForAuthentication() {
+        val widget = mock<Preference>()
+        val lifecycleContext =
+            mock<PreferenceLifecycleContext> {
+                on { requirePreference<Preference>(AirplaneModeAuthenticationPreference.KEY) }
+                    .thenReturn(widget)
+            }
+        val authenticationHelper = mock<AirplaneModeAuthenticationHelper>()
+        preference.authenticationHelper = authenticationHelper
+        preference.isAuthenticationRequired = { true }
+
+        preference.onCreate(lifecycleContext)
+        val listener = argumentCaptor<Preference.OnPreferenceChangeListener>()
+        verify(widget).onPreferenceChangeListener = listener.capture()
+        val accepted = listener.lastValue.onPreferenceChange(widget, false)
+
+        assertThat(accepted).isFalse()
+        verify(authenticationHelper).runAfterAuthentication(any())
+    }
+
+    @Test
+    fun onCreate_disablingAfterAuthentication_rechecksAndWritesSetting() {
+        ExtSettings.REQUIRE_AUTHENTICATION_TO_DISABLE_AIRPLANE_MODE.put(context, true)
+        val widget = mock<Preference>()
+        val lifecycleContext =
+            mock<PreferenceLifecycleContext> {
+                on { requirePreference<Preference>(AirplaneModeAuthenticationPreference.KEY) }
+                    .thenReturn(widget)
+                on { applicationContext }.thenReturn(context)
+                on { contentResolver }.thenReturn(context.contentResolver)
+            }
+        val authenticationHelper = mock<AirplaneModeAuthenticationHelper>()
+        doAnswer { invocation ->
+                invocation.getArgument<Runnable>(0).run()
+                null
+            }
+            .`when`(authenticationHelper)
+            .runAfterAuthentication(any())
+        preference.authenticationHelper = authenticationHelper
+
+        preference.onCreate(lifecycleContext)
+        val listener = argumentCaptor<Preference.OnPreferenceChangeListener>()
+        verify(widget).onPreferenceChangeListener = listener.capture()
+        val accepted = listener.lastValue.onPreferenceChange(widget, false)
+
+        assertThat(accepted).isFalse()
+        assertThat(ExtSettings.REQUIRE_AUTHENTICATION_TO_DISABLE_AIRPLANE_MODE.get(context)).isFalse()
+    }
+
+    @Test
+    fun onDestroy_cancelsAuthentication() {
+        val authenticationHelper = mock<AirplaneModeAuthenticationHelper>()
+        preference.authenticationHelper = authenticationHelper
+
+        preference.onDestroy(mock())
+
+        verify(authenticationHelper).cancel()
+        assertThat(preference.authenticationHelper).isNull()
+    }
+}

--- a/tests/robotests/src/com/android/settings/network/AirplaneModePreferenceTest.kt
+++ b/tests/robotests/src/com/android/settings/network/AirplaneModePreferenceTest.kt
@@ -61,9 +61,11 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.stub
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
@@ -151,7 +153,7 @@ class AirplaneModePreferenceTest {
     fun getWritePermit_satelliteOn_disallow() {
         SatelliteRepository.setIsSessionStartedForTesting(true)
 
-        val permit = airplaneModePreference.getWritePermit(context, 0, 0)
+        val permit = airplaneModePreference.getWritePermit(context, true, 0, 0)
 
         assertThat(permit).isEqualTo(ReadWritePermit.DISALLOW)
     }
@@ -161,14 +163,41 @@ class AirplaneModePreferenceTest {
         shadowOf(context.getSystemService(TelephonyManager::class.java))
             .setEmergencyCallbackMode(true)
 
-        val permit = airplaneModePreference.getWritePermit(context, 0, 0)
+        val permit = airplaneModePreference.getWritePermit(context, true, 0, 0)
 
         assertThat(permit).isEqualTo(ReadWritePermit.DISALLOW)
     }
 
     @Test
+    fun getWritePermit_authenticationRequired_disallowMetadataWrite() {
+        airplaneModePreference.isAuthenticationRequired = { true }
+
+        val permit = airplaneModePreference.getWritePermit(context, false, 0, 0)
+
+        assertThat(permit).isEqualTo(ReadWritePermit.DISALLOW)
+    }
+
+    @Test
+    fun getWritePermit_authenticationRequired_disallowsUnknownMetadataWrite() {
+        airplaneModePreference.isAuthenticationRequired = { true }
+
+        val permit = airplaneModePreference.getWritePermit(context, null, 0, 0)
+
+        assertThat(permit).isEqualTo(ReadWritePermit.DISALLOW)
+    }
+
+    @Test
+    fun getWritePermit_authenticationRequired_allowsEnablingAirplaneMode() {
+        airplaneModePreference.isAuthenticationRequired = { true }
+
+        val permit = airplaneModePreference.getWritePermit(context, true, 0, 0)
+
+        assertThat(permit).isEqualTo(ReadWritePermit.ALLOW)
+    }
+
+    @Test
     fun getWritePermit_allow() {
-        val permit = airplaneModePreference.getWritePermit(context, 0, 0)
+        val permit = airplaneModePreference.getWritePermit(context, true, 0, 0)
 
         assertThat(permit).isEqualTo(ReadWritePermit.ALLOW)
     }
@@ -235,6 +264,97 @@ class AirplaneModePreferenceTest {
         verify(mockContext).requirePreference<Preference>(AirplaneModePreference.KEY)
         verify(mockContext).getSystemService(TelephonyManager::class.java)
         verifyNoMoreInteractions(mockContext)
+    }
+
+    @Test
+    fun onCreate_turningOffWithAuthenticationRequired_waitsForSuccess() {
+        val mockPreference = mock<Preference>()
+        val mockStore =
+            mock<KeyValueStore> {
+                on { getBoolean(AirplaneModePreference.KEY) } doReturn true
+            }
+        val mockHelper = mock<AirplaneModeAuthenticationHelper>()
+        val mockContext =
+            mock<PreferenceLifecycleContext> {
+                on { requirePreference<Preference>(AirplaneModePreference.KEY) } doReturn
+                    mockPreference
+                on { getKeyValueStore(AirplaneModePreference.KEY) } doReturn mockStore
+            }
+        airplaneModePreference.authenticationHelper = mockHelper
+        airplaneModePreference.isAuthenticationRequired = { true }
+
+        airplaneModePreference.onCreate(mockContext)
+        val listener = argumentCaptor<OnPreferenceChangeListener>()
+        verify(mockPreference).onPreferenceChangeListener = listener.capture()
+        val result = listener.lastValue.onPreferenceChange(mockPreference, false)
+
+        assertThat(result).isFalse()
+        verify(mockHelper).runAfterAuthentication(any())
+        verify(mockStore, never()).setBoolean(AirplaneModePreference.KEY, false)
+    }
+
+    @Test
+    fun onCreate_turningOffWithAuthenticationRequiredAndMissingStore_failsClosed() {
+        val mockPreference = mock<Preference>()
+        val mockHelper = mock<AirplaneModeAuthenticationHelper>()
+        val mockContext =
+            mock<PreferenceLifecycleContext> {
+                on { requirePreference<Preference>(AirplaneModePreference.KEY) } doReturn
+                    mockPreference
+                on { getKeyValueStore(AirplaneModePreference.KEY) } doReturn null
+            }
+        airplaneModePreference.authenticationHelper = mockHelper
+        airplaneModePreference.isAuthenticationRequired = { true }
+
+        airplaneModePreference.onCreate(mockContext)
+        val listener = argumentCaptor<OnPreferenceChangeListener>()
+        verify(mockPreference).onPreferenceChangeListener = listener.capture()
+
+        assertThat(listener.lastValue.onPreferenceChange(mockPreference, false)).isFalse()
+        verify(mockHelper, never()).runAfterAuthentication(any())
+    }
+
+    @Test
+    fun onCreate_turningOffAfterAuthentication_writesFalse() {
+        val mockPreference = mock<Preference>()
+        val mockStore =
+            mock<KeyValueStore> {
+                on { getBoolean(AirplaneModePreference.KEY) } doReturn true
+            }
+        val mockHelper = mock<AirplaneModeAuthenticationHelper>()
+        val mockContext =
+            mock<PreferenceLifecycleContext> {
+                on { requirePreference<Preference>(AirplaneModePreference.KEY) } doReturn
+                    mockPreference
+                on { getKeyValueStore(AirplaneModePreference.KEY) } doReturn mockStore
+            }
+        airplaneModePreference.authenticationHelper = mockHelper
+        airplaneModePreference.isAuthenticationRequired = { true }
+        mockHelper.stub {
+            on { runAfterAuthentication(any()) } doAnswer {
+                it.getArgument<Runnable>(0).run()
+                Unit
+            }
+        }
+
+        airplaneModePreference.onCreate(mockContext)
+        val listener = argumentCaptor<OnPreferenceChangeListener>()
+        verify(mockPreference).onPreferenceChangeListener = listener.capture()
+        val result = listener.lastValue.onPreferenceChange(mockPreference, false)
+
+        assertThat(result).isFalse()
+        verify(mockStore).setBoolean(AirplaneModePreference.KEY, false)
+    }
+
+    @Test
+    fun onDestroy_cancelsAndReleasesAuthenticationHelper() {
+        val mockHelper = mock<AirplaneModeAuthenticationHelper>()
+        airplaneModePreference.authenticationHelper = mockHelper
+
+        airplaneModePreference.onDestroy(mock())
+
+        verify(mockHelper).cancel()
+        assertThat(airplaneModePreference.authenticationHelper).isNull()
     }
 
     @Test

--- a/tests/unit/src/com/android/settings/network/AirplaneModeAuthenticationPreferenceControllerTest.java
+++ b/tests/unit/src/com/android/settings/network/AirplaneModeAuthenticationPreferenceControllerTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.network;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import android.content.Context;
+import android.ext.settings.ExtSettings;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+@RunWith(AndroidJUnit4.class)
+public class AirplaneModeAuthenticationPreferenceControllerTest {
+    @Mock
+    private AirplaneModeAuthenticationHelper mAuthenticationHelper;
+
+    private Context mContext;
+    private AirplaneModeAuthenticationPreferenceController mController;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        mContext = ApplicationProvider.getApplicationContext();
+        ExtSettings.REQUIRE_AUTHENTICATION_TO_DISABLE_AIRPLANE_MODE.put(mContext, false);
+        mController = new AirplaneModeAuthenticationPreferenceController(
+                mContext, "require_authentication_to_disable_airplane_mode");
+        mController.setAuthenticationHelper(mAuthenticationHelper);
+    }
+
+    @After
+    public void tearDown() {
+        ExtSettings.REQUIRE_AUTHENTICATION_TO_DISABLE_AIRPLANE_MODE.put(mContext, false);
+    }
+
+    @Test
+    public void setChecked_enabling_doesNotAuthenticate() {
+        assertThat(mController.setChecked(true)).isTrue();
+
+        assertThat(ExtSettings.REQUIRE_AUTHENTICATION_TO_DISABLE_AIRPLANE_MODE.get(mContext))
+                .isTrue();
+        verify(mAuthenticationHelper, never()).runAfterAuthentication(any());
+    }
+
+    @Test
+    public void setChecked_disabling_waitsForAuthentication() {
+        ExtSettings.REQUIRE_AUTHENTICATION_TO_DISABLE_AIRPLANE_MODE.put(mContext, true);
+
+        assertThat(mController.setChecked(false)).isFalse();
+
+        assertThat(ExtSettings.REQUIRE_AUTHENTICATION_TO_DISABLE_AIRPLANE_MODE.get(mContext))
+                .isTrue();
+        verify(mAuthenticationHelper).runAfterAuthentication(any());
+    }
+
+    @Test
+    public void setChecked_disablingAfterAuthentication_rechecksAndDisables() {
+        ExtSettings.REQUIRE_AUTHENTICATION_TO_DISABLE_AIRPLANE_MODE.put(mContext, true);
+        doAnswer(invocation -> {
+            ((Runnable) invocation.getArgument(0)).run();
+            return null;
+        }).when(mAuthenticationHelper).runAfterAuthentication(any());
+
+        assertThat(mController.setChecked(false)).isFalse();
+
+        assertThat(ExtSettings.REQUIRE_AUTHENTICATION_TO_DISABLE_AIRPLANE_MODE.get(mContext))
+                .isFalse();
+    }
+
+    @Test
+    public void onDestroy_cancelsAuthentication() {
+        mController.onDestroy();
+
+        verify(mAuthenticationHelper).cancel();
+    }
+}

--- a/tests/unit/src/com/android/settings/network/AirplaneModePreferenceControllerTest.java
+++ b/tests/unit/src/com/android/settings/network/AirplaneModePreferenceControllerTest.java
@@ -23,7 +23,9 @@ import static com.android.settings.flags.Flags.FLAG_CATALYST_NETWORK_PROVIDER_AN
 import static com.google.common.truth.Truth.assertThat;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -31,6 +33,7 @@ import static org.mockito.Mockito.when;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.content.pm.PackageManager;
+import android.ext.settings.ExtSettings;
 import android.os.Looper;
 import android.platform.test.flag.junit.SetFlagsRule;
 import android.provider.Settings;
@@ -46,6 +49,7 @@ import com.android.settings.AirplaneModeEnabler;
 import com.android.settings.core.BasePreferenceController;
 import com.android.settingslib.RestrictedSwitchPreference;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -65,6 +69,8 @@ public class AirplaneModePreferenceControllerTest {
     private PackageManager mPackageManager;
     @Mock
     private AirplaneModeEnabler mAirplaneModeEnabler;
+    @Mock
+    private AirplaneModeAuthenticationHelper mAuthenticationHelper;
     private Context mContext;
     private ContentResolver mResolver;
     private PreferenceManager mPreferenceManager;
@@ -86,6 +92,8 @@ public class AirplaneModePreferenceControllerTest {
         doReturn(mPackageManager).when(mContext).getPackageManager();
         mController = new AirplaneModePreferenceController(mContext,
                 AirplaneModePreference.KEY);
+        mController.setAuthenticationHelper(mAuthenticationHelper);
+        ExtSettings.REQUIRE_AUTHENTICATION_TO_DISABLE_AIRPLANE_MODE.put(mContext, false);
 
         mPreferenceManager = new PreferenceManager(mContext);
         mScreen = mPreferenceManager.createPreferenceScreen(mContext);
@@ -93,6 +101,11 @@ public class AirplaneModePreferenceControllerTest {
         mPreference.setKey(AirplaneModePreference.KEY);
         mScreen.addPreference(mPreference);
         mController.setFragment(null);
+    }
+
+    @After
+    public void tearDown() {
+        ExtSettings.REQUIRE_AUTHENTICATION_TO_DISABLE_AIRPLANE_MODE.put(mContext, false);
     }
 
     @Test
@@ -144,6 +157,34 @@ public class AirplaneModePreferenceControllerTest {
 
         // Set to OFF
         assertThat(mController.setChecked(false)).isTrue();
+    }
+
+    @Test
+    public void setChecked_turningOffWithAuthenticationRequired_waitsForSuccess() {
+        mController.setAirplaneModeEnabler(mAirplaneModeEnabler);
+        when(mAirplaneModeEnabler.isAirplaneModeOn()).thenReturn(true);
+        ExtSettings.REQUIRE_AUTHENTICATION_TO_DISABLE_AIRPLANE_MODE.put(mContext, true);
+        doAnswer(invocation -> {
+            ((Runnable) invocation.getArgument(0)).run();
+            return null;
+        }).when(mAuthenticationHelper).runAfterAuthentication(any());
+
+        assertThat(mController.setChecked(false)).isFalse();
+
+        verify(mAuthenticationHelper).runAfterAuthentication(any());
+        verify(mAirplaneModeEnabler).setAirplaneMode(false);
+    }
+
+    @Test
+    public void setChecked_turningOffAndAuthenticationCancelled_keepsAirplaneModeEnabled() {
+        mController.setAirplaneModeEnabler(mAirplaneModeEnabler);
+        when(mAirplaneModeEnabler.isAirplaneModeOn()).thenReturn(true);
+        ExtSettings.REQUIRE_AUTHENTICATION_TO_DISABLE_AIRPLANE_MODE.put(mContext, true);
+
+        assertThat(mController.setChecked(false)).isFalse();
+
+        verify(mAuthenticationHelper).runAfterAuthentication(any());
+        verify(mAirplaneModeEnabler, never()).setAirplaneMode(false);
     }
 
     @Test


### PR DESCRIPTION
Refs https://github.com/GrapheneOS/os-issue-tracker/issues/6059

This proof of concept adds an opt-in, off-by-default "Require authentication to turn off airplane mode" switch under Network & internet.

When enabled, both legacy and Catalyst Settings airplane-mode toggles use the active user's standard operating-system authentication prompt before disabling airplane mode. The prompt accepts a strong biometric or the existing device credential (PIN, pattern, or password); it does not create or store a separate password. Enabling airplane mode remains immediate.

Cancellation, authentication error, or lockout leaves airplane mode enabled. The implementation allows one Settings prompt at a time, cancels and releases it with the preference lifecycle, and rechecks the live setting before applying the authenticated change. The option is only shown when the current user has a secure lock configured. Disabling the protection itself also requires fresh system authentication on both legacy and Catalyst paths.

The Catalyst hierarchy has first-class metadata for the opt-in. Preferences API writes remain able to enable airplane mode, but external false or unknown-value writes cannot disable airplane mode or the protection while authentication is required. A background public-slice request cannot bypass the gate: if Settings cannot present the standard prompt, the operation fails closed and airplane mode stays enabled. The network screen still declares an incomplete Catalyst hierarchy, so the XML preference remains part of the rendered screen.

This is accidental-activation protection rather than a central radio policy.

Depends on https://github.com/GrapheneOS/platform_frameworks_base/pull/437 for the protected global setting and coordinated SystemUI coverage.

Test: not run; building GrapheneOS was intentionally not attempted on the resource-constrained development host. `git diff --check` passed, modified XML parsed successfully, the complete cross-repository diff received Sol static review, and an independent immutable-diff Claude Opus review passed before publication. Suggested upstream targets are `SettingsRoboTests` and `SettingsUnitTests` for the added and updated airplane-mode test classes.
