### PR TITLE
initialize display color mode to adevtool Natural default

### DIFF
--- a/src/com/android/settings/SettingsApplication.java
+++ b/src/com/android/settings/SettingsApplication.java
@@ -106,6 +106,8 @@ public class SettingsApplication extends Application {
             ElapsedTimeUtils.assignSuwFinishedTimeStamp(getApplicationContext());
         }
 
+        com.android.settings.display.DisplayColorModeFixup.run(this);
+
         if (getUserId() == android.os.UserHandle.USER_SYSTEM) {
             com.android.settings.users.UserRestrictions.fixupPrivateSpaceRestrictions(this);
             com.android.settingslib.utils.ThreadUtils.postOnBackgroundThread(() -> {

--- a/src/com/android/settings/display/DisplayColorModeFixup.java
+++ b/src/com/android/settings/display/DisplayColorModeFixup.java
@@ -1,0 +1,36 @@
+package com.android.settings.display;
+
+import android.content.Context;
+import android.hardware.display.ColorDisplayManager;
+import android.provider.Settings;
+import android.util.Log;
+
+public final class DisplayColorModeFixup {
+    private static final String TAG = "DisplayColorModeFixup";
+
+    private DisplayColorModeFixup() {
+    }
+
+    public static void run(Context context) {
+        try {
+            runInner(context);
+        } catch (Throwable e) {
+            Log.e(TAG, "unable to initialize display color mode", e);
+        }
+    }
+
+    private static void runInner(Context context) {
+        final int userId = context.getUserId();
+        if (Settings.System.getStringForUser(context.getContentResolver(),
+                Settings.System.DISPLAY_COLOR_MODE, userId) != null) {
+            return;
+        }
+
+        if (!Settings.System.putIntForUser(context.getContentResolver(),
+                Settings.System.DISPLAY_COLOR_MODE,
+                ColorDisplayManager.COLOR_MODE_NATURAL,
+                userId)) {
+            Log.w(TAG, "unable to set the default display color mode for user " + userId);
+        }
+    }
+}


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/os-issue-tracker/issues/6492

This is also partly related to https://github.com/GrapheneOS/os-issue-tracker/issues/8336, since this bug left the color in Saturated mode after turning off an accessibility color mode for a user that has not touched the color mode settings in Settings > Display > Colors. 

https://github.com/GrapheneOS/os-issue-tracker/issues/8336 appears to be a bug in the Pixel HWC path used on devices shipping libexynosdisplay.so (10th-gen Pixels don't seem to be affected except for 10a): setting the display color transform to the identity matrix does not take effect while Saturated mode is active. Changes like setting other color modes or setting Night Light forces many non-identity matrix updates which is why it fixes it.

Stock OS doesn't expose Saturated color option in that screen, so it's very unlikely Google will fix this bug as it can not be reproduced on stock OS. However, it's exposed by GosOverlay which has `android:priority="100"`. We should probably just remove the Saturated option entirely

---

adevtool configures Pixel devices to use Natural as the default display color mode through `persist.sys.sf.color_saturation`.

ColorDisplayService falls back to `persist.sys.sf.native_mode` when Settings.System.DISPLAY_COLOR_MODE is unset. Accessibility color transforms use `config_accessibilityColorMode`, which is Saturated on Pixels, and update this property. When the transform is disabled, the unset setting causes ColorDisplayService to read back the temporary property state instead of restoring Natural.

Materialize the adevtool default in DISPLAY_COLOR_MODE for each user when the setting is unset. Explicit user choices remain unchanged.