### PR TITLE
Add toggle to hide gesture navigation hint

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -12362,13 +12362,6 @@
 
     <!-- Search keywords for System Navigation settings. [CHAR_LIMIT=NONE]-->
     <string name="keywords_system_navigation">system navigation, 2 button navigation, 3 button navigation, gesture navigation, swipe</string>
-    
-    <!-- Title for setting category that is used to toggle displaying or hiding the navigation hint (pill). [CHAR LIMIT=60] -->
-    <string name="hide_navigation_handle_category_title">Navigation hint</string>
-    <!-- Title text for hiding the navigation hint (pill). [CHAR LIMIT=60] -->
-    <string name="hide_navigation_handle_title">Hide navigation hint</string>
-    <!-- Summary text for hiding the navigation hint (pill). [CHAR LIMIT=NONE] -->
-    <string name="hide_navigation_handle_summary">Hide the gesture navigation hint (pill) shown at the bottom of the screen</string>
 
     <!-- Title for setting category that is shown to enable invoking digital assistant with swipe. [CHAR LIMIT=60] -->
     <string name="assistant_gesture_category_title">Digital assistant</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -12362,6 +12362,13 @@
 
     <!-- Search keywords for System Navigation settings. [CHAR_LIMIT=NONE]-->
     <string name="keywords_system_navigation">system navigation, 2 button navigation, 3 button navigation, gesture navigation, swipe</string>
+    
+    <!-- Title for setting category that is used to toggle displaying or hiding the navigation hint (pill). [CHAR LIMIT=60] -->
+    <string name="hide_navigation_handle_category_title">Navigation hint</string>
+    <!-- Title text for hiding the navigation hint (pill). [CHAR LIMIT=60] -->
+    <string name="hide_navigation_handle_title">Hide navigation hint</string>
+    <!-- Summary text for hiding the navigation hint (pill). [CHAR LIMIT=NONE] -->
+    <string name="hide_navigation_handle_summary">Hide the gesture navigation hint (pill) shown at the bottom of the screen</string>
 
     <!-- Title for setting category that is shown to enable invoking digital assistant with swipe. [CHAR LIMIT=60] -->
     <string name="assistant_gesture_category_title">Digital assistant</string>
@@ -15641,7 +15648,4 @@
     <!-- Search keywords for Human interface device access setting -->
     <string name="keywords_access_hid">hid, human, access, device</string>
     <!-- Access HID end -->
-    <string name="hide_navigation_handle_title">Hide navigation bar hint</string>
-    <string name="hide_navigation_handle_summary">Hide the gesture navigation bar hint line shown at the bottom of the screen</string>
-    <string name="hide_navigation_handle_category_title">Navigation bar hint</string>
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -15641,4 +15641,7 @@
     <!-- Search keywords for Human interface device access setting -->
     <string name="keywords_access_hid">hid, human, access, device</string>
     <!-- Access HID end -->
+    <string name="hide_navigation_handle_title">Hide navigation bar hint</string>
+    <string name="hide_navigation_handle_summary">Hide the gesture navigation bar hint line shown at the bottom of the screen</string>
+    <string name="hide_navigation_handle_category_title">Navigation bar hint</string>
 </resources>

--- a/res/values/strings_ext.xml
+++ b/res/values/strings_ext.xml
@@ -340,4 +340,11 @@ May cause unreliable service. Use at your own risk.
     <string name="cert_transparency_dl_footer">"Certificate Transparency (CT) is an Internet standard designed to enhance the security of digital certificates. It requires Certificate Authorities (CAs) to submit all issued certificates to a public log that records them, increasing transparency and accountability in the certificate issuance process.
 
 By maintaining a verifiable record of all certificates, CT makes it significantly harder for malicious actors to forge certificates or for CAs to mistakenly issue them. This helps protect apps from man-in-the-middle attacks and other security threats."</string>
+
+    <!-- Title for setting category in gesture navigation settings that is used to toggle displaying or hiding the navigation hint (pill). [CHAR LIMIT=60] -->
+    <string name="hide_navigation_handle_category_title">Navigation hint</string>
+    <!-- Title text for hiding the navigation hint (pill). [CHAR LIMIT=60] -->
+    <string name="hide_navigation_handle_title">Hide navigation hint</string>
+    <!-- Summary text for hiding the navigation hint (pill). [CHAR LIMIT=NONE] -->
+    <string name="hide_navigation_handle_summary">Hide the gesture navigation hint (pill) shown at the bottom of the screen</string>
 </resources>

--- a/res/xml/gesture_navigation_settings.xml
+++ b/res/xml/gesture_navigation_settings.xml
@@ -35,6 +35,19 @@
     </PreferenceCategory>
 
     <PreferenceCategory
+        android:key="hide_navigation_handle_category"
+        android:persistent="false"
+        android:title="@string/hide_navigation_handle_category_title">
+
+        <SwitchPreferenceCompat
+            android:key="hide_navigation_handle"
+            android:title="@string/hide_navigation_handle_title"
+            android:summary="@string/hide_navigation_handle_summary"
+            settings:controller="com.android.settings.gestures.HideNavigationHandleController"
+        />
+    </PreferenceCategory>
+
+    <PreferenceCategory
         android:key="assistant_gesture_category"
         android:persistent="false"
         android:title="@string/assistant_gesture_category_title">

--- a/src/com/android/settings/gestures/HideNavigationHandleController.java
+++ b/src/com/android/settings/gestures/HideNavigationHandleController.java
@@ -1,56 +1,27 @@
 /*
- * Copyright (C) 2026 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright (C) 2026 GrapheneOS
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 package com.android.settings.gestures;
 
 import android.content.Context;
-import android.provider.Settings;
+import android.ext.settings.ExtSettings;
 
-import com.android.settings.R;
-import com.android.settings.core.TogglePreferenceController;
+import com.android.settings.ext.BoolSettingPrefController;
 
 /**
  * Configures behaviour of hiding the navigation hint pill.
  */
-public class HideNavigationHandleController extends TogglePreferenceController {
+public class HideNavigationHandleController extends BoolSettingPrefController {
 
-    public HideNavigationHandleController(Context context, String key) {
-        super(context, key);
-    }
-
-    @Override
-    public boolean isChecked() {
-        return Settings.Secure.getInt(mContext.getContentResolver(),
-                Settings.Secure.HIDE_NAVIGATION_HANDLE, 0) == 1;
-    }
-
-    @Override
-    public boolean setChecked(boolean isChecked) {
-        return Settings.Secure.putInt(mContext.getContentResolver(),
-                Settings.Secure.HIDE_NAVIGATION_HANDLE, isChecked ? 1 : 0);
+    public HideNavigationHandleController(Context ctx, String key) {
+        super(ctx, key, ExtSettings.HIDE_NAVIGATION_HANDLE);
     }
 
     @Override
     public int getAvailabilityStatus() {
-        return SystemNavigationPreferenceController.isGestureAvailable(mContext) ? AVAILABLE
-                : UNSUPPORTED_ON_DEVICE;
-    }
-
-    @Override
-    public int getSliceHighlightMenuRes() {
-        return R.string.menu_key_system;
+        return SystemNavigationPreferenceController.isGestureAvailable(mContext)
+                ? super.getAvailabilityStatus() : UNSUPPORTED_ON_DEVICE;
     }
 }

--- a/src/com/android/settings/gestures/HideNavigationHandleController.java
+++ b/src/com/android/settings/gestures/HideNavigationHandleController.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.gestures;
+
+import android.content.Context;
+import android.provider.Settings;
+
+import com.android.settings.R;
+import com.android.settings.core.TogglePreferenceController;
+
+/**
+ * Configures behaviour of hiding the navigation hint pill.
+ */
+public class HideNavigationHandleController extends TogglePreferenceController {
+
+    public HideNavigationHandleController(Context context, String key) {
+        super(context, key);
+    }
+
+    @Override
+    public boolean isChecked() {
+        return Settings.Secure.getInt(mContext.getContentResolver(),
+                Settings.Secure.HIDE_NAVIGATION_HANDLE, 0) == 1;
+    }
+
+    @Override
+    public boolean setChecked(boolean isChecked) {
+        return Settings.Secure.putInt(mContext.getContentResolver(),
+                Settings.Secure.HIDE_NAVIGATION_HANDLE, isChecked ? 1 : 0);
+    }
+
+    @Override
+    public int getAvailabilityStatus() {
+        return SystemNavigationPreferenceController.isGestureAvailable(mContext) ? AVAILABLE
+                : UNSUPPORTED_ON_DEVICE;
+    }
+
+    @Override
+    public int getSliceHighlightMenuRes() {
+        return R.string.menu_key_system;
+    }
+}


### PR DESCRIPTION
Adds a "Navigation bar hint" category with a switch to the gesture navigation
settings screen, backed by `Settings.Secure.HIDE_NAVIGATION_HANDLE`.


This feature has been referenced as acceptable by the GrapheneOS team, by @thestinger in [#2760](https://github.com/GrapheneOS/os-issue-tracker/issues/2760#issuecomment-3046177708), it has been implemented in this PR as instructed: _"[It] should not remove the reserved space in apps without edge-to-edge support to avoid breaking app compatibility. It should only hide the navigation zone hint."_

This feature is implemented in 3 repos:
- frameworks/base: defines the setting ([link](https://github.com/GrapheneOS/platform_frameworks_base/pull/440))
- Launcher3: consumes the setting and hides the handle ([link](https://github.com/GrapheneOS/platform_packages_apps_Launcher3/pull/83))

<img width="1280" height="760" alt="image" src="https://github.com/user-attachments/assets/bafd3856-b0c2-4f51-aa02-5597d698d8d9" />
